### PR TITLE
refactor: PK 컬럼 id로 통일

### DIFF
--- a/backend/src/main/java/com/woowacourse/kkogkkog/domain/Coupon.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/domain/Coupon.java
@@ -22,7 +22,6 @@ public class Coupon {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "coupon_id")
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/backend/src/main/java/com/woowacourse/kkogkkog/domain/CouponTemplate.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/domain/CouponTemplate.java
@@ -16,7 +16,6 @@ public class CouponTemplate {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "coupon_template_id")
     private Long id;
 
     @Column(name = "member_id")

--- a/backend/src/main/java/com/woowacourse/kkogkkog/domain/Member.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/domain/Member.java
@@ -16,8 +16,8 @@ public class Member {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "member_id")
     private Long id;
+
     private String name;
 
     public Member(Long id, String name) {

--- a/backend/src/test/java/com/woowacourse/kkogkkog/acceptance/support/DatabaseCleaner.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/acceptance/support/DatabaseCleaner.java
@@ -33,8 +33,8 @@ public class DatabaseCleaner implements InitializingBean {
 
         for (String tableName : tableNames) {
             entityManager.createNativeQuery("TRUNCATE TABLE " + tableName).executeUpdate();
-            entityManager.createNativeQuery("ALTER TABLE " + tableName + " ALTER COLUMN "
-                    + tableName + "_" + "ID RESTART WITH 1").executeUpdate();
+            entityManager.createNativeQuery("ALTER TABLE " + tableName + " ALTER COLUMN ID RESTART WITH 1")
+                    .executeUpdate();
         }
         entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY TRUE").executeUpdate();
     }


### PR DESCRIPTION
## 작업 내용

- 모든 테이블의 PK 컬럼을 id로 통일
- 테스트 DB 리셋시키는 TRUNCATE문 수정

## 공유사항

많은 도메인을 건들이기 때문에 미리 작업하여 올립니다.

Resolves #35 
