### PR TITLE
feat: 회원가입 된 회원들의 전체 조회 API 구현

### DIFF
--- a/backend/src/docs/asciidoc/member.adoc
+++ b/backend/src/docs/asciidoc/member.adoc
@@ -8,3 +8,7 @@
 == Member
 === 회원가입
 operation::member-create[snippets='http-request,http-response,request-fields']
+
+=== 전체 조회
+operation::member-showAll[snippets='http-request,http-response,response-fields']
+

--- a/backend/src/main/java/com/woowacourse/kkogkkog/application/MemberService.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/application/MemberService.java
@@ -1,9 +1,14 @@
 package com.woowacourse.kkogkkog.application;
 
+import static java.util.stream.Collectors.*;
+
+import com.woowacourse.kkogkkog.application.dto.MemberResponse;
+import com.woowacourse.kkogkkog.application.dto.MembersResponse;
 import com.woowacourse.kkogkkog.domain.Member;
 import com.woowacourse.kkogkkog.domain.repository.MemberRepository;
 import com.woowacourse.kkogkkog.exception.member.MemberDuplicatedEmail;
 import com.woowacourse.kkogkkog.presentation.dto.MemberCreateRequest;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,5 +32,13 @@ public class MemberService {
         Member member = memberCreateRequest.toEntity();
 
         return memberRepository.save(member).getId();
+    }
+
+    public MembersResponse findAll() {
+        List<MemberResponse> memberResponses = memberRepository.findAll().stream()
+            .map(it -> new MemberResponse(it.getId(), it.getEmail(), it.getNickname()))
+            .collect(toList());
+
+        return new MembersResponse(memberResponses);
     }
 }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/application/MemberService.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/application/MemberService.java
@@ -36,7 +36,7 @@ public class MemberService {
 
     public MembersResponse findAll() {
         List<MemberResponse> memberResponses = memberRepository.findAll().stream()
-            .map(it -> new MemberResponse(it.getId(), it.getEmail(), it.getNickname()))
+            .map(it -> MemberResponse.of(it))
             .collect(toList());
 
         return new MembersResponse(memberResponses);

--- a/backend/src/main/java/com/woowacourse/kkogkkog/application/dto/MemberResponse.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/application/dto/MemberResponse.java
@@ -1,0 +1,20 @@
+package com.woowacourse.kkogkkog.application.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class MemberResponse {
+
+    private Long id;
+    private String nickname;
+    private String email;
+
+    public MemberResponse(Long id, String nickname, String email) {
+        this.id = id;
+        this.nickname = nickname;
+        this.email = email;
+    }
+}

--- a/backend/src/main/java/com/woowacourse/kkogkkog/application/dto/MemberResponse.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/application/dto/MemberResponse.java
@@ -9,12 +9,12 @@ import lombok.NoArgsConstructor;
 public class MemberResponse {
 
     private Long id;
-    private String nickname;
     private String email;
+    private String nickname;
 
-    public MemberResponse(Long id, String nickname, String email) {
+    public MemberResponse(Long id, String email, String nickname) {
         this.id = id;
-        this.nickname = nickname;
         this.email = email;
+        this.nickname = nickname;
     }
 }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/application/dto/MemberResponse.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/application/dto/MemberResponse.java
@@ -1,5 +1,6 @@
 package com.woowacourse.kkogkkog.application.dto;
 
+import com.woowacourse.kkogkkog.domain.Member;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -16,5 +17,9 @@ public class MemberResponse {
         this.id = id;
         this.email = email;
         this.nickname = nickname;
+    }
+
+    public static MemberResponse of(Member member) {
+        return new MemberResponse(member.getId(), member.getEmail(), member.getNickname());
     }
 }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/application/dto/MembersResponse.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/application/dto/MembersResponse.java
@@ -1,0 +1,17 @@
+package com.woowacourse.kkogkkog.application.dto;
+
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class MembersResponse {
+
+    private List<MemberResponse> data;
+
+    public MembersResponse(List<MemberResponse> data) {
+        this.data = data;
+    }
+}

--- a/backend/src/main/java/com/woowacourse/kkogkkog/presentation/MemberController.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/presentation/MemberController.java
@@ -1,8 +1,10 @@
 package com.woowacourse.kkogkkog.presentation;
 
 import com.woowacourse.kkogkkog.application.MemberService;
+import com.woowacourse.kkogkkog.application.dto.MembersResponse;
 import com.woowacourse.kkogkkog.presentation.dto.MemberCreateRequest;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -23,5 +25,12 @@ public class MemberController {
         memberService.save(memberCreateRequest);
 
         return ResponseEntity.created(null).build();
+    }
+
+    @GetMapping
+    public ResponseEntity<MembersResponse> showAll() {
+        MembersResponse membersResponse = memberService.findAll();
+
+        return ResponseEntity.ok(membersResponse);
     }
 }

--- a/backend/src/test/java/com/woowacourse/kkogkkog/acceptance/MemberAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/acceptance/MemberAcceptanceTest.java
@@ -3,11 +3,14 @@ package com.woowacourse.kkogkkog.acceptance;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import com.woowacourse.kkogkkog.application.dto.MemberResponse;
 import com.woowacourse.kkogkkog.application.dto.MembersResponse;
+import com.woowacourse.kkogkkog.domain.Member;
 import com.woowacourse.kkogkkog.presentation.dto.MemberCreateRequest;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -75,7 +78,12 @@ public class MemberAcceptanceTest extends AcceptanceTest {
 
         assertAll(
             () -> assertThat(extract.statusCode()).isEqualTo(HttpStatus.OK.value()),
-            () -> assertThat(membersResponse.getData()).hasSize(2)
-        );
+            () -> assertThat(membersResponse.getData()).hasSize(2),
+            () -> assertThat(membersResponse.getData()).usingRecursiveComparison().isEqualTo(
+                List.of(
+                    MemberResponse.of(new Member(1L, "rookie@gmail.com", null, "rookie")),
+                    MemberResponse.of(new Member(2L, "arthur@gmail.com", null, "arthur"))
+                )
+        ));
     }
 }

--- a/backend/src/test/java/com/woowacourse/kkogkkog/acceptance/MemberAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/acceptance/MemberAcceptanceTest.java
@@ -1,7 +1,9 @@
 package com.woowacourse.kkogkkog.acceptance;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
+import com.woowacourse.kkogkkog.application.dto.MembersResponse;
 import com.woowacourse.kkogkkog.presentation.dto.MemberCreateRequest;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
@@ -52,5 +54,28 @@ public class MemberAcceptanceTest extends AcceptanceTest {
             .extract();
 
         assertThat(extract.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+    }
+
+    @Test
+    void 회원_가입된_전체_사용자_조회를_할_수_있다() {
+        MemberCreateRequest memberCreateRequest1 = new MemberCreateRequest("rookie@gmail.com",
+            "password1234!", "rookie");
+        MemberCreateRequest memberCreateRequest2 = new MemberCreateRequest("arthur@gmail.com",
+            "password1234!", "arthur");
+        회원_가입에_성공한다(memberCreateRequest1);
+        회원_가입에_성공한다(memberCreateRequest2);
+
+        ExtractableResponse<Response> extract = RestAssured.given().log().all()
+            .when()
+            .get("/api/members")
+            .then().log().all()
+            .extract();
+
+        MembersResponse membersResponse = extract.as(MembersResponse.class);
+
+        assertAll(
+            () -> assertThat(extract.statusCode()).isEqualTo(HttpStatus.OK.value()),
+            () -> assertThat(membersResponse.getData()).hasSize(2)
+        );
     }
 }

--- a/backend/src/test/java/com/woowacourse/kkogkkog/application/MemberServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/application/MemberServiceTest.java
@@ -3,6 +3,7 @@ package com.woowacourse.kkogkkog.application;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.woowacourse.kkogkkog.application.dto.MembersResponse;
 import com.woowacourse.kkogkkog.exception.member.MemberDuplicatedEmail;
 import com.woowacourse.kkogkkog.presentation.dto.MemberCreateRequest;
 import org.junit.jupiter.api.DisplayName;
@@ -36,5 +37,18 @@ class MemberServiceTest {
         memberService.save(memberCreateRequest);
         assertThatThrownBy(() -> memberService.save(memberCreateRequest))
             .isInstanceOf(MemberDuplicatedEmail.class);
+    }
+
+    @Test
+    @DisplayName("회원가입된 회원들의 정보를 조회할 수 있다.")
+    void findAll() {
+        MemberCreateRequest memberCreateRequest1 = new MemberCreateRequest("email1@gmail.com", "password1234!", "nickname1");
+        MemberCreateRequest memberCreateRequest2 = new MemberCreateRequest("email2@gmail.com", "password1234!", "nickname2");
+        memberService.save(memberCreateRequest1);
+        memberService.save(memberCreateRequest2);
+
+        MembersResponse membersResponse = memberService.findAll();
+
+        assertThat(membersResponse.getData()).hasSize(2);
     }
 }

--- a/backend/src/test/java/com/woowacourse/kkogkkog/documentation/MemberControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/documentation/MemberControllerTest.java
@@ -5,13 +5,18 @@ import static com.woowacourse.kkogkkog.documentation.support.ApiDocumentUtils.ge
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.woowacourse.kkogkkog.application.dto.MemberResponse;
+import com.woowacourse.kkogkkog.application.dto.MembersResponse;
 import com.woowacourse.kkogkkog.presentation.dto.MemberCreateRequest;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
@@ -44,6 +49,35 @@ public class MemberControllerTest extends Documentation {
                     fieldWithPath("email").type(JsonFieldType.STRING).description("이메일"),
                     fieldWithPath("password").type(JsonFieldType.STRING).description("비밀번호"),
                     fieldWithPath("nickname").type(JsonFieldType.STRING).description("닉네임")
+                ))
+            );
+    }
+
+    @Test
+    void 회원_전체를_조회할_수_있다() throws Exception {
+        // given
+        MembersResponse membersResponse = new MembersResponse(List.of(
+            new MemberResponse(1L,"user1@gmail.com", "user1"),
+            new MemberResponse(2L, "user2@gmail.com", "user2")
+        ));
+        given(memberService.findAll()).willReturn(membersResponse);
+
+        // when
+        ResultActions perform = mockMvc.perform(get("/api/members"));
+
+        // then
+        perform.andExpect(status().isOk());
+
+        // docs
+        perform
+            .andDo(print())
+            .andDo(document("member-showAll",
+                getDocumentRequest(),
+                getDocumentResponse(),
+                responseFields(
+                    fieldWithPath("data.[].id").type(JsonFieldType.NUMBER).description("ID"),
+                    fieldWithPath("data.[].email").type(JsonFieldType.STRING).description("이메일"),
+                    fieldWithPath("data.[].nickname").type(JsonFieldType.STRING).description("닉네임")
                 ))
             );
     }


### PR DESCRIPTION
## 작업 내용

- 회원가입 된 회원들의 전체 목록을 조회하는 API 구현


## 공유사항

- 로그인을 했을 경우만 API를 호출할 수 있도록 할지 추후 검토한다.
- 인수테스트가 기존 작성법과 다름. 추후 refactor 브랜치를 통해서 `@Nested`를 통한 DCI 패턴 기반의 작성을 논의한다.
- 기존 fixture 들을 활용하지 않음. 추후 refactor 브랜치를 통해서 'fixture'들의 활용법을 논의한다.

Resolves #31 