### PR TITLE
refactor: 서비스 및 도메인 테스트에 DCI 패턴 적용

### DIFF
--- a/backend/src/test/java/com/woowacourse/kkogkkog/application/AuthServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/application/AuthServiceTest.java
@@ -16,7 +16,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
 @Transactional
-@Nested
 @DisplayName("AuthService 의")
 class AuthServiceTest extends ServiceTest {
 

--- a/backend/src/test/java/com/woowacourse/kkogkkog/application/AuthServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/application/AuthServiceTest.java
@@ -1,18 +1,23 @@
 package com.woowacourse.kkogkkog.application;
 
 import static com.woowacourse.kkogkkog.fixture.MemberFixture.ROOKIE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.woowacourse.kkogkkog.application.dto.TokenResponse;
 import com.woowacourse.kkogkkog.domain.Member;
 import com.woowacourse.kkogkkog.domain.repository.MemberRepository;
+import com.woowacourse.kkogkkog.exception.member.MemberNotFoundException;
 import com.woowacourse.kkogkkog.presentation.dto.TokenRequest;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
 @Transactional
+@Nested
+@DisplayName("AuthService 의")
 class AuthServiceTest extends ServiceTest {
 
     @Autowired
@@ -21,15 +26,30 @@ class AuthServiceTest extends ServiceTest {
     @Autowired
     private AuthService authService;
 
-    @Test
-    @DisplayName("로그인에 성공하면 토큰을 반환한다")
-    void login() {
-        Member rookie = ROOKIE;
-        memberRepository.save(rookie);
+    @Nested
+    @DisplayName("login 매서드는")
+    class Login {
 
-        TokenRequest tokenRequest = new TokenRequest(rookie.getEmail(), rookie.getPassword());
-        TokenResponse tokenResponse = authService.login(tokenRequest);
+        @Test
+        @DisplayName("등록된 회원 이메일과 비밀번호를 입력하면, 토큰을 반환한다.")
+        void success() {
+            Member rookie = ROOKIE;
+            memberRepository.save(rookie);
 
-        Assertions.assertThat(tokenResponse).isNotNull();
+            TokenRequest tokenRequest = new TokenRequest(rookie.getEmail(), rookie.getPassword());
+            TokenResponse tokenResponse = authService.login(tokenRequest);
+
+            assertThat(tokenResponse).isNotNull();
+        }
+
+        @Test
+        @DisplayName("등록되지 않은 회원 이메일과 비밀번호를 입력하면, 예외를 던진다.")
+        void fail_notEnrolled() {
+            Member rookie = ROOKIE;
+            TokenRequest tokenRequest = new TokenRequest(rookie.getEmail(), rookie.getPassword());
+            assertThatThrownBy(
+                    () -> authService.login(tokenRequest)
+            ).isInstanceOf(MemberNotFoundException.class);
+        }
     }
 }

--- a/backend/src/test/java/com/woowacourse/kkogkkog/application/AuthServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/application/AuthServiceTest.java
@@ -16,7 +16,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
 @Transactional
-@DisplayName("AuthService 의")
+@DisplayName("AuthService 클래스의")
 class AuthServiceTest extends ServiceTest {
 
     @Autowired

--- a/backend/src/test/java/com/woowacourse/kkogkkog/application/CouponServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/application/CouponServiceTest.java
@@ -3,9 +3,9 @@ package com.woowacourse.kkogkkog.application;
 import static com.woowacourse.kkogkkog.fixture.MemberFixture.NON_EXISTING_MEMBER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.woowacourse.kkogkkog.application.dto.CouponChangeStatusRequest;
-import com.woowacourse.kkogkkog.application.dto.CouponMemberResponse;
 import com.woowacourse.kkogkkog.application.dto.CouponResponse;
 import com.woowacourse.kkogkkog.application.dto.CouponSaveRequest;
 import com.woowacourse.kkogkkog.domain.CouponEvent;
@@ -25,6 +25,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
 @Transactional
+@Nested
+@DisplayName("CouponService 의")
 public class CouponServiceTest extends ServiceTest {
 
     private static final Member JEONG = new Member(null, "jeong@gmail.com", "password1234!", "정");
@@ -48,13 +50,13 @@ public class CouponServiceTest extends ServiceTest {
         memberRepository.save(ARTHUR);
     }
 
-    @DisplayName("단일 쿠폰을 조회할 수 있다.")
     @Nested
-    class FindByIdTest {
+    @DisplayName("findById 메서드는")
+    class FindById {
 
-        @DisplayName("존재하는 쿠폰을 조회하는 경우 성공한다.")
         @Test
-        void findById() {
+        @DisplayName("쿠폰이 존재하면, 쿠폰 응답을 반환한다.")
+        void success() {
             List<CouponResponse> savedCoupons = couponService.save(toCouponSaveRequest(JEONG, List.of(LEO, ROOKIE)));
 
             CouponResponse expected = savedCoupons.get(0);
@@ -64,82 +66,67 @@ public class CouponServiceTest extends ServiceTest {
         }
 
         @Test
-        @DisplayName("존재하지 않는 쿠폰을 조회할 경우 예외가 발생한다.")
-        void findById_notFound() {
+        @DisplayName("쿠폰이 존재하지 않으면, 예외를 던진다.")
+        void fail_notFound() {
             assertThatThrownBy(() -> couponService.findById(1L))
                     .isInstanceOf(CouponNotFoundException.class);
         }
     }
 
-    @DisplayName("사용자가 보낸 쿠폰들이 조회된다.")
     @Nested
-    class FindBySenderTest {
+    @DisplayName("findAllBySender 메서드는")
+    class FindAllBySender {
 
-        @DisplayName("조회되는 쿠폰 개수 확인")
         @Test
-        void couponCount() {
+        @DisplayName("보낸 사람의 아이디를 받으면, 해당 아이디로 보낸 쿠폰의 리스트를 반환한다.")
+        void success() {
             couponService.save(toCouponSaveRequest(ROOKIE, List.of(ARTHUR, JEONG, LEO)));
             couponService.save(toCouponSaveRequest(JEONG, List.of(ARTHUR, LEO)));
-            List<CouponResponse> actual = couponService.findAllBySender(ROOKIE.getId());
 
-            assertThat(actual.size()).isEqualTo(3);
-        }
-
-        @DisplayName("조회되는 쿠폰의 보낸 사람 정보 확인")
-        @Test
-        void senderId() {
-            couponService.save(toCouponSaveRequest(ROOKIE, List.of(ARTHUR, JEONG, LEO)));
-            couponService.save(toCouponSaveRequest(JEONG, List.of(ARTHUR, LEO)));
             Long senderId = ROOKIE.getId();
 
-            List<Long> actual = couponService.findAllBySender(ROOKIE.getId())
-                    .stream().map(CouponResponse::getSender)
-                    .map(CouponMemberResponse::getId)
+            List<CouponResponse> actual = couponService.findAllBySender(senderId);
+            List<Long> actualSender = actual.stream()
+                    .map(it -> it.getSender().getId())
                     .collect(Collectors.toList());
-            List<Long> expected = List.of(senderId, senderId, senderId);
 
-            assertThat(actual).isEqualTo(expected);
+            assertAll(
+                    () -> assertThat(actual.size()).isEqualTo(3),
+                    () -> assertThat(actualSender).containsOnly(senderId)
+            );
         }
     }
 
-    @DisplayName("사용자가 받은 쿠폰들이 조회된다.")
     @Nested
-    class FindByReceiverTest {
+    @DisplayName("findAllByReceiver 메서드는")
+    class FindAllByReceiver {
 
-        @DisplayName("조회되는 쿠폰 개수 확인")
         @Test
-        void couponCount() {
+        @DisplayName("받은 사람의 아이디를 받으면, 해당 아이디로 받은 쿠폰의 리스트를 반환한다.")
+        void success() {
             couponService.save(toCouponSaveRequest(ARTHUR, List.of(JEONG, LEO)));
             couponService.save(toCouponSaveRequest(LEO, List.of(JEONG, ARTHUR)));
-            List<CouponResponse> actual = couponService.findAllByReceiver(JEONG.getId());
 
-            assertThat(actual.size()).isEqualTo(2);
-        }
-
-        @DisplayName("조회되는 쿠폰의 받은 사람 정보 확인")
-        @Test
-        void receiverId() {
-            couponService.save(toCouponSaveRequest(ARTHUR, List.of(JEONG, LEO)));
-            couponService.save(toCouponSaveRequest(LEO, List.of(JEONG, ARTHUR)));
             Long receiverId = JEONG.getId();
-
-            List<Long> actual = couponService.findAllByReceiver(receiverId)
-                    .stream().map(CouponResponse::getReceiver)
-                    .map(CouponMemberResponse::getId)
+            List<CouponResponse> actual = couponService.findAllByReceiver(receiverId);
+            List<Long> actualReceiver = actual.stream()
+                    .map((it -> it.getReceiver().getId()))
                     .collect(Collectors.toList());
-            List<Long> expected = List.of(receiverId, receiverId);
 
-            assertThat(actual).isEqualTo(expected);
+            assertAll(
+                    () -> assertThat(actual.size()).isEqualTo(2),
+                    () -> assertThat(actualReceiver).containsOnly(receiverId)
+            );
         }
     }
 
-    @DisplayName("복수의 쿠폰을 저장할 수 있다")
     @Nested
-    class SaveTest {
+    @DisplayName("save 메서드는")
+    class Save {
 
         @Test
-        @DisplayName("받는 사람으로 지정한 사용자들에게 동일한 내용의 쿠폰이 발급된다.")
-        void save() {
+        @DisplayName("쿠폰 정보 및 보낸 사람과 받는 사람들을 받으면, 생성된 쿠폰들을 반환한다.")
+        void success() {
             CouponSaveRequest couponSaveRequest = toCouponSaveRequest(ROOKIE, List.of(ARTHUR, JEONG, LEO));
             List<CouponResponse> createdCoupons = couponService.save(couponSaveRequest);
 
@@ -147,8 +134,8 @@ public class CouponServiceTest extends ServiceTest {
         }
 
         @Test
-        @DisplayName("존재하지 않는 사용자가 쿠폰을 보내려는 경우 예외가 발생한다.")
-        void save_senderNotFound() {
+        @DisplayName("보낸 사람이 존재하지 않는다면, 예외를 던진다.")
+        void fail_senderNotFound() {
             CouponSaveRequest couponSaveRequest = toCouponSaveRequest(NON_EXISTING_MEMBER, List.of(ARTHUR, LEO));
 
             assertThatThrownBy(() -> couponService.save(couponSaveRequest))
@@ -156,8 +143,8 @@ public class CouponServiceTest extends ServiceTest {
         }
 
         @Test
-        @DisplayName("존재하지 않는 사용자에게 쿠폰을 보내려는 경우 예외가 발생한다.")
-        void save_receiverNotFound() {
+        @DisplayName("받는 사람이 존재하지 않는다면, 예외를 던진다.")
+        void fail_receiverNotFound() {
             CouponSaveRequest couponSaveRequest = toCouponSaveRequest(JEONG, List.of(ARTHUR, NON_EXISTING_MEMBER));
 
             assertThatThrownBy(() -> couponService.save(couponSaveRequest))
@@ -165,68 +152,78 @@ public class CouponServiceTest extends ServiceTest {
         }
     }
 
-    @DisplayName("쿠폰 이벤트에 따라 쿠폰의 상태를 수정할 수 있다")
     @Nested
-    class ChangeStatusTest {
+    @DisplayName("changeStatus 메서드는")
+    class ChangeStatus {
 
-        @Test
-        @DisplayName("받은 사람은 READY 상태의 쿠폰에 대한 사용 요청을 보낼 수 있다")
-        void request() {
-            CouponSaveRequest couponSaveRequest = toCouponSaveRequest(ROOKIE, List.of(ARTHUR));
-            Long couponId = couponService.save(couponSaveRequest).get(0).getId();
-            CouponChangeStatusRequest couponChangeStatusRequest = new CouponChangeStatusRequest(ARTHUR.getId(),
-                    couponId, CouponEvent.REQUEST);
+        @Nested
+        @DisplayName("READY 상태의 쿠폰에")
+        class ready {
 
-            couponService.changeStatus(couponChangeStatusRequest);
-            CouponResponse actual = couponService.findById(couponId);
+            @Test
+            @DisplayName("받은 사람이 REQUEST 를 보내면, 쿠폰의 상태를 REQUESTED 로 변경한다.")
+            void success_request() {
+                CouponSaveRequest couponSaveRequest = toCouponSaveRequest(ROOKIE, List.of(ARTHUR));
+                Long couponId = couponService.save(couponSaveRequest).get(0).getId();
+                CouponChangeStatusRequest couponChangeStatusRequest = new CouponChangeStatusRequest(ARTHUR.getId(),
+                        couponId, CouponEvent.REQUEST);
 
-            assertThat(actual.getCouponStatus()).isEqualTo(CouponStatus.REQUESTED.name());
+                couponService.changeStatus(couponChangeStatusRequest);
+                CouponResponse actual = couponService.findById(couponId);
+
+                assertThat(actual.getCouponStatus()).isEqualTo(CouponStatus.REQUESTED.name());
+            }
+
+            @Test
+            @DisplayName("보낸 사람이 REQUEST 를 보내면, 예외를 던진다.")
+            void fail_request_senderNotAllowed() {
+                CouponSaveRequest couponSaveRequest = toCouponSaveRequest(ROOKIE, List.of(ARTHUR));
+                Long couponId = couponService.save(couponSaveRequest).get(0).getId();
+
+                CouponChangeStatusRequest couponChangeStatusRequest = new CouponChangeStatusRequest(ROOKIE.getId(),
+                        couponId, CouponEvent.REQUEST);
+
+                assertThatThrownBy(() -> couponService.changeStatus(couponChangeStatusRequest))
+                        .isInstanceOf(ForbiddenException.class);
+            }
         }
 
-        @Test
-        @DisplayName("보낸 사람은 쿠폰 사용 요청을 보낼 수 없다.")
-        void request_senderNotAllowed() {
-            CouponSaveRequest couponSaveRequest = toCouponSaveRequest(ROOKIE, List.of(ARTHUR));
-            Long couponId = couponService.save(couponSaveRequest).get(0).getId();
+        @Nested
+        @DisplayName("REQUESTED 상태의 쿠폰에")
+        class Requested {
 
-            CouponChangeStatusRequest couponChangeStatusRequest = new CouponChangeStatusRequest(ROOKIE.getId(),
-                    couponId, CouponEvent.REQUEST);
+            @Test
+            @DisplayName("받은 사람이 CANCEL 을 보내면, 쿠폰의 상태를 READY 로 변경한다.")
+            void success_cancel() {
+                CouponSaveRequest couponSaveRequest = toCouponSaveRequest(ROOKIE, List.of(ARTHUR));
+                Long couponId = couponService.save(couponSaveRequest).get(0).getId();
+                CouponChangeStatusRequest couponRequest = new CouponChangeStatusRequest(ARTHUR.getId(),
+                        couponId, CouponEvent.REQUEST);
+                couponService.changeStatus(couponRequest);
 
-            assertThatThrownBy(() -> couponService.changeStatus(couponChangeStatusRequest))
-                    .isInstanceOf(ForbiddenException.class);
-        }
+                CouponChangeStatusRequest couponCancel = new CouponChangeStatusRequest(ARTHUR.getId(),
+                        couponId, CouponEvent.CANCEL);
+                couponService.changeStatus(couponCancel);
 
-        @Test
-        @DisplayName("받은 사람은 REQUESTED 상태의 쿠폰에 대한 취소 요청을 할 수 있다.")
-        void cancel() {
-            CouponSaveRequest couponSaveRequest = toCouponSaveRequest(ROOKIE, List.of(ARTHUR));
-            Long couponId = couponService.save(couponSaveRequest).get(0).getId();
-            CouponChangeStatusRequest couponRequest = new CouponChangeStatusRequest(ARTHUR.getId(),
-                    couponId, CouponEvent.REQUEST);
-            couponService.changeStatus(couponRequest);
+                CouponResponse actual = couponService.findById(couponId);
+                assertThat(actual.getCouponStatus()).isEqualTo(CouponStatus.READY.name());
+            }
 
-            CouponChangeStatusRequest couponCancel = new CouponChangeStatusRequest(ARTHUR.getId(),
-                    couponId, CouponEvent.CANCEL);
-            couponService.changeStatus(couponCancel);
+            @Test
+            @DisplayName("보낸 사람이 CANCEL 을 보내면, 예외를 던진다.")
+            void fail_cancel_senderNotAllowed() {
+                CouponSaveRequest couponSaveRequest = toCouponSaveRequest(ROOKIE, List.of(ARTHUR));
+                Long couponId = couponService.save(couponSaveRequest).get(0).getId();
+                CouponChangeStatusRequest couponRequest = new CouponChangeStatusRequest(ARTHUR.getId(),
+                        couponId, CouponEvent.REQUEST);
+                couponService.changeStatus(couponRequest);
 
-            CouponResponse actual = couponService.findById(couponId);
-            assertThat(actual.getCouponStatus()).isEqualTo(CouponStatus.READY.name());
-        }
+                CouponChangeStatusRequest couponCancel = new CouponChangeStatusRequest(ROOKIE.getId(),
+                        couponId, CouponEvent.CANCEL);
 
-        @Test
-        @DisplayName("보낸 사람은 쿠폰 사용 취소를 할 수 없다.")
-        void cancel_senderNotAllowed() {
-            CouponSaveRequest couponSaveRequest = toCouponSaveRequest(ROOKIE, List.of(ARTHUR));
-            Long couponId = couponService.save(couponSaveRequest).get(0).getId();
-            CouponChangeStatusRequest couponRequest = new CouponChangeStatusRequest(ARTHUR.getId(),
-                    couponId, CouponEvent.REQUEST);
-            couponService.changeStatus(couponRequest);
-
-            CouponChangeStatusRequest couponCancel = new CouponChangeStatusRequest(ROOKIE.getId(),
-                    couponId, CouponEvent.CANCEL);
-
-            assertThatThrownBy(() -> couponService.changeStatus(couponCancel))
-                    .isInstanceOf(ForbiddenException.class);
+                assertThatThrownBy(() -> couponService.changeStatus(couponCancel))
+                        .isInstanceOf(ForbiddenException.class);
+            }
         }
     }
 

--- a/backend/src/test/java/com/woowacourse/kkogkkog/application/CouponServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/application/CouponServiceTest.java
@@ -25,7 +25,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
 @Transactional
-@Nested
 @DisplayName("CouponService 의")
 public class CouponServiceTest extends ServiceTest {
 

--- a/backend/src/test/java/com/woowacourse/kkogkkog/application/CouponServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/application/CouponServiceTest.java
@@ -25,7 +25,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
 @Transactional
-@DisplayName("CouponService 의")
+@DisplayName("CouponService 클래스의")
 public class CouponServiceTest extends ServiceTest {
 
     private static final Member JEONG = new Member(null, "jeong@gmail.com", "password1234!", "정");

--- a/backend/src/test/java/com/woowacourse/kkogkkog/application/JwtTokenProviderTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/application/JwtTokenProviderTest.java
@@ -5,41 +5,49 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.woowacourse.kkogkkog.exception.auth.UnauthenticatedTokenException;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
+@Nested
+@DisplayName("JwtTokenProvider 의")
 class JwtTokenProviderTest {
 
     @Autowired
     private JwtTokenProvider jwtTokenProvider;
 
-    @Test
-    @DisplayName("토큰을 생성하고, 토큰의 페이로드를 변환할 수 있다")
-    void getValidatedPayload() {
-        String token = jwtTokenProvider.createToken(Long.toString(1L));
+    @Nested
+    @DisplayName("getValidatedPayload 메서드는")
+    class GetValidatedPayload {
 
-        String payload = jwtTokenProvider.getValidatedPayload(token);
+        @Test
+        @DisplayName("유효한 토큰을 받으면, payload를 반환한다.")
+        void success() {
+            String token = jwtTokenProvider.createToken(Long.toString(1L));
 
-        assertThat(payload).isEqualTo(Long.toString(1L));
-    }
+            String payload = jwtTokenProvider.getValidatedPayload(token);
 
-    @Test
-    @DisplayName("가짜 토큰을 받으면 예외를 던진다.")
-    void validateFakeToken() {
-        String fakeToken = "FakeToken";
+            assertThat(payload).isEqualTo(Long.toString(1L));
+        }
 
-        assertThatThrownBy(() -> jwtTokenProvider.getValidatedPayload(fakeToken))
-                .isInstanceOf(UnauthenticatedTokenException.class);
-    }
+        @Test
+        @DisplayName("가짜 토큰을 받으면, 예외를 던진다.")
+        void fail_fakeToken() {
+            String fakeToken = "FakeToken";
 
-    @Test
-    @DisplayName("만료기간이 지난 토큰을 받으면 예외를 던진다.")
-    void validateExpirationDate() {
-        String expiredToken = "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNjU3Nzg3Mzk3LCJleHAiOjE2NTc3ODc0MzN9.B1dAhi-5oyQSeZjAPYYNPA_eeYxF00HO6YPqq58bk1_Yr7tsV44LhY_n4RVpLW8StdbbLuui7uwgSBLu_uM2cQ";
+            assertThatThrownBy(() -> jwtTokenProvider.getValidatedPayload(fakeToken))
+                    .isInstanceOf(UnauthenticatedTokenException.class);
+        }
 
-        assertThatThrownBy(() -> jwtTokenProvider.getValidatedPayload(expiredToken))
-                .isInstanceOf(UnauthenticatedTokenException.class);
+        @Test
+        @DisplayName("만료기간이 지난 토큰을 받으면, 예외를 던진다.")
+        void fail_expiredToken() {
+            String expiredToken = "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNjU3Nzg3Mzk3LCJleHAiOjE2NTc3ODc0MzN9.B1dAhi-5oyQSeZjAPYYNPA_eeYxF00HO6YPqq58bk1_Yr7tsV44LhY_n4RVpLW8StdbbLuui7uwgSBLu_uM2cQ";
+
+            assertThatThrownBy(() -> jwtTokenProvider.getValidatedPayload(expiredToken))
+                    .isInstanceOf(UnauthenticatedTokenException.class);
+        }
     }
 }

--- a/backend/src/test/java/com/woowacourse/kkogkkog/application/JwtTokenProviderTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/application/JwtTokenProviderTest.java
@@ -11,7 +11,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
-@Nested
 @DisplayName("JwtTokenProvider 의")
 class JwtTokenProviderTest {
 

--- a/backend/src/test/java/com/woowacourse/kkogkkog/application/JwtTokenProviderTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/application/JwtTokenProviderTest.java
@@ -11,7 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
-@DisplayName("JwtTokenProvider 의")
+@DisplayName("JwtTokenProvider 클래스의")
 class JwtTokenProviderTest {
 
     @Autowired

--- a/backend/src/test/java/com/woowacourse/kkogkkog/application/MemberServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/application/MemberServiceTest.java
@@ -18,7 +18,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
 @Transactional
-@Nested
 @DisplayName("MemberService 의")
 class MemberServiceTest extends ServiceTest {
 

--- a/backend/src/test/java/com/woowacourse/kkogkkog/application/MemberServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/application/MemberServiceTest.java
@@ -18,7 +18,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
 @Transactional
-@DisplayName("MemberService 의")
+@DisplayName("MemberService 클래스의")
 class MemberServiceTest extends ServiceTest {
 
     @Autowired

--- a/backend/src/test/java/com/woowacourse/kkogkkog/application/MemberServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/application/MemberServiceTest.java
@@ -27,7 +27,7 @@ class MemberServiceTest extends ServiceTest {
 
     @Nested
     @DisplayName("save 메서드는")
-    class save {
+    class Save {
 
         @Test
         @DisplayName("회원 정보를 받으면, 회원을 저장하고 저장된 Id를 반환한다.")
@@ -54,7 +54,7 @@ class MemberServiceTest extends ServiceTest {
 
     @Nested
     @DisplayName("findById 메서드는")
-    class findById {
+    class FindById {
 
         @Test
         @DisplayName("저장된 회원의 Id를 받으면, 해당 회원의 정보를 반환한다.")
@@ -83,7 +83,7 @@ class MemberServiceTest extends ServiceTest {
 
     @Nested
     @DisplayName("findAll 메서드는")
-    class findAll {
+    class FindAll {
 
         @Test
         @DisplayName("회원가입된 모든 회원들의 정보를 반환한다.")

--- a/backend/src/test/java/com/woowacourse/kkogkkog/application/MemberServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/application/MemberServiceTest.java
@@ -5,64 +5,99 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.woowacourse.kkogkkog.application.dto.MemberResponse;
 import com.woowacourse.kkogkkog.application.dto.MembersResponse;
+import com.woowacourse.kkogkkog.domain.Member;
 import com.woowacourse.kkogkkog.exception.member.MemberDuplicatedEmail;
+import com.woowacourse.kkogkkog.exception.member.MemberNotFoundException;
+import com.woowacourse.kkogkkog.fixture.MemberFixture;
 import com.woowacourse.kkogkkog.presentation.dto.MemberCreateRequest;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
-@SpringBootTest
 @Transactional
-class MemberServiceTest {
+@Nested
+@DisplayName("MemberService 의")
+class MemberServiceTest extends ServiceTest {
 
     @Autowired
     private MemberService memberService;
 
-    @Test
-    @DisplayName("회원가입을 할 수 있다.")
-    void save() {
-        MemberCreateRequest memberCreateRequest = new MemberCreateRequest("email@gmail.com", "password1234!", "nickname");
+    @Nested
+    @DisplayName("save 메서드는")
+    class save {
 
-        Long memberId = memberService.save(memberCreateRequest);
+        @Test
+        @DisplayName("회원 정보를 받으면, 회원을 저장하고 저장된 Id를 반환한다.")
+        void success() {
+            MemberCreateRequest memberCreateRequest = new MemberCreateRequest("email@gmail.com", "password1234!",
+                    "nickname");
 
-        assertThat(memberId).isNotNull();
+            Long memberId = memberService.save(memberCreateRequest);
+
+            assertThat(memberId).isNotNull();
+        }
+
+        @Test
+        @DisplayName("중복된 이메일이 존재하면, 예외를 던진다.")
+        void fail_duplicatedEmail() {
+            MemberCreateRequest memberCreateRequest = new MemberCreateRequest("email@gmail.com", "password1234!",
+                    "nickname");
+
+            memberService.save(memberCreateRequest);
+            assertThatThrownBy(() -> memberService.save(memberCreateRequest))
+                    .isInstanceOf(MemberDuplicatedEmail.class);
+        }
     }
 
-    @Test
-    @DisplayName("중복된 회원의 이메일이 있을 경우 예외가 발생한다.")
-    void save_fail_duplicatedEmail() {
-        MemberCreateRequest memberCreateRequest = new MemberCreateRequest("email@gmail.com", "password1234!", "nickname");
+    @Nested
+    @DisplayName("findById 메서드는")
+    class findById {
 
-        memberService.save(memberCreateRequest);
-        assertThatThrownBy(() -> memberService.save(memberCreateRequest))
-            .isInstanceOf(MemberDuplicatedEmail.class);
+        @Test
+        @DisplayName("저장된 회원의 Id를 받으면, 해당 회원의 정보를 반환한다.")
+        void success() {
+            MemberCreateRequest memberCreateRequest = new MemberCreateRequest("email@gmail.com", "password1234!",
+                    "nickname");
+            Long memberId = memberService.save(memberCreateRequest);
+
+            MemberResponse memberResponse = memberService.findById(memberId);
+
+            assertThat(memberResponse).usingRecursiveComparison().ignoringFields("id").isEqualTo(
+                    new MemberResponse(null, "email@gmail.com", "nickname")
+            );
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 회원 Id를 받으면, 예외를 던진다.")
+        void fail_noExistMember() {
+            Member nonExistingMember = MemberFixture.NON_EXISTING_MEMBER;
+
+            Assertions.assertThatThrownBy(
+                    () -> memberService.findById(nonExistingMember.getId())
+            ).isInstanceOf(MemberNotFoundException.class);
+        }
     }
 
-    @Test
-    @DisplayName("회원 ID를 통해 회원 정보를 조회할 수 있다.")
-    void findById() {
-        MemberCreateRequest memberCreateRequest = new MemberCreateRequest("email@gmail.com", "password1234!", "nickname");
-        Long memberId = memberService.save(memberCreateRequest);
+    @Nested
+    @DisplayName("findAll 메서드는")
+    class findAll {
 
-        MemberResponse memberResponse = memberService.findById(memberId);
+        @Test
+        @DisplayName("회원가입된 모든 회원들의 정보를 반환한다.")
+        void success() {
+            MemberCreateRequest memberCreateRequest1 = new MemberCreateRequest("email1@gmail.com", "password1234!",
+                    "nickname1");
+            MemberCreateRequest memberCreateRequest2 = new MemberCreateRequest("email2@gmail.com", "password1234!",
+                    "nickname2");
+            memberService.save(memberCreateRequest1);
+            memberService.save(memberCreateRequest2);
 
-        assertThat(memberResponse).usingRecursiveComparison().ignoringFields("id").isEqualTo(
-            new MemberResponse(null, "email@gmail.com", "nickname")
-        );
-    }
-    
-    @Test
-    @DisplayName("회원가입된 회원들의 정보를 조회할 수 있다.")
-    void findAll() {
-        MemberCreateRequest memberCreateRequest1 = new MemberCreateRequest("email1@gmail.com", "password1234!", "nickname1");
-        MemberCreateRequest memberCreateRequest2 = new MemberCreateRequest("email2@gmail.com", "password1234!", "nickname2");
-        memberService.save(memberCreateRequest1);
-        memberService.save(memberCreateRequest2);
+            MembersResponse membersResponse = memberService.findAll();
 
-        MembersResponse membersResponse = memberService.findAll();
-
-        assertThat(membersResponse.getData()).hasSize(2);
+            assertThat(membersResponse.getData()).hasSize(2);
+        }
     }
 }

--- a/backend/src/test/java/com/woowacourse/kkogkkog/domain/CouponEventTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/domain/CouponEventTest.java
@@ -8,7 +8,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-@Nested
 @DisplayName("CouponEvent 의")
 class CouponEventTest {
 

--- a/backend/src/test/java/com/woowacourse/kkogkkog/domain/CouponEventTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/domain/CouponEventTest.java
@@ -14,7 +14,7 @@ class CouponEventTest {
 
     @Nested
     @DisplayName("REQUEST 이벤트는")
-    class request {
+    class Request {
 
         @Test
         @DisplayName("받은 사람이 보낼 수 있다.")
@@ -39,7 +39,7 @@ class CouponEventTest {
 
     @Nested
     @DisplayName("CANCEL 이벤트는")
-    class cancel {
+    class Cancel {
 
         @Test
         @DisplayName("받은 사람이 보낼 수 있다.")

--- a/backend/src/test/java/com/woowacourse/kkogkkog/domain/CouponEventTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/domain/CouponEventTest.java
@@ -28,7 +28,7 @@ class CouponEventTest {
 
         @Test
         @DisplayName("보낸 사람이 보내면, 예외를 던진다.")
-        void fail_SenderRequest() {
+        void fail_senderRequest() {
             boolean isSender = true;
             boolean isReceiver = false;
 
@@ -53,7 +53,7 @@ class CouponEventTest {
 
         @Test
         @DisplayName("보낸 사람이 보내면, 예외를 던진다.")
-        void fail_SenderCancel() {
+        void fail_senderCancel() {
             boolean isSender = true;
             boolean isReceiver = false;
 

--- a/backend/src/test/java/com/woowacourse/kkogkkog/domain/CouponEventTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/domain/CouponEventTest.java
@@ -5,47 +5,60 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.woowacourse.kkogkkog.exception.ForbiddenException;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+@Nested
+@DisplayName("CouponEvent 의")
 class CouponEventTest {
 
-    @Test
-    @DisplayName("쿠폰을 받은 사람이 쿠폰 사용 요청을 보낼 수 있다.")
-    void receiverCanRequest() {
-        boolean isSender = false;
-        boolean isReceiver = true;
+    @Nested
+    @DisplayName("REQUEST 이벤트는")
+    class request {
 
-        assertThatNoException()
-                .isThrownBy(() -> CouponEvent.REQUEST.checkExecutable(isSender, isReceiver));
+        @Test
+        @DisplayName("받은 사람이 보낼 수 있다.")
+        void success() {
+            boolean isSender = false;
+            boolean isReceiver = true;
+
+            assertThatNoException()
+                    .isThrownBy(() -> CouponEvent.REQUEST.checkExecutable(isSender, isReceiver));
+        }
+
+        @Test
+        @DisplayName("보낸 사람이 보내면, 예외를 던진다.")
+        void senderCanNotRequest() {
+            boolean isSender = true;
+            boolean isReceiver = false;
+
+            assertThatThrownBy(() -> CouponEvent.REQUEST.checkExecutable(isSender, isReceiver))
+                    .isInstanceOf(ForbiddenException.class);
+        }
     }
 
-    @Test
-    @DisplayName("쿠폰을 보낸 사람이 쿠폰 사용 요청을 보내는 경우 예외가 발생한다.")
-    void senderCanNotRequest() {
-        boolean isSender = true;
-        boolean isReceiver = false;
+    @Nested
+    @DisplayName("CANCEL 이벤트는")
+    class cancel {
 
-        assertThatThrownBy(() -> CouponEvent.REQUEST.checkExecutable(isSender, isReceiver))
-                .isInstanceOf(ForbiddenException.class);
-    }
+        @Test
+        @DisplayName("받은 사람이 보낼 수 있다.")
+        void receiverCanCancel() {
+            boolean isSender = false;
+            boolean isReceiver = true;
 
-    @Test
-    @DisplayName("쿠폰을 받은 사람이 쿠폰 사용 요청을 취소할 수 있다.")
-    void receiverCanCancel() {
-        boolean isSender = false;
-        boolean isReceiver = true;
+            assertThatNoException()
+                    .isThrownBy(() -> CouponEvent.CANCEL.checkExecutable(isSender, isReceiver));
+        }
 
-        assertThatNoException()
-                .isThrownBy(() -> CouponEvent.CANCEL.checkExecutable(isSender, isReceiver));
-    }
+        @Test
+        @DisplayName("보낸 사람이 보내면, 예외를 던진다.")
+        void senderCanNotCancel() {
+            boolean isSender = true;
+            boolean isReceiver = false;
 
-    @Test
-    @DisplayName("쿠폰을 보낸 사람이 쿠폰 사용 요청 취소를 보내는 경우 예외가 발생한다.")
-    void senderCanNotCancel() {
-        boolean isSender = true;
-        boolean isReceiver = false;
-
-        assertThatThrownBy(() -> CouponEvent.CANCEL.checkExecutable(isSender, isReceiver))
-                .isInstanceOf(ForbiddenException.class);
+            assertThatThrownBy(() -> CouponEvent.CANCEL.checkExecutable(isSender, isReceiver))
+                    .isInstanceOf(ForbiddenException.class);
+        }
     }
 }

--- a/backend/src/test/java/com/woowacourse/kkogkkog/domain/CouponEventTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/domain/CouponEventTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-@DisplayName("CouponEvent 의")
+@DisplayName("CouponEvent 클래스의")
 class CouponEventTest {
 
     @Nested

--- a/backend/src/test/java/com/woowacourse/kkogkkog/domain/CouponEventTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/domain/CouponEventTest.java
@@ -28,7 +28,7 @@ class CouponEventTest {
 
         @Test
         @DisplayName("보낸 사람이 보내면, 예외를 던진다.")
-        void senderCanNotRequest() {
+        void fail_SenderRequest() {
             boolean isSender = true;
             boolean isReceiver = false;
 
@@ -43,7 +43,7 @@ class CouponEventTest {
 
         @Test
         @DisplayName("받은 사람이 보낼 수 있다.")
-        void receiverCanCancel() {
+        void success() {
             boolean isSender = false;
             boolean isReceiver = true;
 
@@ -53,7 +53,7 @@ class CouponEventTest {
 
         @Test
         @DisplayName("보낸 사람이 보내면, 예외를 던진다.")
-        void senderCanNotCancel() {
+        void fail_SenderCancel() {
             boolean isSender = true;
             boolean isReceiver = false;
 

--- a/backend/src/test/java/com/woowacourse/kkogkkog/domain/CouponStatusTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/domain/CouponStatusTest.java
@@ -5,51 +5,64 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.woowacourse.kkogkkog.exception.InvalidRequestException;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+@Nested
+@DisplayName("CouponStatus 의")
 class CouponStatusTest {
 
-    @Test
-    @DisplayName("READY 상태의 쿠폰은 REQUEST 이벤트를 받으면 REQUESTED 상태로 변경된다.")
-    void readyChangesToRequestedOnRequestEvent() {
-        CouponStatus currentStatus = CouponStatus.READY;
-        CouponEvent event = CouponEvent.REQUEST;
+    @Nested
+    @DisplayName("READY 상태는")
+    class Ready {
 
-        CouponStatus actual = currentStatus.handle(event);
-        CouponStatus expected = CouponStatus.REQUESTED;
+        @Test
+        @DisplayName("REQUEST 이벤트를 받으면, REQUESTED 를 반환한다.")
+        void success_request() {
+            CouponStatus currentStatus = CouponStatus.READY;
+            CouponEvent event = CouponEvent.REQUEST;
 
-        assertThat(actual).isEqualTo(expected);
+            CouponStatus actual = currentStatus.handle(event);
+            CouponStatus expected = CouponStatus.REQUESTED;
+
+            assertThat(actual).isEqualTo(expected);
+        }
+
+        @Test
+        @DisplayName("CANCEL 이벤트를 받으면, 예외를 던진다.")
+        void fail_cancel() {
+            CouponStatus currentStatus = CouponStatus.READY;
+            CouponEvent event = CouponEvent.CANCEL;
+
+            assertThatThrownBy(() -> currentStatus.handle(event))
+                    .isInstanceOf(InvalidRequestException.class);
+        }
     }
 
-    @Test
-    @DisplayName("REQUESTED 상태의 쿠폰은 REQUEST 이벤트를 받으면 예외가 발생된다.")
-    void requestedCanNotHandleRequestEvent() {
-        CouponStatus currentStatus = CouponStatus.REQUESTED;
-        CouponEvent event = CouponEvent.REQUEST;
+    @Nested
+    @DisplayName("REQUESTED 상태는")
+    class Requested {
 
-        assertThatThrownBy(() -> currentStatus.handle(event))
-                .isInstanceOf(InvalidRequestException.class);
-    }
+        @Test
+        @DisplayName("REQUEST 이벤트를 받으면, 예외를 던진다.")
+        void fail_request() {
+            CouponStatus currentStatus = CouponStatus.REQUESTED;
+            CouponEvent event = CouponEvent.REQUEST;
 
-    @Test
-    @DisplayName("REQUESTED 상태의 쿠폰은 CANCEL 이벤트를 받으면 READY 상태로 변경된다.")
-    void requestedChangesToReadyOnCancelEvent() {
-        CouponStatus currentStatus = CouponStatus.REQUESTED;
-        CouponEvent event = CouponEvent.CANCEL;
+            assertThatThrownBy(() -> currentStatus.handle(event))
+                    .isInstanceOf(InvalidRequestException.class);
+        }
 
-        CouponStatus actual = currentStatus.handle(event);
-        CouponStatus expected = CouponStatus.READY;
+        @Test
+        @DisplayName("CANCEL 이벤트를 받으면, READY 를 반환한다.")
+        void fail_cancel() {
+            CouponStatus currentStatus = CouponStatus.REQUESTED;
+            CouponEvent event = CouponEvent.CANCEL;
 
-        assertThat(actual).isEqualTo(expected);
-    }
+            CouponStatus actual = currentStatus.handle(event);
+            CouponStatus expected = CouponStatus.READY;
 
-    @Test
-    @DisplayName("READY 상태의 쿠폰은 CANCEL 이벤트를 받으면 예외가 발생된다.")
-    void readyCanNotHandleCancelEvent() {
-        CouponStatus currentStatus = CouponStatus.READY;
-        CouponEvent event = CouponEvent.CANCEL;
-
-        assertThatThrownBy(() -> currentStatus.handle(event))
-                .isInstanceOf(InvalidRequestException.class);
+            assertThat(actual).isEqualTo(expected);
+        }
     }
 }

--- a/backend/src/test/java/com/woowacourse/kkogkkog/domain/CouponStatusTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/domain/CouponStatusTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-@DisplayName("CouponStatus 의")
+@DisplayName("CouponStatus 클래스의")
 class CouponStatusTest {
 
     @Nested

--- a/backend/src/test/java/com/woowacourse/kkogkkog/domain/CouponStatusTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/domain/CouponStatusTest.java
@@ -8,7 +8,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-@Nested
 @DisplayName("CouponStatus 의")
 class CouponStatusTest {
 

--- a/backend/src/test/java/com/woowacourse/kkogkkog/domain/CouponTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/domain/CouponTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-@DisplayName("Coupon 의")
+@DisplayName("Coupon 클래스의")
 public class CouponTest {
 
     @Nested

--- a/backend/src/test/java/com/woowacourse/kkogkkog/domain/CouponTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/domain/CouponTest.java
@@ -17,7 +17,7 @@ public class CouponTest {
 
     @Nested
     @DisplayName("생성자는")
-    class constructor {
+    class Constructor {
 
         @Test
         @DisplayName("쿠폰의 정보를 받으면, 쿠폰을 생성한다.")

--- a/backend/src/test/java/com/woowacourse/kkogkkog/domain/CouponTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/domain/CouponTest.java
@@ -7,85 +7,115 @@ import com.woowacourse.kkogkkog.exception.ForbiddenException;
 import com.woowacourse.kkogkkog.exception.InvalidRequestException;
 import com.woowacourse.kkogkkog.exception.coupon.SameSenderReceiverException;
 import com.woowacourse.kkogkkog.fixture.MemberFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-@SuppressWarnings("NonAsciiCharacters")
+@Nested
+@DisplayName("Coupon 의")
 public class CouponTest {
 
-    @Test
-    void 쿠폰을_생성할_수_있다() {
-        Member sender = MemberFixture.ROOKIE;
-        Member receiver = MemberFixture.ARTHUR;
+    @Nested
+    @DisplayName("생성자는")
+    class constructor {
 
-        Coupon actual = new Coupon(null, sender, receiver, "한턱쏘는", "추가 메세지", "#241223", CouponType.COFFEE,
-                CouponStatus.READY);
+        @Test
+        @DisplayName("쿠폰의 정보를 받으면, 쿠폰을 생성한다.")
+        void success() {
+            Member sender = MemberFixture.ROOKIE;
+            Member receiver = MemberFixture.ARTHUR;
 
-        assertThat(actual).isNotNull();
+            Coupon actual = new Coupon(null, sender, receiver, "한턱쏘는", "추가 메세지", "#241223", CouponType.COFFEE,
+                    CouponStatus.READY);
+
+            assertThat(actual).isNotNull();
+        }
+
+        @Test
+        @DisplayName("보낸 사람과 받는 사람이 동일하면, 예외를 던진다.")
+        void fail_sameSenderAndReceiver() {
+            Member member = MemberFixture.ROOKIE;
+            assertThatThrownBy(
+                    () -> new Coupon(null, member, member, "한턱쏘는", "추가 메세지", "#241223", CouponType.COFFEE,
+                            CouponStatus.READY)
+            ).isInstanceOf(SameSenderReceiverException.class);
+        }
     }
 
-    @Test
-    void 보낸_사람과_받는_사람이_같은_경우_예외를_던진다() {
-        Member member = MemberFixture.ROOKIE;
-        assertThatThrownBy(
-                () -> new Coupon(null, member, member, "한턱쏘는", "추가 메세지", "#241223", CouponType.COFFEE,
-                        CouponStatus.READY)
-        ).isInstanceOf(SameSenderReceiverException.class);
-    }
+    @Nested
+    @DisplayName("changeStatus 메서드는")
+    class ChangeStatus {
 
-    @Test
-    void 받은_사람은_READY_상태의_쿠폰에_대한_사용_요청을_보낼_수_있다() {
-        Member sender = MemberFixture.ROOKIE;
-        Member receiver = MemberFixture.ARTHUR;
-        Coupon coupon = new Coupon(null, sender, receiver, "한턱쏘는", "추가 메세지", "#241223", CouponType.COFFEE,
-                CouponStatus.READY);
+        @Nested
+        @DisplayName("READY 상태의 쿠폰에")
+        class Ready {
 
-        coupon.changeStatus(CouponEvent.REQUEST, receiver);
+            @Test
+            @DisplayName("받은 사람이 REQUEST 를 보내면, REQUESTED 로 변경한다.")
+            void success_request() {
+                Member sender = MemberFixture.ROOKIE;
+                Member receiver = MemberFixture.ARTHUR;
+                Coupon coupon = new Coupon(null, sender, receiver, "한턱쏘는", "추가 메세지", "#241223", CouponType.COFFEE,
+                        CouponStatus.READY);
 
-        assertThat(coupon.getCouponStatus()).isEqualTo(CouponStatus.REQUESTED);
-    }
+                coupon.changeStatus(CouponEvent.REQUEST, receiver);
 
-    @Test
-    void 보낸_사람은_쿠폰_사용_요청을_보낼_수_없다() {
-        Member sender = MemberFixture.ROOKIE;
-        Member receiver = MemberFixture.ARTHUR;
-        Coupon coupon = new Coupon(null, sender, receiver, "한턱쏘는", "추가 메세지", "#241223", CouponType.COFFEE,
-                CouponStatus.READY);
+                assertThat(coupon.getCouponStatus()).isEqualTo(CouponStatus.REQUESTED);
+            }
 
-        assertThatThrownBy(() -> coupon.changeStatus(CouponEvent.REQUEST, sender))
-                .isInstanceOf(ForbiddenException.class);
-    }
+            @Test
+            @DisplayName("보낸 사람이 REQUEST 를 보내면, 예외를 던진다.")
+            void fail_requestBySender() {
+                Member sender = MemberFixture.ROOKIE;
+                Member receiver = MemberFixture.ARTHUR;
+                Coupon coupon = new Coupon(null, sender, receiver, "한턱쏘는", "추가 메세지", "#241223", CouponType.COFFEE,
+                        CouponStatus.READY);
 
-    @Test
-    void 받은_사람은_REQUESTED_상태의_쿠폰에_대한_사용_요청_취소를_보낼_수_있다() {
-        Member sender = MemberFixture.ROOKIE;
-        Member receiver = MemberFixture.ARTHUR;
-        Coupon coupon = new Coupon(null, sender, receiver, "한턱쏘는", "추가 메세지", "#241223", CouponType.COFFEE,
-                CouponStatus.REQUESTED);
+                assertThatThrownBy(() -> coupon.changeStatus(CouponEvent.REQUEST, sender))
+                        .isInstanceOf(ForbiddenException.class);
+            }
 
-        coupon.changeStatus(CouponEvent.CANCEL, receiver);
+            @Test
+            @DisplayName("받은 사람이 CANCEL 을 보내면, 예외를 던진다.")
+            void fail_cancelReady() {
+                Member sender = MemberFixture.ROOKIE;
+                Member receiver = MemberFixture.ARTHUR;
+                Coupon coupon = new Coupon(null, sender, receiver, "한턱쏘는", "추가 메세지", "#241223", CouponType.COFFEE,
+                        CouponStatus.READY);
 
-        assertThat(coupon.getCouponStatus()).isEqualTo(CouponStatus.READY);
-    }
+                assertThatThrownBy(() -> coupon.changeStatus(CouponEvent.CANCEL, receiver))
+                        .isInstanceOf(InvalidRequestException.class);
+            }
+        }
 
-    @Test
-    void 받은_사람은_READY_상태의_쿠폰에_대한_사용_요청_취소를_보낼_수_없다() {
-        Member sender = MemberFixture.ROOKIE;
-        Member receiver = MemberFixture.ARTHUR;
-        Coupon coupon = new Coupon(null, sender, receiver, "한턱쏘는", "추가 메세지", "#241223", CouponType.COFFEE,
-                CouponStatus.READY);
+        @Nested
+        @DisplayName("REQUESTED 상태의 쿠폰에")
+        class Requested {
 
-        assertThatThrownBy(() -> coupon.changeStatus(CouponEvent.CANCEL, receiver))
-                .isInstanceOf(InvalidRequestException.class);
-    }
+            @Test
+            @DisplayName("받은 사람이 CANCEL 을 보내면, READY 로 변경한다.")
+            void success_cancel() {
+                Member sender = MemberFixture.ROOKIE;
+                Member receiver = MemberFixture.ARTHUR;
+                Coupon coupon = new Coupon(null, sender, receiver, "한턱쏘는", "추가 메세지", "#241223", CouponType.COFFEE,
+                        CouponStatus.REQUESTED);
 
-    @Test
-    void 보낸_사람은_쿠폰_사용_요청_취소를_보낼_수_없다() {
-        Member sender = MemberFixture.ROOKIE;
-        Member receiver = MemberFixture.ARTHUR;
-        Coupon coupon = new Coupon(null, sender, receiver, "한턱쏘는", "추가 메세지", "#241223", CouponType.COFFEE,
-                CouponStatus.REQUESTED);
+                coupon.changeStatus(CouponEvent.CANCEL, receiver);
 
-        assertThatThrownBy(() -> coupon.changeStatus(CouponEvent.CANCEL, sender))
-                .isInstanceOf(ForbiddenException.class);
+                assertThat(coupon.getCouponStatus()).isEqualTo(CouponStatus.READY);
+            }
+
+            @Test
+            @DisplayName("보낸 사람이 CANCEL 을 보내면, 예외를 던진다.")
+            void fail_cancelBySender() {
+                Member sender = MemberFixture.ROOKIE;
+                Member receiver = MemberFixture.ARTHUR;
+                Coupon coupon = new Coupon(null, sender, receiver, "한턱쏘는", "추가 메세지", "#241223", CouponType.COFFEE,
+                        CouponStatus.REQUESTED);
+
+                assertThatThrownBy(() -> coupon.changeStatus(CouponEvent.CANCEL, sender))
+                        .isInstanceOf(ForbiddenException.class);
+            }
+        }
     }
 }

--- a/backend/src/test/java/com/woowacourse/kkogkkog/domain/CouponTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/domain/CouponTest.java
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-@Nested
 @DisplayName("Coupon 의")
 public class CouponTest {
 


### PR DESCRIPTION
## 작업 내용

각 ServiceTest 와 DomainTest에 DCI 패턴 적용

기본적인 형태는 아래와 같습니다
`Class` 의 `method` 메서드는 `condition` 면, `action` 한다.
ex) `AuthService` 의 `login` 메서드는 `저장된 회원 이메일과 비밀번호를 입력하` 면, `회원 정보를 반환` 한다.

하지만 changeStatus의 경우 상태에 따라서 구분이 많이 되기 때문에 현재 상태를 문구가 하나 추가되면서 depth가 1증가했습니다.
`Class` 의 `method` 메서드는 `CouponStatus`에 `condition`  면, `action` 한다.
`Coupon` 의 `changeStatus` 메서드는 `READY 상태의 쿠폰`에 `받은 사람이 REQUEST를 보내`면, `REQUESTED 상태로 변경`한다.


### <기존 테스트 목록>
<img width="428" alt="Screen Shot 2022-07-21 at 10 42 48 AM" src="https://user-images.githubusercontent.com/75936123/180136291-4c269b68-bf89-4239-bfa9-b7ebbded150f.png">

### <변경된 테스트 목록>
<img width="395" alt="Screen Shot 2022-07-21 at 2 26 15 PM" src="https://user-images.githubusercontent.com/75936123/180136320-098db317-9fe0-4be1-9e19-afc56ed88d81.png">



## 공유사항

우선 제가 작성하던 방식대로 작성해봤습니다.
CouponService 와 Coupon의 changeStatus 메서드의 경우 상태에 따라 여러가지 경우의 수가 존재할 수 있어서 상태별로 분류했습니다.

Resolves #92
