### PR TITLE
feat : 쿠폰 사용 요청 취소 API 구현

### DIFF
--- a/backend/src/main/java/com/woowacourse/kkogkkog/domain/CouponEvent.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/domain/CouponEvent.java
@@ -19,7 +19,7 @@ public enum CouponEvent {
     public static CouponEvent of(String value) {
         try {
             return CouponEvent.valueOf(value);
-        } catch (IllegalArgumentException e) {
+        } catch (IllegalArgumentException | NullPointerException e) {
             throw new InvalidRequestException("처리할 수 없는 요청입니다.");
         }
     }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/domain/CouponEvent.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/domain/CouponEvent.java
@@ -7,6 +7,7 @@ import java.util.function.BiConsumer;
 public enum CouponEvent {
 
     REQUEST(CouponEvent::canRequest),
+    CANCEL(CouponEvent::canCancel),
     ;
 
     private final BiConsumer<Boolean, Boolean> canChange;
@@ -29,7 +30,13 @@ public enum CouponEvent {
 
     private static void canRequest(boolean isSender, boolean isReceiver) {
         if (!isReceiver) {
-            throw new ForbiddenException("쿠폰을 받은 사람만 쿠폰을 사용할 수 있습니다.");
+            throw new ForbiddenException("쿠폰을 받은 사람만 사용할 수 있습니다.");
+        }
+    }
+
+    private static void canCancel(boolean isSender, boolean isReceiver) {
+        if (!isReceiver) {
+            throw new ForbiddenException("쿠폰을 받은 사람만 사용 요청을 취소할 수 있습니다.");
         }
     }
 }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/domain/CouponStatus.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/domain/CouponStatus.java
@@ -27,7 +27,7 @@ public enum CouponStatus {
 
     private CouponStatus handleCancel() {
         if (this != REQUESTED) {
-            throw new InvalidRequestException("사용 요청을 취소할 수 없는 상태의 쿠폰 입니다.");
+            throw new InvalidRequestException("사용 요청을 취소할 수 없는 상태의 쿠폰입니다.");
         }
         return READY;
     }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/domain/CouponStatus.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/domain/CouponStatus.java
@@ -12,6 +12,9 @@ public enum CouponStatus {
         if (event == CouponEvent.REQUEST) {
             return handleRequest();
         }
+        if (event == CouponEvent.CANCEL) {
+            return handleCancel();
+        }
         throw new InvalidRequestException("처리할 수 없는 요청입니다.");
     }
 
@@ -20,5 +23,12 @@ public enum CouponStatus {
             throw new InvalidRequestException("사용 요청을 보낼 수 없는 상태의 쿠폰입니다.");
         }
         return REQUESTED;
+    }
+
+    private CouponStatus handleCancel() {
+        if (this != REQUESTED) {
+            throw new InvalidRequestException("사용 요청을 취소할 수 없는 상태의 쿠폰 입니다.");
+        }
+        return READY;
     }
 }

--- a/backend/src/test/java/com/woowacourse/kkogkkog/acceptance/CouponAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/acceptance/CouponAcceptanceTest.java
@@ -222,7 +222,7 @@ public class CouponAcceptanceTest extends AcceptanceTest {
         }
 
         @Test
-        void 요청하지_않은_쿠폰은_취소할_수_없다() {
+        void 사용_요청_상태가_아닌_쿠폰은_요청을_취소할_수_없다() {
             회원_가입에_성공한다(toMemberCreateRequest(JEONG));
             회원_가입에_성공한다(toMemberCreateRequest(LEO));
             String jeongAccessToken = 로그인에_성공한다(toTokenRequest(JEONG)).getAccessToken();

--- a/backend/src/test/java/com/woowacourse/kkogkkog/acceptance/CouponAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/acceptance/CouponAcceptanceTest.java
@@ -207,6 +207,33 @@ public class CouponAcceptanceTest extends AcceptanceTest {
             assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
         }
 
+        @Test
+        void 쿠폰을_보낸_사람은_사용_요청을_취소_할_수_있다() {
+            회원_가입에_성공한다(toMemberCreateRequest(JEONG));
+            회원_가입에_성공한다(toMemberCreateRequest(LEO));
+            String jeongAccessToken = 로그인에_성공한다(toTokenRequest(JEONG)).getAccessToken();
+            String leoAccessToken = 로그인에_성공한다(toTokenRequest(LEO)).getAccessToken();
+            쿠폰_발급에_성공한다(jeongAccessToken, List.of(LEO));
+
+            쿠폰_상태_변경을_요청한다(leoAccessToken, 1L, CouponEvent.REQUEST.name());
+            ExtractableResponse<Response> response = 쿠폰_상태_변경을_요청한다(leoAccessToken, 1L, CouponEvent.CANCEL.name());
+
+            assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        }
+
+        @Test
+        void 요청하지_않은_쿠폰은_취소할_수_없다() {
+            회원_가입에_성공한다(toMemberCreateRequest(JEONG));
+            회원_가입에_성공한다(toMemberCreateRequest(LEO));
+            String jeongAccessToken = 로그인에_성공한다(toTokenRequest(JEONG)).getAccessToken();
+            String leoAccessToken = 로그인에_성공한다(toTokenRequest(LEO)).getAccessToken();
+            쿠폰_발급에_성공한다(jeongAccessToken, List.of(LEO));
+
+            ExtractableResponse<Response> response = 쿠폰_상태_변경을_요청한다(leoAccessToken, 1L, CouponEvent.CANCEL.name());
+
+            assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+        }
+
         private ExtractableResponse<Response> 쿠폰_상태_변경을_요청한다(String accessToken,
                                                              Long couponId,
                                                              String couponEvent) {

--- a/backend/src/test/java/com/woowacourse/kkogkkog/application/CouponServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/application/CouponServiceTest.java
@@ -195,6 +195,39 @@ public class CouponServiceTest extends ServiceTest {
             assertThatThrownBy(() -> couponService.changeStatus(couponChangeStatusRequest))
                     .isInstanceOf(ForbiddenException.class);
         }
+
+        @Test
+        @DisplayName("받은 사람은 REQUESTED 상태의 쿠폰에 대한 취소 요청을 할 수 있다.")
+        void cancel() {
+            CouponSaveRequest couponSaveRequest = toCouponSaveRequest(ROOKIE, List.of(ARTHUR));
+            Long couponId = couponService.save(couponSaveRequest).get(0).getId();
+            CouponChangeStatusRequest couponRequest = new CouponChangeStatusRequest(ARTHUR.getId(),
+                    couponId, CouponEvent.REQUEST);
+            couponService.changeStatus(couponRequest);
+
+            CouponChangeStatusRequest couponCancel = new CouponChangeStatusRequest(ARTHUR.getId(),
+                    couponId, CouponEvent.CANCEL);
+            couponService.changeStatus(couponCancel);
+
+            CouponResponse actual = couponService.findById(couponId);
+            assertThat(actual.getCouponStatus()).isEqualTo(CouponStatus.READY.name());
+        }
+
+        @Test
+        @DisplayName("보낸 사람은 쿠폰 사용 취소를 할 수 없다.")
+        void cancel_senderNotAllowed() {
+            CouponSaveRequest couponSaveRequest = toCouponSaveRequest(ROOKIE, List.of(ARTHUR));
+            Long couponId = couponService.save(couponSaveRequest).get(0).getId();
+            CouponChangeStatusRequest couponRequest = new CouponChangeStatusRequest(ARTHUR.getId(),
+                    couponId, CouponEvent.REQUEST);
+            couponService.changeStatus(couponRequest);
+
+            CouponChangeStatusRequest couponCancel = new CouponChangeStatusRequest(ROOKIE.getId(),
+                    couponId, CouponEvent.CANCEL);
+
+            assertThatThrownBy(() -> couponService.changeStatus(couponCancel))
+                    .isInstanceOf(ForbiddenException.class);
+        }
     }
 
     private CouponSaveRequest toCouponSaveRequest(Member sender, List<Member> receivers) {

--- a/backend/src/test/java/com/woowacourse/kkogkkog/domain/CouponEventTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/domain/CouponEventTest.java
@@ -28,4 +28,24 @@ class CouponEventTest {
         assertThatThrownBy(() -> CouponEvent.REQUEST.checkExecutable(isSender, isReceiver))
                 .isInstanceOf(ForbiddenException.class);
     }
+
+    @Test
+    @DisplayName("쿠폰을 받은 사람이 쿠폰 사용 요청을 취소할 수 있다.")
+    void receiverCanCancel() {
+        boolean isSender = false;
+        boolean isReceiver = true;
+
+        assertThatNoException()
+                .isThrownBy(() -> CouponEvent.CANCEL.checkExecutable(isSender, isReceiver));
+    }
+
+    @Test
+    @DisplayName("쿠폰을 보낸 사람이 쿠폰 사용 요청 취소를 보내는 경우 예외가 발생한다.")
+    void senderCanNotCancel() {
+        boolean isSender = true;
+        boolean isReceiver = false;
+
+        assertThatThrownBy(() -> CouponEvent.CANCEL.checkExecutable(isSender, isReceiver))
+                .isInstanceOf(ForbiddenException.class);
+    }
 }

--- a/backend/src/test/java/com/woowacourse/kkogkkog/domain/CouponStatusTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/domain/CouponStatusTest.java
@@ -30,4 +30,26 @@ class CouponStatusTest {
         assertThatThrownBy(() -> currentStatus.handle(event))
                 .isInstanceOf(InvalidRequestException.class);
     }
+
+    @Test
+    @DisplayName("REQUESTED 상태의 쿠폰은 CANCEL 이벤트를 받으면 READY 상태로 변경된다.")
+    void requestedChangesToReadyOnCancelEvent() {
+        CouponStatus currentStatus = CouponStatus.REQUESTED;
+        CouponEvent event = CouponEvent.CANCEL;
+
+        CouponStatus actual = currentStatus.handle(event);
+        CouponStatus expected = CouponStatus.READY;
+
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("READY 상태의 쿠폰은 CANCEL 이벤트를 받으면 예외가 발생된다.")
+    void readyCanNotHandleCancelEvent() {
+        CouponStatus currentStatus = CouponStatus.READY;
+        CouponEvent event = CouponEvent.CANCEL;
+
+        assertThatThrownBy(() -> currentStatus.handle(event))
+                .isInstanceOf(InvalidRequestException.class);
+    }
 }

--- a/backend/src/test/java/com/woowacourse/kkogkkog/domain/CouponTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/domain/CouponTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.woowacourse.kkogkkog.exception.ForbiddenException;
+import com.woowacourse.kkogkkog.exception.InvalidRequestException;
 import com.woowacourse.kkogkkog.exception.coupon.SameSenderReceiverException;
 import com.woowacourse.kkogkkog.fixture.MemberFixture;
 import org.junit.jupiter.api.Test;
@@ -51,6 +52,40 @@ public class CouponTest {
                 CouponStatus.READY);
 
         assertThatThrownBy(() -> coupon.changeStatus(CouponEvent.REQUEST, sender))
+                .isInstanceOf(ForbiddenException.class);
+    }
+
+    @Test
+    void 받은_사람은_REQUESTED_상태의_쿠폰에_대한_사용_요청_취소를_보낼_수_있다() {
+        Member sender = MemberFixture.ROOKIE;
+        Member receiver = MemberFixture.ARTHUR;
+        Coupon coupon = new Coupon(null, sender, receiver, "한턱쏘는", "추가 메세지", "#241223", CouponType.COFFEE,
+                CouponStatus.REQUESTED);
+
+        coupon.changeStatus(CouponEvent.CANCEL, receiver);
+
+        assertThat(coupon.getCouponStatus()).isEqualTo(CouponStatus.READY);
+    }
+
+    @Test
+    void 받은_사람은_READY_상태의_쿠폰에_대한_사용_요청_취소를_보낼_수_없다() {
+        Member sender = MemberFixture.ROOKIE;
+        Member receiver = MemberFixture.ARTHUR;
+        Coupon coupon = new Coupon(null, sender, receiver, "한턱쏘는", "추가 메세지", "#241223", CouponType.COFFEE,
+                CouponStatus.READY);
+
+        assertThatThrownBy(() -> coupon.changeStatus(CouponEvent.CANCEL, receiver))
+                .isInstanceOf(InvalidRequestException.class);
+    }
+
+    @Test
+    void 보낸_사람은_쿠폰_사용_요청_취소를_보낼_수_없다() {
+        Member sender = MemberFixture.ROOKIE;
+        Member receiver = MemberFixture.ARTHUR;
+        Coupon coupon = new Coupon(null, sender, receiver, "한턱쏘는", "추가 메세지", "#241223", CouponType.COFFEE,
+                CouponStatus.REQUESTED);
+
+        assertThatThrownBy(() -> coupon.changeStatus(CouponEvent.CANCEL, sender))
                 .isInstanceOf(ForbiddenException.class);
     }
 }


### PR DESCRIPTION
## 작업 내용

- 받은 사람(Receiver)이 쿠폰 사용 요청을 취소하는 기능 구현


## 공유사항
기존 CouponEvent 에서 of 를 사용할 때 null 이 넘어오면 NPE 가 발생하는 문제도 같이 수정했습니다.

Resolves #83
