### PR TITLE
feat: 랜딩 페이지 Suspense 처리, router의 state를 잘 활용해보자

### DIFF
--- a/frontend/src/@components/@shared/CustomSuspense/index.tsx
+++ b/frontend/src/@components/@shared/CustomSuspense/index.tsx
@@ -1,0 +1,11 @@
+const CustomSuspense = (props: any) => {
+  const { fallback, isLoading, children } = props;
+
+  if (isLoading) {
+    return fallback;
+  }
+
+  return children;
+};
+
+export default CustomSuspense;

--- a/frontend/src/@components/@shared/ListFilter/index.tsx
+++ b/frontend/src/@components/@shared/ListFilter/index.tsx
@@ -1,3 +1,7 @@
+import { css } from '@emotion/react';
+
+import Placeholder from '@/@components/@shared/Placeholder';
+
 import * as Styled from './style';
 
 interface ListFilterProps<T> {
@@ -25,3 +29,13 @@ const ListFilter = <T extends string>(props: ListFilterProps<T>) => {
 };
 
 export default ListFilter;
+
+ListFilter.Skeleton = function Skeleton() {
+  return (
+    <Styled.Root>
+      <Placeholder width={'100px'} height={'40px'} css={Styled.ExtendedPlaceholder} />
+      <Placeholder width={'100px'} height={'40px'} css={Styled.ExtendedPlaceholder} />
+      <Placeholder width={'100px'} height={'40px'} css={Styled.ExtendedPlaceholder} />
+    </Styled.Root>
+  );
+};

--- a/frontend/src/@components/@shared/ListFilter/style.tsx
+++ b/frontend/src/@components/@shared/ListFilter/style.tsx
@@ -31,3 +31,7 @@ export const FilterButton = styled.button<{ isFocus?: boolean }>`
     color: ${isFocus ? theme.colors.white_100 : theme.colors.grey_100};
   `}
 `;
+
+export const ExtendedPlaceholder = css`
+  margin-right: 20px;
+`;

--- a/frontend/src/@components/kkogkkog/KkogKkogList/index.tsx
+++ b/frontend/src/@components/kkogkkog/KkogKkogList/index.tsx
@@ -30,3 +30,14 @@ const KkogKkogList = (props: KkogKkogListProps) => {
 };
 
 export default KkogKkogList;
+
+KkogKkogList.Skeleton = function Skeleton() {
+  return (
+    <Styled.Root>
+      <KkogKkogItem.Skeleton />
+      <KkogKkogItem.Skeleton />
+      <KkogKkogItem.Skeleton />
+      <KkogKkogItem.Skeleton />
+    </Styled.Root>
+  );
+};

--- a/frontend/src/@components/kkogkkog/ReceivedKkogKkog/index.tsx
+++ b/frontend/src/@components/kkogkkog/ReceivedKkogKkog/index.tsx
@@ -69,3 +69,12 @@ const ReceivedKkogKkog = (props: ReceivedKkogKkogProps) => {
 };
 
 export default ReceivedKkogKkog;
+
+ReceivedKkogKkog.Skeleton = function Skeleton() {
+  return (
+    <Styled.Root>
+      <ListFilter.Skeleton />
+      <KkogKkogList.Skeleton />
+    </Styled.Root>
+  );
+};

--- a/frontend/src/@components/kkogkkog/SentKkogKkog/index.tsx
+++ b/frontend/src/@components/kkogkkog/SentKkogKkog/index.tsx
@@ -74,3 +74,12 @@ const SentKkogKkog = (props: SentkogKkogProps) => {
 };
 
 export default SentKkogKkog;
+
+SentKkogKkog.Skeleton = function Skeleton() {
+  return (
+    <Styled.Root>
+      <ListFilter.Skeleton />
+      <KkogKkogList.Skeleton />
+    </Styled.Root>
+  );
+};

--- a/frontend/src/@hooks/@common/useRouterState.ts
+++ b/frontend/src/@hooks/@common/useRouterState.ts
@@ -1,15 +1,15 @@
 import { useLocation } from 'react-router-dom';
 
-export const useRouterState = (key: string) => {
+import { hasKey } from '@/types/utils';
+
+const useRouterState = <ValueType>(key: string) => {
   const { state } = useLocation();
 
-  if (state === null) {
-    return null;
-  }
-
-  if (key in state) {
+  if (hasKey<ValueType>(state, key)) {
     return state[key];
   }
 
   return null;
 };
+
+export default useRouterState;

--- a/frontend/src/@hooks/@common/useRouterState.ts
+++ b/frontend/src/@hooks/@common/useRouterState.ts
@@ -1,0 +1,15 @@
+import { useLocation } from 'react-router-dom';
+
+export const useRouterState = (key: string) => {
+  const { state } = useLocation();
+
+  if (state === null) {
+    return null;
+  }
+
+  if (key in state) {
+    return state[key];
+  }
+
+  return null;
+};

--- a/frontend/src/@hooks/kkogkkog/useKkogKkogList.ts
+++ b/frontend/src/@hooks/kkogkkog/useKkogKkogList.ts
@@ -6,7 +6,10 @@ import { KkogKkogListResponse } from '@/types/remote/response';
 export const useKkogKkogList = () => {
   const kkogkkogListQuery = useQuery<{ data: KkogKkogListResponse }>(
     ['kkogkkogList'],
-    getKkogkkogList
+    getKkogkkogList,
+    {
+      suspense: false,
+    }
   );
 
   return {

--- a/frontend/src/@hooks/user/useMe.ts
+++ b/frontend/src/@hooks/user/useMe.ts
@@ -5,7 +5,7 @@ import { MeResponse } from '@/types/remote/response';
 
 const useMe = () => {
   const meQuery = useQuery<{ data: MeResponse }>(['me'], getMe, {
-    suspense: false,
+    suspense: true,
   });
 
   return {

--- a/frontend/src/@pages/landing/index.tsx
+++ b/frontend/src/@pages/landing/index.tsx
@@ -8,7 +8,7 @@ import PageTemplate from '@/@components/@shared/PageTemplate';
 import KkogKkogItem from '@/@components/kkogkkog/KkogKkogItem';
 import ReceivedKkogKkog from '@/@components/kkogkkog/ReceivedKkogKkog';
 import SentKkogKkog from '@/@components/kkogkkog/SentKkogKkog';
-import { useRouterState } from '@/@hooks/@common/useRouterState';
+import useRouterState from '@/@hooks/@common/useRouterState';
 import { useStatus } from '@/@hooks/@common/useStatus';
 import { useKkogKkogList } from '@/@hooks/kkogkkog/useKkogKkogList';
 import useMe from '@/@hooks/user/useMe';
@@ -35,7 +35,7 @@ const UnAuthorizedLanding = () => {
 const AuthorizedLanding = () => {
   const { kkogkkogList, isLoading } = useKkogKkogList();
 
-  const routerState = useRouterState('action');
+  const routerState = useRouterState<'create'>('action');
 
   const { status, changeStatus } = useStatus<STATUS_TYPE>(
     routerState === 'create' ? 'sent' : 'received'

--- a/frontend/src/Router.tsx
+++ b/frontend/src/Router.tsx
@@ -26,7 +26,7 @@ const Router = () => {
       <Route
         path={PATH.LANDING}
         element={
-          <Suspense fallback={<LandingPage.Skeleton />}>
+          <Suspense fallback={<Loading>👻</Loading>}>
             <LandingPage />
           </Suspense>
         }

--- a/frontend/src/types/utils.ts
+++ b/frontend/src/types/utils.ts
@@ -1,0 +1,11 @@
+export const hasKey = <T>(state: unknown, key: string): state is { [key: string]: T } => {
+  if (typeof state !== 'object') {
+    return false;
+  }
+
+  if (state === null) {
+    return false;
+  }
+
+  return key in state;
+};


### PR DESCRIPTION
## 작업 내용

랜딩 페이지 Suspense 처리

 CustomSuspense 컴포넌트를 개발하여 React.Suspense 컴포넌트가 할 수 없는 동작을 하도록 구현한다.
 Skeleton UI들을 추가적으로 개발, 개선한다.
router의 state를 잘 활용해보자

 useRouterState 훅을 개발하여 Router 의 state를 활용하는 코드를 더 이해하기 쉽도록한다.

 정적 Typing을 추가한다.(다음 풀리퀘에서 진행)

## 공유사항

해당 작업 내용에 관한 부연 설명 및 및 향후 작업해야 할 내용 등에 대한 설명

Resolves #97
