### PR TITLE
feat: Spring Bean Validation 도입

### DIFF
--- a/backend/src/main/java/com/woowacourse/kkogkkog/exception/GlobalControllerAdvice.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/exception/GlobalControllerAdvice.java
@@ -43,14 +43,13 @@ public class GlobalControllerAdvice {
     }
 
     @ExceptionHandler
-    public ResponseEntity<ErrorResponse> handleInvalidRequest(
-        MethodArgumentNotValidException bindingResult) {
+    public ResponseEntity<ErrorResponse> handleException(MethodArgumentNotValidException bindingResult) {
         String causes = bindingResult.getFieldErrors()
             .stream()
             .map(DefaultMessageSourceResolvable::getDefaultMessage)
             .collect(Collectors.joining(INVALID_REQUEST_DELIMITER));
         String errorMessage = String.format(INVALID_REQUEST_EXCEPTION_MESSAGE_FORMAT, causes);
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ErrorResponse(errorMessage));
+        return new ResponseEntity<>(new ErrorResponse(errorMessage), HttpStatus.BAD_REQUEST);
     }
 
     @Getter

--- a/backend/src/main/java/com/woowacourse/kkogkkog/presentation/AuthController.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/presentation/AuthController.java
@@ -3,6 +3,7 @@ package com.woowacourse.kkogkkog.presentation;
 import com.woowacourse.kkogkkog.application.AuthService;
 import com.woowacourse.kkogkkog.application.dto.TokenResponse;
 import com.woowacourse.kkogkkog.presentation.dto.TokenRequest;
+import javax.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -20,7 +21,7 @@ public class AuthController {
     }
 
     @PostMapping("/login")
-    public ResponseEntity<TokenResponse> login(@RequestBody TokenRequest tokenRequest) {
+    public ResponseEntity<TokenResponse> login(@Valid @RequestBody TokenRequest tokenRequest) {
         TokenResponse tokenResponse = authService.login(tokenRequest);
 
         return ResponseEntity.ok(tokenResponse);

--- a/backend/src/main/java/com/woowacourse/kkogkkog/presentation/CouponController.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/presentation/CouponController.java
@@ -7,6 +7,7 @@ import com.woowacourse.kkogkkog.presentation.dto.CouponCreateResponse;
 import com.woowacourse.kkogkkog.presentation.dto.CouponsResponse;
 import com.woowacourse.kkogkkog.presentation.dto.MyCouponsResponse;
 import java.util.List;
+import javax.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -36,7 +37,7 @@ public class CouponController {
 
     @PostMapping
     public ResponseEntity<CouponCreateResponse> create(@LoginMember Long authMemberId,
-                                                       @RequestBody CouponCreateRequest couponCreateRequest) {
+                                                       @Valid @RequestBody CouponCreateRequest couponCreateRequest) {
         List<CouponResponse> couponResponses = couponService.save(
                 couponCreateRequest.toCouponSaveRequest(authMemberId));
         return ResponseEntity.created(null).body(new CouponCreateResponse(couponResponses));

--- a/backend/src/main/java/com/woowacourse/kkogkkog/presentation/MemberController.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/presentation/MemberController.java
@@ -4,6 +4,7 @@ import com.woowacourse.kkogkkog.application.MemberService;
 import com.woowacourse.kkogkkog.application.dto.MemberResponse;
 import com.woowacourse.kkogkkog.application.dto.MembersResponse;
 import com.woowacourse.kkogkkog.presentation.dto.MemberCreateRequest;
+import javax.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -22,7 +23,7 @@ public class MemberController {
     }
 
     @PostMapping
-    public ResponseEntity<Void> create(@RequestBody MemberCreateRequest memberCreateRequest) {
+    public ResponseEntity<Void> create(@Valid @RequestBody MemberCreateRequest memberCreateRequest) {
         memberService.save(memberCreateRequest);
 
         return ResponseEntity.created(null).build();

--- a/backend/src/main/java/com/woowacourse/kkogkkog/presentation/dto/CouponCreateRequest.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/presentation/dto/CouponCreateRequest.java
@@ -2,6 +2,8 @@ package com.woowacourse.kkogkkog.presentation.dto;
 
 import com.woowacourse.kkogkkog.application.dto.CouponSaveRequest;
 import java.util.List;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotEmpty;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,10 +12,18 @@ import lombok.NoArgsConstructor;
 @Getter
 public class CouponCreateRequest {
 
+    @NotEmpty(message = "받는 사람의 아이디를 입력해주세요")
     private List<Long> receivers;
+
+    @NotBlank(message = "수식어를 입력해주세요")
     private String modifier;
+
     private String message;
+
+    @NotBlank(message = "쿠폰 배경색을 입력해주세요")
     private String backgroundColor;
+
+    @NotBlank(message = "쿠폰 타입을 입력해주세요")
     private String couponType;
 
     public CouponCreateRequest(List<Long> receivers, String modifier, String message, String backgroundColor,

--- a/backend/src/main/java/com/woowacourse/kkogkkog/presentation/dto/MemberCreateRequest.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/presentation/dto/MemberCreateRequest.java
@@ -1,6 +1,7 @@
 package com.woowacourse.kkogkkog.presentation.dto;
 
 import com.woowacourse.kkogkkog.domain.Member;
+import javax.validation.constraints.NotBlank;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -9,8 +10,13 @@ import lombok.NoArgsConstructor;
 @Getter
 public class MemberCreateRequest {
 
+    @NotBlank(message = "이메일을 입력해주세요")
     private String email;
+
+    @NotBlank(message = "비밀번호를 입력해주세요")
     private String password;
+
+    @NotBlank(message = "닉네임을 입력해주세요")
     private String nickname;
 
     public MemberCreateRequest(String email, String password, String nickname) {

--- a/backend/src/main/java/com/woowacourse/kkogkkog/presentation/dto/TokenRequest.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/presentation/dto/TokenRequest.java
@@ -1,5 +1,6 @@
 package com.woowacourse.kkogkkog.presentation.dto;
 
+import javax.validation.constraints.NotBlank;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -8,7 +9,10 @@ import lombok.NoArgsConstructor;
 @Getter
 public class TokenRequest {
 
+    @NotBlank(message = "이메일을 입력해주세요")
     private String email;
+
+    @NotBlank(message = "비밀번호를 입력해주세요")
     private String password;
 
     public TokenRequest(String email, String password) {


### PR DESCRIPTION
## 작업 내용

- 모든 API들의 RequestBody 필드 내 Spring Bean Validation 적용함

## 공유사항

- validation에 의해 검증에 실패하면 MethodArgumentNotValidException을 반환하나 세부 커스텀 예외로 핸들링하지는 못하고  
InvalidRequestException을 호출하도록 구현함
- 이메일과 패스워드 등 정규식은 구현하지 않음. 빈 문자열인지만 검사함.
- 스타일 가이드 통일 요청.
Resolves #70 
