### PR TITLE
feat : 쿠폰 사용 요청 수락 API 구현

### DIFF
--- a/backend/src/main/java/com/woowacourse/kkogkkog/domain/CouponEvent.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/domain/CouponEvent.java
@@ -9,6 +9,7 @@ public enum CouponEvent {
     REQUEST(CouponEvent::canRequest),
     CANCEL(CouponEvent::canCancel),
     DECLINE(CouponEvent::canDecline),
+    ACCEPT(CouponEvent::canAccept)
     ;
 
     private final BiConsumer<Boolean, Boolean> canChange;
@@ -44,6 +45,12 @@ public enum CouponEvent {
     private static void canDecline(boolean isSender, boolean isReceiver) {
         if (!isSender) {
             throw new ForbiddenException("쿠폰을 보낸 사람만 사용 요청을 거절할 수 있습니다.");
+        }
+    }
+
+    private static void canAccept(boolean isSender, boolean isReceiver) {
+        if (!isSender) {
+            throw new ForbiddenException("쿠폰을 보낸 사람만 사용 승인을 할 수 있습니다.");
         }
     }
 }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/domain/CouponStatus.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/domain/CouponStatus.java
@@ -6,6 +6,7 @@ public enum CouponStatus {
 
     READY,
     REQUESTED,
+    ACCEPTED
     ;
 
     public CouponStatus handle(CouponEvent event) {
@@ -17,6 +18,9 @@ public enum CouponStatus {
         }
         if (event == CouponEvent.DECLINE) {
             return handleDecline();
+        }
+        if (event == CouponEvent.ACCEPT) {
+            return handleAccept();
         }
         throw new InvalidRequestException("처리할 수 없는 요청입니다.");
     }
@@ -40,5 +44,12 @@ public enum CouponStatus {
             throw new InvalidRequestException("사용 요청을 거절할 수 없는 상태의 쿠폰입니다.");
         }
         return READY;
+    }
+
+    private CouponStatus handleAccept() {
+        if (this != REQUESTED) {
+            throw new InvalidRequestException("사용 요청을 승인할 수 없는 상태의 쿠폰입니다.");
+        }
+        return ACCEPTED;
     }
 }

--- a/backend/src/test/java/com/woowacourse/kkogkkog/acceptance/CouponAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/acceptance/CouponAcceptanceTest.java
@@ -262,6 +262,35 @@ public class CouponAcceptanceTest extends AcceptanceTest {
             assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
         }
 
+        @Test
+        void 로그인된_사용자가_보낸_쿠폰에_대해_사용_요청을_받으면_요청을_승인할_수_있다() {
+            회원_가입에_성공한다(toMemberCreateRequest(JEONG));
+            회원_가입에_성공한다(toMemberCreateRequest(LEO));
+            String jeongAccessToken = 로그인에_성공한다(toTokenRequest(JEONG)).getAccessToken();
+            String leoAccessToken = 로그인에_성공한다(toTokenRequest(LEO)).getAccessToken();
+            쿠폰_발급에_성공한다(jeongAccessToken, List.of(LEO));
+            쿠폰_상태_변경을_요청한다(leoAccessToken, 1L, CouponEvent.REQUEST.name());
+
+            ExtractableResponse<Response> response = 쿠폰_상태_변경을_요청한다(jeongAccessToken, 1L,
+                CouponEvent.ACCEPT.name());
+
+            assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        }
+
+        @Test
+        void 쿠폰이_사용_준비_상태이면_사용_승인을_할_수_없다() {
+            회원_가입에_성공한다(toMemberCreateRequest(JEONG));
+            회원_가입에_성공한다(toMemberCreateRequest(LEO));
+            String jeongAccessToken = 로그인에_성공한다(toTokenRequest(JEONG)).getAccessToken();
+            로그인에_성공한다(toTokenRequest(LEO)).getAccessToken();
+            쿠폰_발급에_성공한다(jeongAccessToken, List.of(LEO));
+
+            ExtractableResponse<Response> response = 쿠폰_상태_변경을_요청한다(jeongAccessToken, 1L,
+                CouponEvent.ACCEPT.name());
+
+            assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+        }
+
         private ExtractableResponse<Response> 쿠폰_상태_변경을_요청한다(String accessToken,
                                                              Long couponId,
                                                              String couponEvent) {

--- a/backend/src/test/java/com/woowacourse/kkogkkog/application/CouponServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/application/CouponServiceTest.java
@@ -261,6 +261,39 @@ public class CouponServiceTest extends ServiceTest {
             assertThatThrownBy(() -> couponService.changeStatus(couponDecline))
                 .isInstanceOf(ForbiddenException.class);
         }
+
+        @Test
+        @DisplayName("보낸 사람은 REQUESTED 상태의 쿠폰에 대한 사용 요청을 승인할 수 있다.")
+        void accept() {
+            CouponSaveRequest couponSaveRequest = toCouponSaveRequest(ROOKIE, List.of(ARTHUR));
+            Long couponId = couponService.save(couponSaveRequest).get(0).getId();
+            CouponChangeStatusRequest couponRequest = new CouponChangeStatusRequest(ARTHUR.getId(),
+                couponId, CouponEvent.REQUEST);
+            couponService.changeStatus(couponRequest);
+
+            CouponChangeStatusRequest couponDecline = new CouponChangeStatusRequest(ROOKIE.getId(),
+                couponId, CouponEvent.ACCEPT);
+            couponService.changeStatus(couponDecline);
+
+            CouponResponse actual = couponService.findById(couponId);
+            assertThat(actual.getCouponStatus()).isEqualTo(CouponStatus.ACCEPTED.name());
+        }
+
+        @Test
+        @DisplayName("받은 사람은 쿠폰 사용 요청을 승인할 수 없다.")
+        void accept_receiverNotAllowed() {
+            CouponSaveRequest couponSaveRequest = toCouponSaveRequest(ROOKIE, List.of(ARTHUR));
+            Long couponId = couponService.save(couponSaveRequest).get(0).getId();
+            CouponChangeStatusRequest couponRequest = new CouponChangeStatusRequest(ARTHUR.getId(),
+                couponId, CouponEvent.REQUEST);
+            couponService.changeStatus(couponRequest);
+
+            CouponChangeStatusRequest couponDecline = new CouponChangeStatusRequest(ARTHUR.getId(),
+                couponId, CouponEvent.ACCEPT);
+
+            assertThatThrownBy(() -> couponService.changeStatus(couponDecline))
+                .isInstanceOf(ForbiddenException.class);
+        }
     }
 
     private CouponSaveRequest toCouponSaveRequest(Member sender, List<Member> receivers) {

--- a/backend/src/test/java/com/woowacourse/kkogkkog/domain/CouponEventTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/domain/CouponEventTest.java
@@ -16,7 +16,7 @@ class CouponEventTest {
         boolean isReceiver = true;
 
         assertThatNoException()
-                .isThrownBy(() -> CouponEvent.REQUEST.checkExecutable(isSender, isReceiver));
+            .isThrownBy(() -> CouponEvent.REQUEST.checkExecutable(isSender, isReceiver));
     }
 
     @Test
@@ -26,7 +26,7 @@ class CouponEventTest {
         boolean isReceiver = false;
 
         assertThatThrownBy(() -> CouponEvent.REQUEST.checkExecutable(isSender, isReceiver))
-                .isInstanceOf(ForbiddenException.class);
+            .isInstanceOf(ForbiddenException.class);
     }
 
     @Test
@@ -36,7 +36,7 @@ class CouponEventTest {
         boolean isReceiver = true;
 
         assertThatNoException()
-                .isThrownBy(() -> CouponEvent.CANCEL.checkExecutable(isSender, isReceiver));
+            .isThrownBy(() -> CouponEvent.CANCEL.checkExecutable(isSender, isReceiver));
     }
 
     @Test
@@ -46,7 +46,7 @@ class CouponEventTest {
         boolean isReceiver = false;
 
         assertThatThrownBy(() -> CouponEvent.CANCEL.checkExecutable(isSender, isReceiver))
-                .isInstanceOf(ForbiddenException.class);
+            .isInstanceOf(ForbiddenException.class);
     }
 
     @Test
@@ -66,6 +66,26 @@ class CouponEventTest {
         boolean isReceiver = true;
 
         assertThatThrownBy(() -> CouponEvent.DECLINE.checkExecutable(isSender, isReceiver))
+            .isInstanceOf(ForbiddenException.class);
+    }
+
+    @Test
+    @DisplayName("쿠폰을 보낸 사람만 사용 요청 승인을 할 수 있다.")
+    void senderCanExecute() {
+        boolean isSender = true;
+        boolean isReceiver = false;
+
+        assertThatNoException()
+            .isThrownBy(() -> CouponEvent.ACCEPT.checkExecutable(isSender, isReceiver));
+    }
+
+    @Test
+    @DisplayName("쿠폰을 받은 사람이 쿠폰 사용 요청 승인을 보내는 경우 예외가 발생한다.")
+    void senderCanNotAccept() {
+        boolean isSender = false;
+        boolean isReceiver = true;
+
+        assertThatThrownBy(() -> CouponEvent.ACCEPT.checkExecutable(isSender, isReceiver))
             .isInstanceOf(ForbiddenException.class);
     }
 }

--- a/backend/src/test/java/com/woowacourse/kkogkkog/domain/CouponStatusTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/domain/CouponStatusTest.java
@@ -74,4 +74,26 @@ class CouponStatusTest {
         assertThatThrownBy(() -> currentStatus.handle(event))
             .isInstanceOf(InvalidRequestException.class);
     }
+
+    @Test
+    @DisplayName("REQUESTED 상태의 쿠폰은 ACCEPT 이벤트를 받으면 ACCEPTED 상태로 변경된다.")
+    void requestedChangesToAcceptedOnAcceptEvent() {
+        CouponStatus currentStatus = CouponStatus.REQUESTED;
+        CouponEvent event = CouponEvent.ACCEPT;
+
+        CouponStatus actual = currentStatus.handle(event);
+        CouponStatus expected = CouponStatus.ACCEPTED;
+
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("READY 상태의 쿠폰은 ACCEPT 이벤트를 받으면 예외가 발생된다.")
+    void readyCanNotHandleAcceptEvent() {
+        CouponStatus currentStatus = CouponStatus.READY;
+        CouponEvent event = CouponEvent.ACCEPT;
+
+        assertThatThrownBy(() -> currentStatus.handle(event))
+            .isInstanceOf(InvalidRequestException.class);
+    }
 }


### PR DESCRIPTION
## 작업 내용

- 보낸 사람(Sender)이 쿠폰 사용 요청을 승인하는 기능 구현

  - CouponEvent ACCEPT, CouponStatus ACCEPTED 추가

## 공유사항

Resolves #93 
