### PR TITLE
fix: 쿠폰 목록 조회 버그 수정

### DIFF
--- a/backend/src/main/java/com/woowacourse/kkogkkog/domain/CouponType.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/domain/CouponType.java
@@ -3,5 +3,6 @@ package com.woowacourse.kkogkkog.domain;
 public enum CouponType {
 
     COFFEE,
-    MEAL
+    MEAL,
+    DRINK
 }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/presentation/CouponController.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/presentation/CouponController.java
@@ -30,16 +30,17 @@ public class CouponController {
     @GetMapping
     public ResponseEntity<MyCouponsResponse> showAll(@LoginMember Long loginMemberId) {
         MyCouponsResponse myCouponsResponse = new MyCouponsResponse(new CouponsResponse(
-                couponService.findAllBySender(loginMemberId),
-                couponService.findAllByReceiver(loginMemberId)));
+                couponService.findAllByReceiver(loginMemberId),
+                couponService.findAllBySender(loginMemberId)));
 
         return ResponseEntity.ok(myCouponsResponse);
     }
 
     @PostMapping
-        public ResponseEntity<CouponCreateResponse> create(@LoginMember Long loginMemberId,
-                                                           @Valid @RequestBody CouponCreateRequest couponCreateRequest) {
-        List<CouponResponse> couponResponses = couponService.save(couponCreateRequest.toCouponSaveRequest(loginMemberId));
+    public ResponseEntity<CouponCreateResponse> create(@LoginMember Long loginMemberId,
+                                                       @Valid @RequestBody CouponCreateRequest couponCreateRequest) {
+        List<CouponResponse> couponResponses = couponService.save(
+                couponCreateRequest.toCouponSaveRequest(loginMemberId));
         return ResponseEntity.created(null).body(new CouponCreateResponse(couponResponses));
     }
 

--- a/backend/src/test/java/com/woowacourse/kkogkkog/acceptance/CouponAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/acceptance/CouponAcceptanceTest.java
@@ -56,7 +56,7 @@ public class CouponAcceptanceTest extends AcceptanceTest {
             List<CouponResponse> receivedCoupons = 쿠폰_발급에_성공한다(leoAccessToken, List.of(JEONG)).getData();
 
             MyCouponsResponse actual = 쿠폰_전체_조회에_성공한다(jeongAccessToken);
-            MyCouponsResponse expected = new MyCouponsResponse(new CouponsResponse(sentCoupons, receivedCoupons));
+            MyCouponsResponse expected = new MyCouponsResponse(new CouponsResponse(receivedCoupons, sentCoupons));
 
             assertThat(actual).usingRecursiveComparison()
                     .isEqualTo(expected);

--- a/backend/src/test/java/com/woowacourse/kkogkkog/documentation/CouponControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/documentation/CouponControllerTest.java
@@ -153,8 +153,8 @@ class CouponControllerTest extends Documentation {
 
         // then
         MyCouponsResponse myCouponsResponse = new MyCouponsResponse(new CouponsResponse(
-                List.of(toCouponResponse(1L, JEONG, LEO), toCouponResponse(2L, JEONG, ARTHUR)),
-                List.of(toCouponResponse(3L, LEO, JEONG), toCouponResponse(4L, ARTHUR, JEONG))));
+                List.of(toCouponResponse(3L, LEO, JEONG), toCouponResponse(4L, ARTHUR, JEONG)),
+                List.of(toCouponResponse(1L, JEONG, LEO), toCouponResponse(2L, JEONG, ARTHUR))));
 
         perform.andExpect(status().isOk())
                 .andExpect(content().string(objectMapper.writeValueAsString(myCouponsResponse)));


### PR DESCRIPTION
## 작업 내용

- 사용자의 쿠폰 목록 조회시 받은 쿠폰과 보낸 쿠폰 반대로 조회되는 문제 해결
- 프론트에는 존재하지만 백엔드에는 누락된 쿠폰 타입 DRINK 추가

Resolves #87