### PR TITLE
feat: Login API 연동 및 인가 처리

### DIFF
--- a/frontend/src/@hooks/user/useMe.ts
+++ b/frontend/src/@hooks/user/useMe.ts
@@ -4,15 +4,13 @@ import { getMe } from '@/apis/user';
 import { MeResponse } from '@/types/remote/response';
 
 const useMe = () => {
-  const { data, isLoading, isError, remove } = useQuery<{ data: MeResponse }>(['me'], getMe, {
+  const meQuery = useQuery<{ data: MeResponse }>(['me'], getMe, {
     suspense: false,
   });
 
   return {
-    me: data?.data,
-    isLoading,
-    isError,
-    remove,
+    ...meQuery,
+    me: meQuery.data?.data,
   };
 };
 

--- a/frontend/src/@hooks/user/useMe.ts
+++ b/frontend/src/@hooks/user/useMe.ts
@@ -9,8 +9,8 @@ const useMe = () => {
   });
 
   return {
-    ...meQuery,
     me: meQuery.data?.data,
+    ...meQuery,
   };
 };
 

--- a/frontend/src/@pages/landing/index.tsx
+++ b/frontend/src/@pages/landing/index.tsx
@@ -12,7 +12,11 @@ import useMe from '@/@hooks/user/useMe';
 import { PATH } from '@/Router';
 
 const LandingPage = () => {
-  const { me } = useMe();
+  const { me, isFetched } = useMe();
+
+  if (!isFetched) {
+    return <></>;
+  }
 
   return me ? <AuthorizedLanding /> : <UnAuthorizedLanding />;
 };
@@ -21,7 +25,7 @@ export default LandingPage;
 
 LandingPage.Skeleton = function Skeleton() {
   return (
-    <PageTemplate title='꼭꼭'>
+    <PageTemplate title='꼭꼭' hasHeader={false}>
       <Styled.Root>
         <Styled.LinkContainer>
           <Link to={PATH.KKOGKKOG_CREATE}>

--- a/frontend/src/@pages/landing/index.tsx
+++ b/frontend/src/@pages/landing/index.tsx
@@ -11,32 +11,64 @@ import { useKkogKkogList } from '@/@hooks/kkogkkog/useKkogKkogList';
 import useMe from '@/@hooks/user/useMe';
 import { PATH } from '@/Router';
 
-type STATUS_TYPE = 'received' | 'sent';
-
 const LandingPage = () => {
   const { me } = useMe();
 
+  return me ? <AuthorizedLanding /> : <UnAuthorizedLanding />;
+};
+
+export default LandingPage;
+
+LandingPage.Skeleton = function Skeleton() {
+  return (
+    <PageTemplate title='꼭꼭'>
+      <Styled.Root>
+        <Styled.LinkContainer>
+          <Link to={PATH.KKOGKKOG_CREATE}>
+            <KkogKkogItem.LinkButton />
+          </Link>
+        </Styled.LinkContainer>
+        <Styled.ListContainer>
+          <Styled.ListHeaderContainer>
+            <Styled.ListHeaderItem>받은 쿠폰</Styled.ListHeaderItem>
+            <Styled.ListHeaderItem>보낸 쿠폰</Styled.ListHeaderItem>
+          </Styled.ListHeaderContainer>
+          <KkogKkogItem.Skeleton />
+          <KkogKkogItem.Skeleton />
+          <KkogKkogItem.Skeleton />
+          <KkogKkogItem.Skeleton />
+          <KkogKkogItem.Skeleton />
+          <KkogKkogItem.Skeleton />
+        </Styled.ListContainer>
+      </Styled.Root>
+    </PageTemplate>
+  );
+};
+
+const UnAuthorizedLanding = () => {
+  return (
+    <PageTemplate title='꼭꼭'>
+      <Styled.UnAuthorizedRoot>
+        <Button
+          css={css`
+            padding: 15px;
+          `}
+        >
+          꼭꼭 시작하기
+        </Button>
+      </Styled.UnAuthorizedRoot>
+    </PageTemplate>
+  );
+};
+
+type STATUS_TYPE = 'received' | 'sent';
+
+const AuthorizedLanding = () => {
   const { state } = useLocation() as { state: { status: STATUS_TYPE } };
 
   const { kkogkkogList } = useKkogKkogList();
 
   const { status, changeStatus } = useStatus<STATUS_TYPE>(state?.status ?? 'received');
-
-  if (!me) {
-    return (
-      <PageTemplate title='꼭꼭'>
-        <Styled.UnAuthorizedRoot>
-          <Button
-            css={css`
-              padding: 15px;
-            `}
-          >
-            꼭꼭 시작하기
-          </Button>
-        </Styled.UnAuthorizedRoot>
-      </PageTemplate>
-    );
-  }
 
   return (
     <PageTemplate title='꼭꼭'>
@@ -68,34 +100,6 @@ const LandingPage = () => {
     </PageTemplate>
   );
 };
-
-LandingPage.Skeleton = function Skeleton() {
-  return (
-    <PageTemplate title='꼭꼭'>
-      <Styled.Root>
-        <Styled.LinkContainer>
-          <Link to={PATH.KKOGKKOG_CREATE}>
-            <KkogKkogItem.LinkButton />
-          </Link>
-        </Styled.LinkContainer>
-        <Styled.ListContainer>
-          <Styled.ListHeaderContainer>
-            <Styled.ListHeaderItem>받은 쿠폰</Styled.ListHeaderItem>
-            <Styled.ListHeaderItem>보낸 쿠폰</Styled.ListHeaderItem>
-          </Styled.ListHeaderContainer>
-          <KkogKkogItem.Skeleton />
-          <KkogKkogItem.Skeleton />
-          <KkogKkogItem.Skeleton />
-          <KkogKkogItem.Skeleton />
-          <KkogKkogItem.Skeleton />
-          <KkogKkogItem.Skeleton />
-        </Styled.ListContainer>
-      </Styled.Root>
-    </PageTemplate>
-  );
-};
-
-export default LandingPage;
 
 export const Styled = {
   UnAuthorizedRoot: styled.div`

--- a/frontend/src/Router.tsx
+++ b/frontend/src/Router.tsx
@@ -1,5 +1,5 @@
 import { Suspense } from 'react';
-import { Route, Routes } from 'react-router-dom';
+import { Navigate, Outlet, Route, Routes } from 'react-router-dom';
 
 import Loading from '@/@components/@shared/Loading';
 import JoinPage from '@/@pages/join';
@@ -8,6 +8,7 @@ import KkogkkogCreatePage from '@/@pages/kkogkkog-list/create';
 import LandingPage from '@/@pages/landing';
 import ProfilePage from '@/@pages/profile';
 
+import useMe from './@hooks/user/useMe';
 import LoginPage from './@pages/login';
 
 export const PATH = {
@@ -30,27 +31,35 @@ const Router = () => {
           </Suspense>
         }
       />
-      <Route
-        path={PATH.KKOGKKOG_LIST}
-        element={
-          <Suspense fallback={<KkogkkogListPage.Skeleton />}>
-            <KkogkkogListPage />
-          </Suspense>
-        }
-      />
-      <Route
-        path={PATH.KKOGKKOG_CREATE}
-        element={
-          <Suspense fallback={<Loading>👻</Loading>}>
-            <KkogkkogCreatePage />
-          </Suspense>
-        }
-      />
       <Route path={PATH.LOGIN} element={<LoginPage />} />
       <Route path={PATH.JOIN} element={<JoinPage />} />
-      <Route path={PATH.PROFILE} element={<ProfilePage />} />
+      <Route element={<PrivateRoute />}>
+        <Route
+          path={PATH.KKOGKKOG_LIST}
+          element={
+            <Suspense fallback={<KkogkkogListPage.Skeleton />}>
+              <KkogkkogListPage />
+            </Suspense>
+          }
+        />
+        <Route
+          path={PATH.KKOGKKOG_CREATE}
+          element={
+            <Suspense fallback={<Loading>👻</Loading>}>
+              <KkogkkogCreatePage />
+            </Suspense>
+          }
+        />
+        <Route path={PATH.PROFILE} element={<ProfilePage />} />
+      </Route>
     </Routes>
   );
 };
 
 export default Router;
+
+const PrivateRoute = () => {
+  const { me } = useMe();
+
+  return me ? <Outlet /> : <Navigate to='/' replace />;
+};

--- a/frontend/src/apis/user.ts
+++ b/frontend/src/apis/user.ts
@@ -2,18 +2,7 @@ import { client } from '@/apis';
 import { JoinRequest, LoginRequest } from '@/types/remote/request';
 import { MeResponse, UserListResponse } from '@/types/remote/response';
 
-export const getMe = () =>
-  client.get<MeResponse>('/members/me', {
-    transformResponse: stringResponse => {
-      const parsedData = JSON.parse(stringResponse);
-
-      if (parsedData.error) {
-        return parsedData;
-      }
-
-      return parsedData.data;
-    },
-  });
+export const getMe = () => client.get<MeResponse>('/members/me');
 
 export const getUserList = () =>
   client.get<UserListResponse>('/members', {


### PR DESCRIPTION
## 작업 내용

- Login API 연동했습니다.
`client.defaults.header['Authorization']` 코드가 잘 동작하는데, 타입에러는 떠서 어떻게 해야할지 하하~

- PublicRoute 구현하여 씁니다.
아직, 인가 처리에 대한 고민을 공유하지 않았지만, 코드가 간단해서 일단 심어둡니다.

- LandingPage를 UnAuthorizedLanding과 AuthorizedLanding으로 분리했습니다.
그 이유는 하나의 컴포넌트 안에서 분기처리를 해버리면 hook을 early return할 수 없으므로, useKkogKkogList 같은 데이터 패칭 훅을 무조건 실행하게 됩니다. 하지만, UnAuthorizedLanding 는 데이터 패칭 훅이 필요없습니다. 그래서 컴포넌트를 분리했고 필요한 곳에서만 훅을 선언하도록 했습니다.

## 이슈
- 코드는 간단한데 생각보다 시간이 오래걸렸는데요. Suspense 를 걸어주고
- Landing 에서 getMe가 통신하는 동안 UnAuthorizedLanding 을 보여줘야할지 AuthorizedLanding를 보여줘야할지 판단할 수 없습니다. 현재 상황에서는 UnAuthorizedLanding이지만, AuthorizedLanding의 Skeleton을 보여주기도 하고, AuthorizedLanding이지만, UnAuthorizedLanding가 처음에 반짝 렌더링되는 현상이 있었습니다. 이를 해결하고자, getMe 통신에도 Suspense를 걸어서, Landing에 Loading처리를 해주려고 했습니다. 하지만, useMe를 suspense true로 만드니 갑자기 login 후 useMe 훅이 refetch 되지 않는 현상이 있었습니다.

그래서 결국 Suspense 처리는 포기하고, useMe의 isFetched를 활용해 패치가 끝난 후에만 Landing을 보여주는 것으로 처리해두었습니다.

Resolve #81