### PR TITLE
feat: 쿠폰 사용 요청 API 구현

### DIFF
--- a/backend/src/docs/asciidoc/coupon.adoc
+++ b/backend/src/docs/asciidoc/coupon.adoc
@@ -14,3 +14,6 @@ operation::coupon-show[snippets='http-request,http-response,response-fields']
 
 === 쿠폰 전체 조회
 operation::coupon-showAll[snippets='http-request,http-response,response-fields']
+
+=== 쿠폰 상태 변경
+operation::coupon-action[snippets='http-request,http-response,response-fields']

--- a/backend/src/main/java/com/woowacourse/kkogkkog/application/CouponService.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/application/CouponService.java
@@ -81,9 +81,9 @@ public class CouponService {
     }
 
     public void changeStatus(CouponChangeStatusRequest couponChangeStatusRequest) {
-        Member member = findMember(couponChangeStatusRequest.getAuthUserId());
+        Member loginMember = findMember(couponChangeStatusRequest.getLoginMemberId());
         Coupon coupon = findCoupon(couponChangeStatusRequest.getCouponId());
-        coupon.changeStatus(couponChangeStatusRequest.getEvent(), member);
+        coupon.changeStatus(couponChangeStatusRequest.getEvent(), loginMember);
     }
 
     private Member findMember(Long memberId) {

--- a/backend/src/main/java/com/woowacourse/kkogkkog/application/CouponService.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/application/CouponService.java
@@ -1,5 +1,6 @@
 package com.woowacourse.kkogkkog.application;
 
+import com.woowacourse.kkogkkog.application.dto.CouponChangeStatusRequest;
 import com.woowacourse.kkogkkog.application.dto.CouponResponse;
 import com.woowacourse.kkogkkog.application.dto.CouponSaveRequest;
 import com.woowacourse.kkogkkog.domain.Coupon;
@@ -10,11 +11,10 @@ import com.woowacourse.kkogkkog.domain.repository.CouponRepository;
 import com.woowacourse.kkogkkog.domain.repository.MemberRepository;
 import com.woowacourse.kkogkkog.exception.coupon.CouponNotFoundException;
 import com.woowacourse.kkogkkog.exception.member.MemberNotFoundException;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import java.util.List;
 import java.util.stream.Collectors;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Transactional
@@ -30,8 +30,7 @@ public class CouponService {
 
     @Transactional(readOnly = true)
     public CouponResponse findById(Long couponId) {
-        Coupon coupon = couponRepository.findById(couponId)
-                .orElseThrow(CouponNotFoundException::new);
+        Coupon coupon = findCoupon(couponId);
 
         return CouponResponse.of(coupon);
     }
@@ -81,8 +80,19 @@ public class CouponService {
         return receivers;
     }
 
+    public void changeStatus(CouponChangeStatusRequest couponChangeStatusRequest) {
+        Member member = findMember(couponChangeStatusRequest.getAuthUserId());
+        Coupon coupon = findCoupon(couponChangeStatusRequest.getCouponId());
+        coupon.changeStatus(couponChangeStatusRequest.getEvent(), member);
+    }
+
     private Member findMember(Long memberId) {
         return memberRepository.findById(memberId)
                 .orElseThrow(MemberNotFoundException::new);
+    }
+
+    private Coupon findCoupon(Long couponId) {
+        return couponRepository.findById(couponId)
+                .orElseThrow(CouponNotFoundException::new);
     }
 }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/application/dto/CouponChangeStatusRequest.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/application/dto/CouponChangeStatusRequest.java
@@ -9,12 +9,12 @@ import lombok.NoArgsConstructor;
 @Getter
 public class CouponChangeStatusRequest {
 
-    private Long authUserId;
+    private Long loginMemberId;
     private Long couponId;
     private CouponEvent event;
 
-    public CouponChangeStatusRequest(Long authUserId, Long couponId, CouponEvent event) {
-        this.authUserId = authUserId;
+    public CouponChangeStatusRequest(Long loginMemberId, Long couponId, CouponEvent event) {
+        this.loginMemberId = loginMemberId;
         this.couponId = couponId;
         this.event = event;
     }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/application/dto/CouponChangeStatusRequest.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/application/dto/CouponChangeStatusRequest.java
@@ -1,0 +1,21 @@
+package com.woowacourse.kkogkkog.application.dto;
+
+import com.woowacourse.kkogkkog.domain.CouponEvent;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class CouponChangeStatusRequest {
+
+    private Long authUserId;
+    private Long couponId;
+    private CouponEvent event;
+
+    public CouponChangeStatusRequest(Long authUserId, Long couponId, CouponEvent event) {
+        this.authUserId = authUserId;
+        this.couponId = couponId;
+        this.event = event;
+    }
+}

--- a/backend/src/main/java/com/woowacourse/kkogkkog/config/InterceptorConfig.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/config/InterceptorConfig.java
@@ -18,7 +18,8 @@ public class InterceptorConfig implements WebMvcConfigurer {
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(new LoginInterceptor(jwtTokenProvider))
-            .addPathPatterns("/api/members/me")
-            .addPathPatterns("/api/coupons");
+                .addPathPatterns("/api/members/me")
+                .addPathPatterns("/api/coupons")
+                .addPathPatterns("/api/coupons/*/event");
     }
 }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/domain/Coupon.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/domain/Coupon.java
@@ -71,4 +71,9 @@ public class Coupon {
             throw new SameSenderReceiverException();
         }
     }
+
+    public void changeStatus(CouponEvent event, Member member) {
+        event.checkExecutable(sender.equals(member), receiver.equals(member));
+        this.couponStatus = couponStatus.handle(event);
+    }
 }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/domain/CouponEvent.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/domain/CouponEvent.java
@@ -1,0 +1,26 @@
+package com.woowacourse.kkogkkog.domain;
+
+import com.woowacourse.kkogkkog.exception.ForbiddenException;
+import java.util.function.BiConsumer;
+
+public enum CouponEvent {
+
+    REQUEST(CouponEvent::canRequest),
+    ;
+
+    private final BiConsumer<Boolean, Boolean> canChange;
+
+    CouponEvent(BiConsumer<Boolean, Boolean> canChange) {
+        this.canChange = canChange;
+    }
+
+    public void checkExecutable(boolean isSender, boolean isReceiver) {
+        canChange.accept(isSender, isReceiver);
+    }
+
+    private static void canRequest(boolean isSender, boolean isReceiver) {
+        if (!isReceiver) {
+            throw new ForbiddenException("쿠폰을 받은 사람만 쿠폰을 사용할 수 있습니다.");
+        }
+    }
+}

--- a/backend/src/main/java/com/woowacourse/kkogkkog/domain/CouponEvent.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/domain/CouponEvent.java
@@ -1,6 +1,7 @@
 package com.woowacourse.kkogkkog.domain;
 
 import com.woowacourse.kkogkkog.exception.ForbiddenException;
+import com.woowacourse.kkogkkog.exception.InvalidRequestException;
 import java.util.function.BiConsumer;
 
 public enum CouponEvent {
@@ -12,6 +13,14 @@ public enum CouponEvent {
 
     CouponEvent(BiConsumer<Boolean, Boolean> canChange) {
         this.canChange = canChange;
+    }
+
+    public static CouponEvent of(String value) {
+        try {
+            return CouponEvent.valueOf(value);
+        } catch (IllegalArgumentException e) {
+            throw new InvalidRequestException("처리할 수 없는 요청입니다.");
+        }
     }
 
     public void checkExecutable(boolean isSender, boolean isReceiver) {

--- a/backend/src/main/java/com/woowacourse/kkogkkog/domain/CouponStatus.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/domain/CouponStatus.java
@@ -1,6 +1,24 @@
 package com.woowacourse.kkogkkog.domain;
 
+import com.woowacourse.kkogkkog.exception.InvalidRequestException;
+
 public enum CouponStatus {
 
-    READY
+    READY,
+    REQUESTED,
+    ;
+
+    public CouponStatus handle(CouponEvent event) {
+        if (event == CouponEvent.REQUEST) {
+            return handleRequest();
+        }
+        throw new InvalidRequestException("처리할 수 없는 요청입니다.");
+    }
+
+    private CouponStatus handleRequest() {
+        if (this != READY) {
+            throw new InvalidRequestException("사용 요청을 보낼 수 없는 상태의 쿠폰입니다.");
+        }
+        return REQUESTED;
+    }
 }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/presentation/CouponController.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/presentation/CouponController.java
@@ -27,19 +27,19 @@ public class CouponController {
     }
 
     @GetMapping
-    public ResponseEntity<MyCouponsResponse> showAll(@LoginMember Long authMemberId) {
+    public ResponseEntity<MyCouponsResponse> showAll(@LoginMember Long loginMemberId) {
         MyCouponsResponse myCouponsResponse = new MyCouponsResponse(new CouponsResponse(
-                couponService.findAllBySender(authMemberId),
-                couponService.findAllByReceiver(authMemberId)));
+                couponService.findAllBySender(loginMemberId),
+                couponService.findAllByReceiver(loginMemberId)));
 
         return ResponseEntity.ok(myCouponsResponse);
     }
 
     @PostMapping
-    public ResponseEntity<CouponCreateResponse> create(@LoginMember Long authMemberId,
+    public ResponseEntity<CouponCreateResponse> create(@LoginMember Long loginMemberId,
                                                        @RequestBody CouponCreateRequest couponCreateRequest) {
         List<CouponResponse> couponResponses = couponService.save(
-                couponCreateRequest.toCouponSaveRequest(authMemberId));
+                couponCreateRequest.toCouponSaveRequest(loginMemberId));
         return ResponseEntity.created(null).body(new CouponCreateResponse(couponResponses));
     }
 
@@ -50,10 +50,10 @@ public class CouponController {
     }
 
     @PostMapping("/{couponId}/event")
-    public ResponseEntity<Void> action(@LoginMember Long authMemberId,
+    public ResponseEntity<Void> action(@LoginMember Long loginMemberId,
                                        @PathVariable Long couponId,
                                        @RequestBody CouponEventRequest couponEventRequest) {
-        couponService.changeStatus(couponEventRequest.toCouponChangeStatusRequest(authMemberId, couponId));
+        couponService.changeStatus(couponEventRequest.toCouponChangeStatusRequest(loginMemberId, couponId));
         return ResponseEntity.ok().build();
     }
 }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/presentation/CouponController.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/presentation/CouponController.java
@@ -4,6 +4,7 @@ import com.woowacourse.kkogkkog.application.CouponService;
 import com.woowacourse.kkogkkog.application.dto.CouponResponse;
 import com.woowacourse.kkogkkog.presentation.dto.CouponCreateRequest;
 import com.woowacourse.kkogkkog.presentation.dto.CouponCreateResponse;
+import com.woowacourse.kkogkkog.presentation.dto.CouponEventRequest;
 import com.woowacourse.kkogkkog.presentation.dto.CouponsResponse;
 import com.woowacourse.kkogkkog.presentation.dto.MyCouponsResponse;
 import java.util.List;
@@ -46,5 +47,13 @@ public class CouponController {
     public ResponseEntity<CouponResponse> show(@PathVariable Long couponId) {
         CouponResponse couponResponse = couponService.findById(couponId);
         return ResponseEntity.ok(couponResponse);
+    }
+
+    @PostMapping("/{couponId}/event")
+    public ResponseEntity<Void> action(@LoginMember Long authMemberId,
+                                       @PathVariable Long couponId,
+                                       @RequestBody CouponEventRequest couponEventRequest) {
+        couponService.changeStatus(couponEventRequest.toCouponChangeStatusRequest(authMemberId, couponId));
+        return ResponseEntity.ok().build();
     }
 }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/presentation/dto/CouponEventRequest.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/presentation/dto/CouponEventRequest.java
@@ -1,0 +1,22 @@
+package com.woowacourse.kkogkkog.presentation.dto;
+
+import com.woowacourse.kkogkkog.application.dto.CouponChangeStatusRequest;
+import com.woowacourse.kkogkkog.domain.CouponEvent;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class CouponEventRequest {
+
+    private String couponEvent;
+
+    public CouponEventRequest(String couponEvent) {
+        this.couponEvent = couponEvent;
+    }
+
+    public CouponChangeStatusRequest toCouponChangeStatusRequest(Long authUserId, Long couponId) {
+        return new CouponChangeStatusRequest(authUserId, couponId, CouponEvent.of(couponEvent));
+    }
+}

--- a/backend/src/main/java/com/woowacourse/kkogkkog/presentation/dto/CouponEventRequest.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/presentation/dto/CouponEventRequest.java
@@ -16,7 +16,7 @@ public class CouponEventRequest {
         this.couponEvent = couponEvent;
     }
 
-    public CouponChangeStatusRequest toCouponChangeStatusRequest(Long authUserId, Long couponId) {
-        return new CouponChangeStatusRequest(authUserId, couponId, CouponEvent.of(couponEvent));
+    public CouponChangeStatusRequest toCouponChangeStatusRequest(Long loginMemberId, Long couponId) {
+        return new CouponChangeStatusRequest(loginMemberId, couponId, CouponEvent.of(couponEvent));
     }
 }

--- a/backend/src/test/java/com/woowacourse/kkogkkog/application/CouponServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/application/CouponServiceTest.java
@@ -4,11 +4,15 @@ import static com.woowacourse.kkogkkog.fixture.MemberFixture.NON_EXISTING_MEMBER
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.woowacourse.kkogkkog.application.dto.CouponChangeStatusRequest;
 import com.woowacourse.kkogkkog.application.dto.CouponMemberResponse;
 import com.woowacourse.kkogkkog.application.dto.CouponResponse;
 import com.woowacourse.kkogkkog.application.dto.CouponSaveRequest;
+import com.woowacourse.kkogkkog.domain.CouponEvent;
+import com.woowacourse.kkogkkog.domain.CouponStatus;
 import com.woowacourse.kkogkkog.domain.Member;
 import com.woowacourse.kkogkkog.domain.repository.MemberRepository;
+import com.woowacourse.kkogkkog.exception.ForbiddenException;
 import com.woowacourse.kkogkkog.exception.coupon.CouponNotFoundException;
 import com.woowacourse.kkogkkog.exception.member.MemberNotFoundException;
 import java.util.List;
@@ -158,6 +162,38 @@ public class CouponServiceTest extends ServiceTest {
 
             assertThatThrownBy(() -> couponService.save(couponSaveRequest))
                     .isInstanceOf(MemberNotFoundException.class);
+        }
+    }
+
+    @DisplayName("쿠폰 이벤트에 따라 쿠폰의 상태를 수정할 수 있다")
+    @Nested
+    class ChangeStatusTest {
+
+        @Test
+        @DisplayName("받은 사람은 READY 상태의 쿠폰에 대한 사용 요청을 보낼 수 있다")
+        void request() {
+            CouponSaveRequest couponSaveRequest = toCouponSaveRequest(ROOKIE, List.of(ARTHUR));
+            long couponId = couponService.save(couponSaveRequest).get(0).getId();
+            CouponChangeStatusRequest couponChangeStatusRequest = new CouponChangeStatusRequest(ARTHUR.getId(),
+                    couponId, CouponEvent.REQUEST);
+
+            couponService.changeStatus(couponChangeStatusRequest);
+            CouponResponse actual = couponService.findById(couponId);
+
+            assertThat(actual.getCouponStatus()).isEqualTo(CouponStatus.REQUESTED.name());
+        }
+
+        @Test
+        @DisplayName("보낸 사람은 쿠폰 사용 요청을 보낼 수 없다.")
+        void request_senderNotAllowed() {
+            CouponSaveRequest couponSaveRequest = toCouponSaveRequest(ROOKIE, List.of(ARTHUR));
+            long couponId = couponService.save(couponSaveRequest).get(0).getId();
+
+            CouponChangeStatusRequest couponChangeStatusRequest = new CouponChangeStatusRequest(ROOKIE.getId(),
+                    couponId, CouponEvent.REQUEST);
+
+            assertThatThrownBy(() -> couponService.changeStatus(couponChangeStatusRequest))
+                    .isInstanceOf(ForbiddenException.class);
         }
     }
 

--- a/backend/src/test/java/com/woowacourse/kkogkkog/application/CouponServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/application/CouponServiceTest.java
@@ -173,7 +173,7 @@ public class CouponServiceTest extends ServiceTest {
         @DisplayName("받은 사람은 READY 상태의 쿠폰에 대한 사용 요청을 보낼 수 있다")
         void request() {
             CouponSaveRequest couponSaveRequest = toCouponSaveRequest(ROOKIE, List.of(ARTHUR));
-            long couponId = couponService.save(couponSaveRequest).get(0).getId();
+            Long couponId = couponService.save(couponSaveRequest).get(0).getId();
             CouponChangeStatusRequest couponChangeStatusRequest = new CouponChangeStatusRequest(ARTHUR.getId(),
                     couponId, CouponEvent.REQUEST);
 
@@ -187,7 +187,7 @@ public class CouponServiceTest extends ServiceTest {
         @DisplayName("보낸 사람은 쿠폰 사용 요청을 보낼 수 없다.")
         void request_senderNotAllowed() {
             CouponSaveRequest couponSaveRequest = toCouponSaveRequest(ROOKIE, List.of(ARTHUR));
-            long couponId = couponService.save(couponSaveRequest).get(0).getId();
+            Long couponId = couponService.save(couponSaveRequest).get(0).getId();
 
             CouponChangeStatusRequest couponChangeStatusRequest = new CouponChangeStatusRequest(ROOKIE.getId(),
                     couponId, CouponEvent.REQUEST);

--- a/backend/src/test/java/com/woowacourse/kkogkkog/documentation/CouponControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/documentation/CouponControllerTest.java
@@ -18,11 +18,13 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.woowacourse.kkogkkog.application.dto.CouponMemberResponse;
 import com.woowacourse.kkogkkog.application.dto.CouponResponse;
+import com.woowacourse.kkogkkog.domain.CouponEvent;
 import com.woowacourse.kkogkkog.domain.CouponStatus;
 import com.woowacourse.kkogkkog.domain.CouponType;
 import com.woowacourse.kkogkkog.domain.Member;
 import com.woowacourse.kkogkkog.presentation.dto.CouponCreateRequest;
 import com.woowacourse.kkogkkog.presentation.dto.CouponCreateResponse;
+import com.woowacourse.kkogkkog.presentation.dto.CouponEventRequest;
 import com.woowacourse.kkogkkog.presentation.dto.CouponsResponse;
 import com.woowacourse.kkogkkog.presentation.dto.MyCouponsResponse;
 import java.util.List;
@@ -192,6 +194,36 @@ class CouponControllerTest extends Documentation {
                                 fieldWithPath("data.sent.[].message").type(JsonFieldType.STRING).description("추가 메시지"),
                                 fieldWithPath("data.sent.[].couponType").type(JsonFieldType.STRING).description("쿠폰 타입"),
                                 fieldWithPath("data.sent.[].couponStatus").type(JsonFieldType.STRING).description("쿠폰 상태")
+                        ))
+                );
+    }
+
+    @Test
+    void 쿠폰_상태_변경을_요청한다() throws Exception {
+        // given
+        CouponEventRequest couponEventRequest = new CouponEventRequest(CouponEvent.REQUEST.name());
+        given(jwtTokenProvider.getValidatedPayload(any())).willReturn("1");
+
+        // when
+        ResultActions perform = mockMvc.perform(post("/api/coupons/{couponId}/event", 1L)
+                .header(HttpHeaders.AUTHORIZATION, BEARER_TOKEN)
+                .content(objectMapper.writeValueAsString(couponEventRequest))
+                .contentType(MediaType.APPLICATION_JSON));
+
+        // then
+        perform.andExpect(status().isOk());
+
+        // docs
+        perform
+                .andDo(print())
+                .andDo(document("coupon-action",
+                        getDocumentRequest(),
+                        getDocumentResponse(),
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("토큰")
+                        ),
+                        requestFields(
+                                fieldWithPath("couponEvent").type(JsonFieldType.STRING).description("쿠폰 이벤트")
                         ))
                 );
     }

--- a/backend/src/test/java/com/woowacourse/kkogkkog/domain/CouponEventTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/domain/CouponEventTest.java
@@ -1,0 +1,31 @@
+package com.woowacourse.kkogkkog.domain;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.woowacourse.kkogkkog.exception.ForbiddenException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class CouponEventTest {
+
+    @Test
+    @DisplayName("쿠폰을 받은 사람이 쿠폰 사용 요청을 보낼 수 있다.")
+    void receiverCanRequest() {
+        boolean isSender = false;
+        boolean isReceiver = true;
+
+        assertThatNoException()
+                .isThrownBy(() -> CouponEvent.REQUEST.checkExecutable(isSender, isReceiver));
+    }
+
+    @Test
+    @DisplayName("쿠폰을 보낸 사람이 쿠폰 사용 요청을 보내는 경우 예외가 발생한다.")
+    void senderCanNotRequest() {
+        boolean isSender = true;
+        boolean isReceiver = false;
+
+        assertThatThrownBy(() -> CouponEvent.REQUEST.checkExecutable(isSender, isReceiver))
+                .isInstanceOf(ForbiddenException.class);
+    }
+}

--- a/backend/src/test/java/com/woowacourse/kkogkkog/domain/CouponStatusTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/domain/CouponStatusTest.java
@@ -1,0 +1,33 @@
+package com.woowacourse.kkogkkog.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.woowacourse.kkogkkog.exception.InvalidRequestException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class CouponStatusTest {
+
+    @Test
+    @DisplayName("READY 상태의 쿠폰은 REQUEST 이벤트를 받으면 REQUESTED 상태로 변경된다.")
+    void readyChangesToRequestedOnRequestEvent() {
+        CouponStatus currentStatus = CouponStatus.READY;
+        CouponEvent event = CouponEvent.REQUEST;
+
+        CouponStatus actual = currentStatus.handle(event);
+        CouponStatus expected = CouponStatus.REQUESTED;
+
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("REQUESTED 상태의 쿠폰은 REQUEST 이벤트를 받으면 예외가 발생된다.")
+    void requestedCanNotHandleRequestEvent() {
+        CouponStatus currentStatus = CouponStatus.REQUESTED;
+        CouponEvent event = CouponEvent.REQUEST;
+
+        assertThatThrownBy(() -> currentStatus.handle(event))
+                .isInstanceOf(InvalidRequestException.class);
+    }
+}

--- a/backend/src/test/java/com/woowacourse/kkogkkog/domain/CouponTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/domain/CouponTest.java
@@ -3,6 +3,7 @@ package com.woowacourse.kkogkkog.domain;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.woowacourse.kkogkkog.exception.ForbiddenException;
 import com.woowacourse.kkogkkog.exception.coupon.SameSenderReceiverException;
 import com.woowacourse.kkogkkog.fixture.MemberFixture;
 import org.junit.jupiter.api.Test;
@@ -28,5 +29,28 @@ public class CouponTest {
                 () -> new Coupon(null, member, member, "한턱쏘는", "추가 메세지", "#241223", CouponType.COFFEE,
                         CouponStatus.READY)
         ).isInstanceOf(SameSenderReceiverException.class);
+    }
+
+    @Test
+    void 받은_사람은_READY_상태의_쿠폰에_대한_사용_요청을_보낼_수_있다() {
+        Member sender = MemberFixture.ROOKIE;
+        Member receiver = MemberFixture.ARTHUR;
+        Coupon coupon = new Coupon(null, sender, receiver, "한턱쏘는", "추가 메세지", "#241223", CouponType.COFFEE,
+                CouponStatus.READY);
+
+        coupon.changeStatus(CouponEvent.REQUEST, receiver);
+
+        assertThat(coupon.getCouponStatus()).isEqualTo(CouponStatus.REQUESTED);
+    }
+
+    @Test
+    void 보낸_사람은_쿠폰_사용_요청을_보낼_수_없다() {
+        Member sender = MemberFixture.ROOKIE;
+        Member receiver = MemberFixture.ARTHUR;
+        Coupon coupon = new Coupon(null, sender, receiver, "한턱쏘는", "추가 메세지", "#241223", CouponType.COFFEE,
+                CouponStatus.READY);
+
+        assertThatThrownBy(() -> coupon.changeStatus(CouponEvent.REQUEST, sender))
+                .isInstanceOf(ForbiddenException.class);
     }
 }


### PR DESCRIPTION
## 작업 내용

- 상태 변경 요청에 대한 도메인, 서비스, API 틀 구현
- 쿠폰 사용 요청 기능 구현
- REST DOCS 추가

## 공유사항

신규 기능에 대한 도메인별 커스텀 예외클래스는 아직 구현하지 않았습니다. 상태코드만 제대로 나오도록`InvalidRequestException`, `ForbiddenException` 등의 클래스를 그대로 사용하였습니다. 

컨틀롤러와 서비스의 메서드명에 대해 고민 중입니다. 다음 쿠폰 사용 거절 요청 기능 구현할 때 수정해서 확정해주었으면 좋겠습니다.

Resolves #69
