### PR TITLE
feat: 회원가입 API 구현

### DIFF
--- a/backend/src/docs/asciidoc/index.adoc
+++ b/backend/src/docs/asciidoc/index.adoc
@@ -7,4 +7,5 @@
 
 = KkogKkog API
 
+include::member.adoc[]
 include::coupon.adoc[]

--- a/backend/src/docs/asciidoc/member.adoc
+++ b/backend/src/docs/asciidoc/member.adoc
@@ -1,0 +1,10 @@
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 4
+
+
+== Member
+=== 회원가입
+operation::member-create[snippets='http-request,http-response,request-fields']

--- a/backend/src/main/java/com/woowacourse/kkogkkog/application/MemberService.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/application/MemberService.java
@@ -2,9 +2,13 @@ package com.woowacourse.kkogkkog.application;
 
 import com.woowacourse.kkogkkog.domain.Member;
 import com.woowacourse.kkogkkog.domain.repository.MemberRepository;
+import com.woowacourse.kkogkkog.exception.member.MemberDuplicatedEmail;
 import com.woowacourse.kkogkkog.presentation.dto.MemberCreateRequest;
+import java.util.Optional;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+@Transactional
 @Service
 public class MemberService {
 
@@ -15,6 +19,11 @@ public class MemberService {
     }
 
     public Long save(MemberCreateRequest memberCreateRequest) {
+        Optional<Member> findMember = memberRepository.findByEmail(memberCreateRequest.getEmail());
+        if (findMember.isPresent()) {
+            throw new MemberDuplicatedEmail();
+        }
+
         Member member = memberCreateRequest.toEntity();
 
         return memberRepository.save(member).getId();

--- a/backend/src/main/java/com/woowacourse/kkogkkog/application/MemberService.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/application/MemberService.java
@@ -1,0 +1,22 @@
+package com.woowacourse.kkogkkog.application;
+
+import com.woowacourse.kkogkkog.domain.Member;
+import com.woowacourse.kkogkkog.domain.repository.MemberRepository;
+import com.woowacourse.kkogkkog.presentation.dto.MemberCreateRequest;
+import org.springframework.stereotype.Service;
+
+@Service
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    public MemberService(MemberRepository memberRepository) {
+        this.memberRepository = memberRepository;
+    }
+
+    public Long save(MemberCreateRequest memberCreateRequest) {
+        Member member = memberCreateRequest.toEntity();
+
+        return memberRepository.save(member).getId();
+    }
+}

--- a/backend/src/main/java/com/woowacourse/kkogkkog/application/dto/CouponResponse.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/application/dto/CouponResponse.java
@@ -31,7 +31,7 @@ public class CouponResponse {
     }
 
     public static CouponResponse of(Coupon coupon) {
-        return new CouponResponse(coupon.getId(), coupon.getSender().getName(), coupon.getReceiver().getName(),
+        return new CouponResponse(coupon.getId(), coupon.getSender().getNickname(), coupon.getReceiver().getNickname(),
                 coupon.getBackgroundColor(), coupon.getModifier(), coupon.getMessage(),
                 coupon.getCouponType().getValue(), coupon.getCouponStatus().name());
     }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/domain/Member.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/domain/Member.java
@@ -5,15 +5,10 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
-import javax.persistence.Table;
-import javax.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Table(
-    uniqueConstraints={@UniqueConstraint(columnNames={"email"})}
-)
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
@@ -23,7 +18,7 @@ public class Member {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false)
+    @Column(nullable = false, unique = true)
     private String email;
 
     @Column(nullable = false)

--- a/backend/src/main/java/com/woowacourse/kkogkkog/domain/Member.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/domain/Member.java
@@ -5,10 +5,15 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.Table;
+import javax.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Table(
+    uniqueConstraints={@UniqueConstraint(columnNames={"email"})}
+)
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
@@ -18,10 +23,19 @@ public class Member {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private String name;
+    @Column(nullable = false)
+    private String email;
 
-    public Member(Long id, String name) {
+    @Column(nullable = false)
+    private String password;
+
+    @Column(nullable = false)
+    private String nickname;
+
+    public Member(Long id, String email, String password, String nickname) {
         this.id = id;
-        this.name = name;
+        this.email = email;
+        this.password = password;
+        this.nickname = nickname;
     }
 }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/domain/repository/MemberRepository.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/domain/repository/MemberRepository.java
@@ -1,9 +1,12 @@
 package com.woowacourse.kkogkkog.domain.repository;
 
 import com.woowacourse.kkogkkog.domain.Member;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    Optional<Member> findByEmail(String email);
 }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/exception/member/MemberDuplicatedEmail.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/exception/member/MemberDuplicatedEmail.java
@@ -1,0 +1,10 @@
+package com.woowacourse.kkogkkog.exception.member;
+
+import com.woowacourse.kkogkkog.exception.InvalidRequestException;
+
+public class MemberDuplicatedEmail extends InvalidRequestException {
+
+    public MemberDuplicatedEmail() {
+        super("이미 존재하는 이메일 입니다.");
+    }
+}

--- a/backend/src/main/java/com/woowacourse/kkogkkog/presentation/MemberController.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/presentation/MemberController.java
@@ -1,0 +1,27 @@
+package com.woowacourse.kkogkkog.presentation;
+
+import com.woowacourse.kkogkkog.application.MemberService;
+import com.woowacourse.kkogkkog.presentation.dto.MemberCreateRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/members")
+public class MemberController {
+
+    private final MemberService memberService;
+
+    public MemberController(MemberService memberService) {
+        this.memberService = memberService;
+    }
+
+    @PostMapping
+    public ResponseEntity<Void> create(@RequestBody MemberCreateRequest memberCreateRequest) {
+        memberService.save(memberCreateRequest);
+
+        return ResponseEntity.created(null).build();
+    }
+}

--- a/backend/src/main/java/com/woowacourse/kkogkkog/presentation/dto/MemberCreateRequest.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/presentation/dto/MemberCreateRequest.java
@@ -1,0 +1,25 @@
+package com.woowacourse.kkogkkog.presentation.dto;
+
+import com.woowacourse.kkogkkog.domain.Member;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class MemberCreateRequest {
+
+    private String email;
+    private String password;
+    private String nickname;
+
+    public MemberCreateRequest(String email, String password, String nickname) {
+        this.email = email;
+        this.password = password;
+        this.nickname = nickname;
+    }
+
+    public Member toEntity() {
+        return new Member(null, this.email, this.password, this.nickname);
+    }
+}

--- a/backend/src/test/java/com/woowacourse/kkogkkog/acceptance/CouponAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/acceptance/CouponAcceptanceTest.java
@@ -5,8 +5,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.woowacourse.kkogkkog.application.dto.CouponResponse;
 import com.woowacourse.kkogkkog.application.dto.CouponsResponse;
 import com.woowacourse.kkogkkog.domain.CouponStatus;
-import com.woowacourse.kkogkkog.domain.Member;
 import com.woowacourse.kkogkkog.domain.repository.MemberRepository;
+import com.woowacourse.kkogkkog.fixture.MemberFixture;
 import com.woowacourse.kkogkkog.presentation.dto.CouponCreateRequest;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
@@ -35,10 +35,10 @@ public class CouponAcceptanceTest extends AcceptanceTest {
     @BeforeEach
     void setUp() {
         super.setUp();
-        memberRepository.save(new Member(1L, "루키"));
-        memberRepository.save(new Member(2L, "아서"));
-        memberRepository.save(new Member(3L, "정"));
-        memberRepository.save(new Member(4L, "레오"));
+        memberRepository.save(MemberFixture.ROOKIE);
+        memberRepository.save(MemberFixture.ARTHUR);
+        memberRepository.save(MemberFixture.JEONG);
+        memberRepository.save(MemberFixture.LEO);
     }
 
     @Test

--- a/backend/src/test/java/com/woowacourse/kkogkkog/acceptance/MemberAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/acceptance/MemberAcceptanceTest.java
@@ -15,7 +15,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
 
     @Test
     void 회원_가입을_할_수_있다() {
-        MemberCreateRequest memberCreateRequest = new MemberCreateRequest("rookie@gmailc.com",
+        MemberCreateRequest memberCreateRequest = new MemberCreateRequest("rookie@gmail.com",
             "password1234!", "rookie");
 
         회원_가입에_성공한다(memberCreateRequest);
@@ -35,7 +35,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
 
     @Test
     void 회원_가입을_할때_이메일이_중복된_경우_실패한다() {
-        MemberCreateRequest memberCreateRequest = new MemberCreateRequest("rookie@gmailc.com",
+        MemberCreateRequest memberCreateRequest = new MemberCreateRequest("rookie@gmail.com",
             "password1234!", "rookie");
         회원_가입에_성공한다(memberCreateRequest);
 

--- a/backend/src/test/java/com/woowacourse/kkogkkog/acceptance/MemberAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/acceptance/MemberAcceptanceTest.java
@@ -1,0 +1,56 @@
+package com.woowacourse.kkogkkog.acceptance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.woowacourse.kkogkkog.presentation.dto.MemberCreateRequest;
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+@SuppressWarnings("NonAsciiCharacters")
+public class MemberAcceptanceTest extends AcceptanceTest {
+
+    @Test
+    void 회원_가입을_할_수_있다() {
+        MemberCreateRequest memberCreateRequest = new MemberCreateRequest("rookie@gmailc.com",
+            "password1234!", "rookie");
+
+        회원_가입에_성공한다(memberCreateRequest);
+    }
+
+    private void 회원_가입에_성공한다(MemberCreateRequest memberCreateRequest) {
+        ExtractableResponse<Response> extract = RestAssured.given().log().all()
+            .body(memberCreateRequest)
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .when()
+            .post("/api/members")
+            .then().log().all()
+            .extract();
+
+        assertThat(extract.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+    }
+
+    @Test
+    void 회원_가입을_할때_이메일이_중복된_경우_실패한다() {
+        MemberCreateRequest memberCreateRequest = new MemberCreateRequest("rookie@gmailc.com",
+            "password1234!", "rookie");
+        회원_가입에_성공한다(memberCreateRequest);
+
+        회원_가입에_실패한다(memberCreateRequest);
+    }
+
+    private void 회원_가입에_실패한다(MemberCreateRequest memberCreateRequest) {
+        ExtractableResponse<Response> extract = RestAssured.given().log().all()
+            .body(memberCreateRequest)
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .when()
+            .post("/api/members")
+            .then().log().all()
+            .extract();
+
+        assertThat(extract.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+    }
+}

--- a/backend/src/test/java/com/woowacourse/kkogkkog/application/CouponServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/application/CouponServiceTest.java
@@ -7,9 +7,9 @@ import static org.springframework.test.annotation.DirtiesContext.ClassMode.BEFOR
 import com.woowacourse.kkogkkog.application.dto.CouponResponse;
 import com.woowacourse.kkogkkog.application.dto.CouponsResponse;
 import com.woowacourse.kkogkkog.domain.CouponStatus;
-import com.woowacourse.kkogkkog.domain.Member;
 import com.woowacourse.kkogkkog.domain.repository.MemberRepository;
 import com.woowacourse.kkogkkog.exception.coupon.CouponNotFoundException;
+import com.woowacourse.kkogkkog.fixture.MemberFixture;
 import com.woowacourse.kkogkkog.presentation.dto.CouponCreateRequest;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -33,9 +33,9 @@ public class CouponServiceTest {
 
     @BeforeEach
     void setUp() {
-        memberRepository.save(new Member(1L, "루키"));
-        memberRepository.save(new Member(2L, "아서"));
-        memberRepository.save(new Member(3L, "정"));
+        memberRepository.save(MemberFixture.ROOKIE);
+        memberRepository.save(MemberFixture.ARTHUR);
+        memberRepository.save(MemberFixture.JEONG);
     }
 
     @Test

--- a/backend/src/test/java/com/woowacourse/kkogkkog/application/MemberServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/application/MemberServiceTest.java
@@ -21,24 +21,19 @@ class MemberServiceTest {
     @Test
     @DisplayName("회원가입을 할 수 있다.")
     void save() {
-        // given
         MemberCreateRequest memberCreateRequest = new MemberCreateRequest("email@gmail.com", "password1234!", "nickname");
 
-        // when
         Long memberId = memberService.save(memberCreateRequest);
 
-        // then
         assertThat(memberId).isNotNull();
     }
 
     @Test
     @DisplayName("중복된 회원의 이메일이 있을 경우 예외가 발생한다.")
     void save_fail_duplicatedEmail() {
-        // given
         MemberCreateRequest memberCreateRequest = new MemberCreateRequest("email@gmail.com", "password1234!", "nickname");
 
-        // when & then
-        Long memberId = memberService.save(memberCreateRequest);
+        memberService.save(memberCreateRequest);
         assertThatThrownBy(() -> memberService.save(memberCreateRequest))
             .isInstanceOf(MemberDuplicatedEmail.class);
     }

--- a/backend/src/test/java/com/woowacourse/kkogkkog/application/MemberServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/application/MemberServiceTest.java
@@ -1,0 +1,31 @@
+package com.woowacourse.kkogkkog.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.woowacourse.kkogkkog.presentation.dto.MemberCreateRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+class MemberServiceTest {
+
+    @Autowired
+    private MemberService memberService;
+
+    @Test
+    @DisplayName("회원가입을 할 수 있다.")
+    void save() {
+        // given
+        MemberCreateRequest memberCreateRequest = new MemberCreateRequest("email@gmail.com", "password1234!", "nickname");
+
+        // when
+        Long memberId = memberService.save(memberCreateRequest);
+
+        // then
+        assertThat(memberId).isNotNull();
+    }
+}

--- a/backend/src/test/java/com/woowacourse/kkogkkog/application/MemberServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/application/MemberServiceTest.java
@@ -1,7 +1,9 @@
 package com.woowacourse.kkogkkog.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.woowacourse.kkogkkog.exception.member.MemberDuplicatedEmail;
 import com.woowacourse.kkogkkog.presentation.dto.MemberCreateRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -27,5 +29,17 @@ class MemberServiceTest {
 
         // then
         assertThat(memberId).isNotNull();
+    }
+
+    @Test
+    @DisplayName("중복된 회원의 이메일이 있을 경우 예외가 발생한다.")
+    void save_fail_duplicatedEmail() {
+        // given
+        MemberCreateRequest memberCreateRequest = new MemberCreateRequest("email@gmail.com", "password1234!", "nickname");
+
+        // when & then
+        Long memberId = memberService.save(memberCreateRequest);
+        assertThatThrownBy(() -> memberService.save(memberCreateRequest))
+            .isInstanceOf(MemberDuplicatedEmail.class);
     }
 }

--- a/backend/src/test/java/com/woowacourse/kkogkkog/documentation/Documentation.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/documentation/Documentation.java
@@ -6,8 +6,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.woowacourse.kkogkkog.application.CouponService;
 import com.woowacourse.kkogkkog.application.CouponTemplateService;
+import com.woowacourse.kkogkkog.application.MemberService;
 import com.woowacourse.kkogkkog.presentation.CouponController;
 import com.woowacourse.kkogkkog.presentation.CouponTemplateController;
+import com.woowacourse.kkogkkog.presentation.MemberController;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -25,7 +27,8 @@ import org.springframework.web.filter.CharacterEncodingFilter;
 @AutoConfigureRestDocs
 @WebMvcTest({
         CouponController.class,
-        CouponTemplateController.class
+        CouponTemplateController.class,
+        MemberController.class
 })
 public abstract class Documentation {
 
@@ -40,6 +43,9 @@ public abstract class Documentation {
 
     @MockBean
     protected CouponTemplateService couponTemplateService;
+
+    @MockBean
+    protected MemberService memberService;
 
     @BeforeEach
     public void setUp(WebApplicationContext ctx, RestDocumentationContextProvider restDocumentationContextProvider) {

--- a/backend/src/test/java/com/woowacourse/kkogkkog/documentation/MemberControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/documentation/MemberControllerTest.java
@@ -1,0 +1,50 @@
+package com.woowacourse.kkogkkog.documentation;
+
+import static com.woowacourse.kkogkkog.documentation.support.ApiDocumentUtils.getDocumentRequest;
+import static com.woowacourse.kkogkkog.documentation.support.ApiDocumentUtils.getDocumentResponse;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.woowacourse.kkogkkog.presentation.dto.MemberCreateRequest;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.ResultActions;
+
+@SuppressWarnings("NonAsciiCharacters")
+public class MemberControllerTest extends Documentation {
+
+    @Test
+    void 회원_가입을_요청한다() throws Exception {
+        // given
+        MemberCreateRequest memberCreateRequest = new MemberCreateRequest("email@gmail.com", "password1234!", "nickname");
+        given(memberService.save(any())).willReturn(1L);
+
+        // when
+        ResultActions perform = mockMvc.perform(post("/api/members")
+            .content(objectMapper.writeValueAsString(memberCreateRequest))
+            .contentType(MediaType.APPLICATION_JSON));
+
+        // then
+        perform.andExpect(status().isCreated());
+
+        // docs
+        perform
+            .andDo(print())
+            .andDo(document("member-create",
+                getDocumentRequest(),
+                getDocumentResponse(),
+                requestFields(
+                    fieldWithPath("email").type(JsonFieldType.STRING).description("이메일"),
+                    fieldWithPath("password").type(JsonFieldType.STRING).description("비밀번호"),
+                    fieldWithPath("nickname").type(JsonFieldType.STRING).description("닉네임")
+                ))
+            );
+    }
+}

--- a/backend/src/test/java/com/woowacourse/kkogkkog/domain/CouponTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/domain/CouponTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.woowacourse.kkogkkog.exception.coupon.SameSenderReceiverException;
+import com.woowacourse.kkogkkog.fixture.MemberFixture;
 import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("NonAsciiCharacters")
@@ -11,8 +12,8 @@ public class CouponTest {
 
     @Test
     void 쿠폰을_생성할_수_있다() {
-        Member sender = new Member(1L, "루키");
-        Member receiver = new Member(2L, "아서");
+        Member sender = MemberFixture.ROOKIE;
+        Member receiver = MemberFixture.ARTHUR;
 
         Coupon actual = new Coupon(null, sender, receiver, "한턱쏘는", "추가 메세지", "#241223", CouponType.COFFEE,
                 CouponStatus.READY);
@@ -22,7 +23,7 @@ public class CouponTest {
 
     @Test
     void 보낸_사람과_받는_사람이_같은_경우_예외를_던진다() {
-        Member member = new Member(1L, "이름");
+        Member member = MemberFixture.ROOKIE;
         assertThatThrownBy(
                 () -> new Coupon(null, member, member, "한턱쏘는", "추가 메세지", "#241223", CouponType.COFFEE,
                         CouponStatus.READY)

--- a/backend/src/test/java/com/woowacourse/kkogkkog/fixture/MemberFixture.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/fixture/MemberFixture.java
@@ -1,0 +1,11 @@
+package com.woowacourse.kkogkkog.fixture;
+
+import com.woowacourse.kkogkkog.domain.Member;
+
+public class MemberFixture {
+
+    public static Member ROOKIE = new Member(null, "rookie@gmail.com", "password1234!", "루키");
+    public static Member ARTHUR = new Member(null, "arthur@gmail.com", "password1234!", "아서");
+    public static Member JEONG = new Member(null, "jeong@gmail.com", "password1234!", "정");
+    public static Member LEO = new Member(null, "leo@gmail.com", "password1234!", "레오");
+}


### PR DESCRIPTION
## 작업 내용

- 회원가입 API 구현

  - Member 엔티티 변경
  - 회원가입 API 구현

## 공유사항

- Test Code에 Fixture 도입
- 프론트와 같이 페어 코딩

Resolves #30 
