### PR TITLE
feat : 쿠폰 사용 요청 수락 기능 구현

### DIFF
--- a/backend/src/main/java/com/woowacourse/kkogkkog/domain/CouponEvent.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/domain/CouponEvent.java
@@ -9,6 +9,7 @@ public enum CouponEvent {
     REQUEST(CouponEvent::canRequest),
     CANCEL(CouponEvent::canCancel),
     DECLINE(CouponEvent::canDecline),
+    ACCEPT(CouponEvent::canAccept),
     ;
 
     private final BiConsumer<Boolean, Boolean> canChange;
@@ -44,6 +45,12 @@ public enum CouponEvent {
     private static void canDecline(boolean isSender, boolean isReceiver) {
         if (!isSender) {
             throw new ForbiddenException("쿠폰을 보낸 사람만 사용 요청을 거절할 수 있습니다.");
+        }
+    }
+
+    private static void canAccept(boolean isSender, boolean isReceiver) {
+        if (!isSender) {
+            throw new ForbiddenException("쿠폰을 보낸 사람만 사용 요청을 수락할 수 있습니다.");
         }
     }
 }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/domain/CouponStatus.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/domain/CouponStatus.java
@@ -48,7 +48,7 @@ public enum CouponStatus {
 
     private CouponStatus handleAccept() {
         if (this != REQUESTED) {
-            throw new InvalidRequestException("사용 요청을 수락할 수 없는 상태의 쿠폰입니다.");
+            throw new InvalidRequestException("사용 요청 상태의 쿠폰이 아닙니다.");
         }
         return ACCEPTED;
     }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/domain/CouponStatus.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/domain/CouponStatus.java
@@ -6,6 +6,7 @@ public enum CouponStatus {
 
     READY,
     REQUESTED,
+    ACCEPTED,
     ;
 
     public CouponStatus handle(CouponEvent event) {
@@ -17,6 +18,9 @@ public enum CouponStatus {
         }
         if (event == CouponEvent.DECLINE) {
             return handleDecline();
+        }
+        if (event == CouponEvent.ACCEPT) {
+            return handleAccept();
         }
         throw new InvalidRequestException("처리할 수 없는 요청입니다.");
     }
@@ -40,5 +44,12 @@ public enum CouponStatus {
             throw new InvalidRequestException("사용 요청을 거절할 수 없는 상태의 쿠폰입니다.");
         }
         return READY;
+    }
+
+    private CouponStatus handleAccept() {
+        if (this != REQUESTED) {
+            throw new InvalidRequestException("사용 요청을 수락할 수 없는 상태의 쿠폰입니다.");
+        }
+        return ACCEPTED;
     }
 }

--- a/backend/src/test/java/com/woowacourse/kkogkkog/acceptance/CouponAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/acceptance/CouponAcceptanceTest.java
@@ -262,6 +262,34 @@ public class CouponAcceptanceTest extends AcceptanceTest {
             assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
         }
 
+//        @Test
+//        void 로그인된_사용자가_보낸_쿠폰에_대해_사용_요청을_받으면_요청을_수락할_수_있다() {
+//            회원_가입에_성공한다(toMemberCreateRequest(JEONG));
+//            회원_가입에_성공한다(toMemberCreateRequest(LEO));
+//            String jeongAccessToken = 로그인에_성공한다(toTokenRequest(JEONG)).getAccessToken();
+//            String leoAccessToken = 로그인에_성공한다(toTokenRequest(LEO)).getAccessToken();
+//            쿠폰_발급에_성공한다(jeongAccessToken, List.of(LEO));
+//
+//            쿠폰_상태_변경을_요청한다(leoAccessToken, 1L, CouponEvent.REQUEST.name());
+//            ExtractableResponse<Response> response = 쿠폰_상태_변경을_요청한다(jeongAccessToken, 1L,
+//                    CouponEvent.ACCEPT.name());
+//
+//            assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+//        }
+//
+//        @Test
+//        void 쿠폰이_사용_준비_상태이면_사용_요청을_수락할_수_없다() {
+//            회원_가입에_성공한다(toMemberCreateRequest(JEONG));
+//            회원_가입에_성공한다(toMemberCreateRequest(LEO));
+//            String jeongAccessToken = 로그인에_성공한다(toTokenRequest(JEONG)).getAccessToken();
+//            쿠폰_발급에_성공한다(jeongAccessToken, List.of(LEO));
+//
+//            ExtractableResponse<Response> response = 쿠폰_상태_변경을_요청한다(jeongAccessToken, 1L,
+//                    CouponEvent.ACCEPT.name());
+//
+//            assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+//        }
+
         private ExtractableResponse<Response> 쿠폰_상태_변경을_요청한다(String accessToken,
                                                              Long couponId,
                                                              String couponEvent) {

--- a/backend/src/test/java/com/woowacourse/kkogkkog/acceptance/CouponAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/acceptance/CouponAcceptanceTest.java
@@ -262,33 +262,33 @@ public class CouponAcceptanceTest extends AcceptanceTest {
             assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
         }
 
-//        @Test
-//        void 로그인된_사용자가_보낸_쿠폰에_대해_사용_요청을_받으면_요청을_수락할_수_있다() {
-//            회원_가입에_성공한다(toMemberCreateRequest(JEONG));
-//            회원_가입에_성공한다(toMemberCreateRequest(LEO));
-//            String jeongAccessToken = 로그인에_성공한다(toTokenRequest(JEONG)).getAccessToken();
-//            String leoAccessToken = 로그인에_성공한다(toTokenRequest(LEO)).getAccessToken();
-//            쿠폰_발급에_성공한다(jeongAccessToken, List.of(LEO));
-//
-//            쿠폰_상태_변경을_요청한다(leoAccessToken, 1L, CouponEvent.REQUEST.name());
-//            ExtractableResponse<Response> response = 쿠폰_상태_변경을_요청한다(jeongAccessToken, 1L,
-//                    CouponEvent.ACCEPT.name());
-//
-//            assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
-//        }
-//
-//        @Test
-//        void 쿠폰이_사용_준비_상태이면_사용_요청을_수락할_수_없다() {
-//            회원_가입에_성공한다(toMemberCreateRequest(JEONG));
-//            회원_가입에_성공한다(toMemberCreateRequest(LEO));
-//            String jeongAccessToken = 로그인에_성공한다(toTokenRequest(JEONG)).getAccessToken();
-//            쿠폰_발급에_성공한다(jeongAccessToken, List.of(LEO));
-//
-//            ExtractableResponse<Response> response = 쿠폰_상태_변경을_요청한다(jeongAccessToken, 1L,
-//                    CouponEvent.ACCEPT.name());
-//
-//            assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
-//        }
+        @Test
+        void 로그인된_사용자가_보낸_쿠폰에_대해_사용_요청을_받으면_요청을_수락할_수_있다() {
+            회원_가입에_성공한다(toMemberCreateRequest(JEONG));
+            회원_가입에_성공한다(toMemberCreateRequest(LEO));
+            String jeongAccessToken = 로그인에_성공한다(toTokenRequest(JEONG)).getAccessToken();
+            String leoAccessToken = 로그인에_성공한다(toTokenRequest(LEO)).getAccessToken();
+            쿠폰_발급에_성공한다(jeongAccessToken, List.of(LEO));
+
+            쿠폰_상태_변경을_요청한다(leoAccessToken, 1L, CouponEvent.REQUEST.name());
+            ExtractableResponse<Response> response = 쿠폰_상태_변경을_요청한다(jeongAccessToken, 1L,
+                    CouponEvent.ACCEPT.name());
+
+            assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        }
+
+        @Test
+        void 쿠폰이_사용_준비_상태이면_사용_요청을_수락할_수_없다() {
+            회원_가입에_성공한다(toMemberCreateRequest(JEONG));
+            회원_가입에_성공한다(toMemberCreateRequest(LEO));
+            String jeongAccessToken = 로그인에_성공한다(toTokenRequest(JEONG)).getAccessToken();
+            쿠폰_발급에_성공한다(jeongAccessToken, List.of(LEO));
+
+            ExtractableResponse<Response> response = 쿠폰_상태_변경을_요청한다(jeongAccessToken, 1L,
+                    CouponEvent.ACCEPT.name());
+
+            assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+        }
 
         private ExtractableResponse<Response> 쿠폰_상태_변경을_요청한다(String accessToken,
                                                              Long couponId,

--- a/backend/src/test/java/com/woowacourse/kkogkkog/domain/CouponEventTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/domain/CouponEventTest.java
@@ -68,4 +68,24 @@ class CouponEventTest {
         assertThatThrownBy(() -> CouponEvent.DECLINE.checkExecutable(isSender, isReceiver))
             .isInstanceOf(ForbiddenException.class);
     }
+
+    @Test
+    @DisplayName("쿠폰을 보낸 사람이 사용 요청을 수락할 수 있다.")
+    void senderCanAccept() {
+        boolean isSender = true;
+        boolean isReceiver = false;
+
+        assertThatNoException()
+                .isThrownBy(() -> CouponEvent.ACCEPT.checkExecutable(isSender, isReceiver));
+    }
+
+    @Test
+    @DisplayName("쿠폰을 받은 사람이 쿠폰 사용 요청 수락을 보내는 경우 예외가 발생한다.")
+    void receiverCanNotAccept() {
+        boolean isSender = false;
+        boolean isReceiver = true;
+
+        assertThatThrownBy(() -> CouponEvent.ACCEPT.checkExecutable(isSender, isReceiver))
+                .isInstanceOf(ForbiddenException.class);
+    }
 }

--- a/backend/src/test/java/com/woowacourse/kkogkkog/domain/CouponStatusTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/domain/CouponStatusTest.java
@@ -74,4 +74,26 @@ class CouponStatusTest {
         assertThatThrownBy(() -> currentStatus.handle(event))
             .isInstanceOf(InvalidRequestException.class);
     }
+
+    @Test
+    @DisplayName("REQUESTED 상태의 쿠폰은 ACCEPT 이벤트를 받으면 ACCEPTED 상태로 변경된다.")
+    void requestedChangesToAcceptedOnAcceptEvent() {
+        CouponStatus currentStatus = CouponStatus.REQUESTED;
+        CouponEvent event = CouponEvent.ACCEPT;
+
+        CouponStatus actual = currentStatus.handle(event);
+        CouponStatus expected = CouponStatus.ACCEPTED;
+
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("READY 상태의 쿠폰은 ACCEPT 이벤트를 받으면 예외가 발생된다.")
+    void readyCanNotHandleAcceptEvent() {
+        CouponStatus currentStatus = CouponStatus.READY;
+        CouponEvent event = CouponEvent.ACCEPT;
+
+        assertThatThrownBy(() -> currentStatus.handle(event))
+                .isInstanceOf(InvalidRequestException.class);
+    }
 }

--- a/backend/src/test/java/com/woowacourse/kkogkkog/domain/CouponTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/domain/CouponTest.java
@@ -88,4 +88,38 @@ public class CouponTest {
         assertThatThrownBy(() -> coupon.changeStatus(CouponEvent.CANCEL, sender))
                 .isInstanceOf(ForbiddenException.class);
     }
+
+    @Test
+    void 보낸_사람은_REQUESTED_상태의_쿠폰에_대한_사용_요청_수락을_보낼_수_있다() {
+        Member sender = MemberFixture.ROOKIE;
+        Member receiver = MemberFixture.ARTHUR;
+        Coupon coupon = new Coupon(null, sender, receiver, "한턱쏘는", "추가 메세지", "#241223", CouponType.COFFEE,
+                CouponStatus.REQUESTED);
+
+        coupon.changeStatus(CouponEvent.ACCEPT, sender);
+
+        assertThat(coupon.getCouponStatus()).isEqualTo(CouponStatus.ACCEPTED);
+    }
+
+    @Test
+    void 보낸_사람은_READY_상태의_쿠폰에_대한_사용_요청_수락을_보낼_수_없다() {
+        Member sender = MemberFixture.ROOKIE;
+        Member receiver = MemberFixture.ARTHUR;
+        Coupon coupon = new Coupon(null, sender, receiver, "한턱쏘는", "추가 메세지", "#241223", CouponType.COFFEE,
+                CouponStatus.READY);
+
+        assertThatThrownBy(() -> coupon.changeStatus(CouponEvent.ACCEPT, sender))
+                .isInstanceOf(InvalidRequestException.class);
+    }
+
+    @Test
+    void 받은_사람은_쿠폰_사용_요청_수락을_보낼_수_없다() {
+        Member sender = MemberFixture.ROOKIE;
+        Member receiver = MemberFixture.ARTHUR;
+        Coupon coupon = new Coupon(null, sender, receiver, "한턱쏘는", "추가 메세지", "#241223", CouponType.COFFEE,
+                CouponStatus.REQUESTED);
+
+        assertThatThrownBy(() -> coupon.changeStatus(CouponEvent.ACCEPT, receiver))
+                .isInstanceOf(ForbiddenException.class);
+    }
 }


### PR DESCRIPTION
## 작업 내용

쿠폰 사용 요청을 수락하는 기능 구현

- CouponEvent enum에 ACCEPT 이벤트 추가
- CouponStatus enum에 ACCEPTED 상태 추가
- 쿠폰 사용 요청 수락에 대한 테스트 작성

## 공유사항

테스트는 우선 기존 틀에 맞춰서 작성했습니다.

Resolves #93 
