### PR TITLE
feat : 쿠폰 사용 완료 API 구현

### DIFF
--- a/backend/src/main/java/com/woowacourse/kkogkkog/domain/CouponEvent.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/domain/CouponEvent.java
@@ -10,6 +10,7 @@ public enum CouponEvent {
     CANCEL(CouponEvent::canCancel),
     DECLINE(CouponEvent::canDecline),
     ACCEPT(CouponEvent::canAccept),
+    FINISH(CouponEvent::canFinish),
     ;
 
     private final BiConsumer<Boolean, Boolean> canChange;
@@ -52,5 +53,8 @@ public enum CouponEvent {
         if (!isSender) {
             throw new ForbiddenException("쿠폰을 보낸 사람만 사용 요청을 수락할 수 있습니다.");
         }
+    }
+
+    private static void canFinish(boolean isSender, boolean isReceiver) {
     }
 }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/domain/CouponEvent.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/domain/CouponEvent.java
@@ -56,5 +56,8 @@ public enum CouponEvent {
     }
 
     private static void canFinish(boolean isSender, boolean isReceiver) {
+        if (!isSender && !isReceiver) {
+            throw new ForbiddenException("쿠폰을 보낸 사람과 받은 사람만 사용 완료할 수 있습니다.");
+        }
     }
 }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/domain/CouponStatus.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/domain/CouponStatus.java
@@ -7,6 +7,7 @@ public enum CouponStatus {
     READY,
     REQUESTED,
     ACCEPTED,
+    FINISHED,
     ;
 
     public CouponStatus handle(CouponEvent event) {
@@ -21,6 +22,9 @@ public enum CouponStatus {
         }
         if (event == CouponEvent.ACCEPT) {
             return handleAccept();
+        }
+        if (event == CouponEvent.FINISH) {
+            return handleFinish();
         }
         throw new InvalidRequestException("처리할 수 없는 요청입니다.");
     }
@@ -51,5 +55,12 @@ public enum CouponStatus {
             throw new InvalidRequestException("사용 요청 상태의 쿠폰이 아닙니다.");
         }
         return ACCEPTED;
+    }
+
+    private CouponStatus handleFinish() {
+        if (this == FINISHED) {
+            throw new InvalidRequestException("이미 사용 완료 된 쿠폰입니다.");
+        }
+        return FINISHED;
     }
 }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/domain/CouponStatus.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/domain/CouponStatus.java
@@ -59,7 +59,7 @@ public enum CouponStatus {
 
     private CouponStatus handleFinish() {
         if (this == FINISHED) {
-            throw new InvalidRequestException("이미 사용 완료 된 쿠폰입니다.");
+            throw new InvalidRequestException("이미 사용 완료된 쿠폰입니다.");
         }
         return FINISHED;
     }

--- a/backend/src/test/java/com/woowacourse/kkogkkog/acceptance/CouponAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/acceptance/CouponAcceptanceTest.java
@@ -290,6 +290,127 @@ public class CouponAcceptanceTest extends AcceptanceTest {
             assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
         }
 
+        @Test
+        void 로그인된_사용자는_받은_쿠폰에_대해_사용_대기_상태이면_사용_완료를_할_수_있다() {
+            회원_가입에_성공한다(toMemberCreateRequest(JEONG));
+            회원_가입에_성공한다(toMemberCreateRequest(LEO));
+            String jeongAccessToken = 로그인에_성공한다(toTokenRequest(JEONG)).getAccessToken();
+            String leoAccessToken = 로그인에_성공한다(toTokenRequest(LEO)).getAccessToken();
+            쿠폰_발급에_성공한다(jeongAccessToken, List.of(LEO));
+
+            ExtractableResponse<Response> response = 쿠폰_상태_변경을_요청한다(leoAccessToken, 1L,
+                CouponEvent.FINISH.name());
+
+            assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        }
+        @Test
+        void 로그인된_사용자는_받은_쿠폰에_대해_사용_요청_상태이면_사용_완료를_할_수_있다() {
+            회원_가입에_성공한다(toMemberCreateRequest(JEONG));
+            회원_가입에_성공한다(toMemberCreateRequest(LEO));
+            String jeongAccessToken = 로그인에_성공한다(toTokenRequest(JEONG)).getAccessToken();
+            String leoAccessToken = 로그인에_성공한다(toTokenRequest(LEO)).getAccessToken();
+            쿠폰_발급에_성공한다(jeongAccessToken, List.of(LEO));
+
+            쿠폰_상태_변경을_요청한다(leoAccessToken, 1L, CouponEvent.REQUEST.name());
+            ExtractableResponse<Response> response = 쿠폰_상태_변경을_요청한다(leoAccessToken, 1L,
+                CouponEvent.FINISH.name());
+
+            assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        }
+
+        @Test
+        void 로그인된_사용자는_받은_쿠폰에_대해_사용_수락_상태이면_사용_완료를_할_수_있다() {
+            회원_가입에_성공한다(toMemberCreateRequest(JEONG));
+            회원_가입에_성공한다(toMemberCreateRequest(LEO));
+            String jeongAccessToken = 로그인에_성공한다(toTokenRequest(JEONG)).getAccessToken();
+            String leoAccessToken = 로그인에_성공한다(toTokenRequest(LEO)).getAccessToken();
+            쿠폰_발급에_성공한다(jeongAccessToken, List.of(LEO));
+
+            쿠폰_상태_변경을_요청한다(leoAccessToken, 1L, CouponEvent.REQUEST.name());
+            쿠폰_상태_변경을_요청한다(jeongAccessToken, 1L, CouponEvent.ACCEPT.name());
+            ExtractableResponse<Response> response = 쿠폰_상태_변경을_요청한다(leoAccessToken, 1L,
+                CouponEvent.FINISH.name());
+
+            assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        }
+
+        @Test
+        void 받은_쿠폰에_대해_사용_완료_상태이면_사용_완료를_할_수_없다() {
+            회원_가입에_성공한다(toMemberCreateRequest(JEONG));
+            회원_가입에_성공한다(toMemberCreateRequest(LEO));
+            String jeongAccessToken = 로그인에_성공한다(toTokenRequest(JEONG)).getAccessToken();
+            String leoAccessToken = 로그인에_성공한다(toTokenRequest(LEO)).getAccessToken();
+            쿠폰_발급에_성공한다(jeongAccessToken, List.of(LEO));
+
+            쿠폰_상태_변경을_요청한다(leoAccessToken, 1L, CouponEvent.REQUEST.name());
+            쿠폰_상태_변경을_요청한다(jeongAccessToken, 1L, CouponEvent.ACCEPT.name());
+            쿠폰_상태_변경을_요청한다(leoAccessToken, 1L, CouponEvent.FINISH.name());
+            ExtractableResponse<Response> response = 쿠폰_상태_변경을_요청한다(leoAccessToken, 1L,
+                CouponEvent.FINISH.name());
+
+            assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+        }
+
+        @Test
+        void 로그인된_사용자는_보낸_쿠폰에_대해_사용_대기_상태이면_사용_완료를_할_수_있다() {
+            회원_가입에_성공한다(toMemberCreateRequest(JEONG));
+            회원_가입에_성공한다(toMemberCreateRequest(LEO));
+            String jeongAccessToken = 로그인에_성공한다(toTokenRequest(JEONG)).getAccessToken();
+            쿠폰_발급에_성공한다(jeongAccessToken, List.of(LEO));
+
+            ExtractableResponse<Response> response = 쿠폰_상태_변경을_요청한다(jeongAccessToken, 1L,
+                CouponEvent.FINISH.name());
+
+            assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        }
+        @Test
+        void 로그인된_사용자는_보낸_쿠폰에_대해_사용_요청_상태이면_사용_완료를_할_수_있다() {
+            회원_가입에_성공한다(toMemberCreateRequest(JEONG));
+            회원_가입에_성공한다(toMemberCreateRequest(LEO));
+            String jeongAccessToken = 로그인에_성공한다(toTokenRequest(JEONG)).getAccessToken();
+            String leoAccessToken = 로그인에_성공한다(toTokenRequest(LEO)).getAccessToken();
+            쿠폰_발급에_성공한다(jeongAccessToken, List.of(LEO));
+
+            쿠폰_상태_변경을_요청한다(leoAccessToken, 1L, CouponEvent.REQUEST.name());
+            ExtractableResponse<Response> response = 쿠폰_상태_변경을_요청한다(jeongAccessToken, 1L,
+                CouponEvent.FINISH.name());
+
+            assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        }
+
+        @Test
+        void 로그인된_사용자는_보낸_쿠폰에_대해_사용_수락_상태이면_사용_완료를_할_수_있다() {
+            회원_가입에_성공한다(toMemberCreateRequest(JEONG));
+            회원_가입에_성공한다(toMemberCreateRequest(LEO));
+            String jeongAccessToken = 로그인에_성공한다(toTokenRequest(JEONG)).getAccessToken();
+            String leoAccessToken = 로그인에_성공한다(toTokenRequest(LEO)).getAccessToken();
+            쿠폰_발급에_성공한다(jeongAccessToken, List.of(LEO));
+
+            쿠폰_상태_변경을_요청한다(leoAccessToken, 1L, CouponEvent.REQUEST.name());
+            쿠폰_상태_변경을_요청한다(jeongAccessToken, 1L, CouponEvent.ACCEPT.name());
+            ExtractableResponse<Response> response = 쿠폰_상태_변경을_요청한다(jeongAccessToken, 1L,
+                CouponEvent.FINISH.name());
+
+            assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        }
+
+        @Test
+        void 보낸_쿠폰에_대해_사용_완료_상태이면_사용_완료를_할_수_없다() {
+            회원_가입에_성공한다(toMemberCreateRequest(JEONG));
+            회원_가입에_성공한다(toMemberCreateRequest(LEO));
+            String jeongAccessToken = 로그인에_성공한다(toTokenRequest(JEONG)).getAccessToken();
+            String leoAccessToken = 로그인에_성공한다(toTokenRequest(LEO)).getAccessToken();
+            쿠폰_발급에_성공한다(jeongAccessToken, List.of(LEO));
+
+            쿠폰_상태_변경을_요청한다(leoAccessToken, 1L, CouponEvent.REQUEST.name());
+            쿠폰_상태_변경을_요청한다(jeongAccessToken, 1L, CouponEvent.ACCEPT.name());
+            쿠폰_상태_변경을_요청한다(jeongAccessToken, 1L, CouponEvent.FINISH.name());
+            ExtractableResponse<Response> response = 쿠폰_상태_변경을_요청한다(jeongAccessToken, 1L,
+                CouponEvent.FINISH.name());
+
+            assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+        }
+
         private ExtractableResponse<Response> 쿠폰_상태_변경을_요청한다(String accessToken,
                                                              Long couponId,
                                                              String couponEvent) {

--- a/backend/src/test/java/com/woowacourse/kkogkkog/domain/CouponEventTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/domain/CouponEventTest.java
@@ -88,4 +88,24 @@ class CouponEventTest {
         assertThatThrownBy(() -> CouponEvent.ACCEPT.checkExecutable(isSender, isReceiver))
                 .isInstanceOf(ForbiddenException.class);
     }
+
+    @Test
+    @DisplayName("쿠폰을 보낸 사람이 사용 완료를 할 수 있다")
+    void senderCanFinish() {
+        boolean isSender = true;
+        boolean isReceiver = false;
+
+        assertThatNoException()
+            .isThrownBy(() -> CouponEvent.FINISH.checkExecutable(isSender, isReceiver));
+    }
+
+    @Test
+    @DisplayName("쿠폰을 받은 사람이 사용 완료를 할 수 있다")
+    void receiverCanFinish() {
+        boolean isSender = false;
+        boolean isReceiver = true;
+
+        assertThatNoException()
+            .isThrownBy(() -> CouponEvent.FINISH.checkExecutable(isSender, isReceiver));
+    }
 }

--- a/backend/src/test/java/com/woowacourse/kkogkkog/domain/CouponEventTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/domain/CouponEventTest.java
@@ -108,4 +108,14 @@ class CouponEventTest {
         assertThatNoException()
             .isThrownBy(() -> CouponEvent.FINISH.checkExecutable(isSender, isReceiver));
     }
+
+    @Test
+    @DisplayName("쿠폰을 보내거나 받지 않은 사람이 쿠폰 사용 완료를 보내는 경우 예외가 발생한다.")
+    void otherCanNotFinish() {
+        boolean isSender = false;
+        boolean isReceiver = false;
+
+        assertThatThrownBy(() -> CouponEvent.FINISH.checkExecutable(isSender, isReceiver))
+            .isInstanceOf(ForbiddenException.class);
+    }
 }

--- a/backend/src/test/java/com/woowacourse/kkogkkog/domain/CouponStatusTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/domain/CouponStatusTest.java
@@ -96,4 +96,50 @@ class CouponStatusTest {
         assertThatThrownBy(() -> currentStatus.handle(event))
                 .isInstanceOf(InvalidRequestException.class);
     }
+
+    @Test
+    @DisplayName("READY 상태의 쿠폰은 FINISH 이벤트를 받으면 FINISHED 상태로 변경된다.")
+    void readyChangesToFinishOnFinishedEvent() {
+        CouponStatus currentStatus = CouponStatus.READY;
+        CouponEvent event = CouponEvent.FINISH;
+
+        CouponStatus actual = currentStatus.handle(event);
+        CouponStatus expected = CouponStatus.FINISHED;
+
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("REQUESTED 상태의 쿠폰은 FINISH 이벤트를 받으면 FINISHED 상태로 변경된다.")
+    void requestedChangesToFinishOnFinishedEvent() {
+        CouponStatus currentStatus = CouponStatus.REQUESTED;
+        CouponEvent event = CouponEvent.FINISH;
+
+        CouponStatus actual = currentStatus.handle(event);
+        CouponStatus expected = CouponStatus.FINISHED;
+
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("ACCEPTED 상태의 쿠폰은 FINISH 이벤트를 받으면 FINISHED 상태로 변경된다.")
+    void acceptedChangesToFinishOnFinishedEvent() {
+        CouponStatus currentStatus = CouponStatus.ACCEPTED;
+        CouponEvent event = CouponEvent.FINISH;
+
+        CouponStatus actual = currentStatus.handle(event);
+        CouponStatus expected = CouponStatus.FINISHED;
+
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("FINISHED 상태의 쿠폰은 FINISH 이벤트를 받으면 예외가 발생된다.")
+    void finishedCanNotHandleFinishEvent() {
+        CouponStatus currentStatus = CouponStatus.FINISHED;
+        CouponEvent event = CouponEvent.FINISH;
+
+        assertThatThrownBy(() -> currentStatus.handle(event))
+            .isInstanceOf(InvalidRequestException.class);
+    }
 }

--- a/backend/src/test/java/com/woowacourse/kkogkkog/domain/CouponTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/domain/CouponTest.java
@@ -129,9 +129,7 @@ public class CouponTest {
 
     @ParameterizedTest
     @MethodSource("provideSenderAndReceiver")
-    void READY_상태의_쿠폰에_대한_사용_완료를_보낼_수_있다(Member requester) {
-        Member sender = MemberFixture.ROOKIE;
-        Member receiver = MemberFixture.ARTHUR;
+    void READY_상태의_쿠폰에_대한_사용_완료를_보낼_수_있다(Member sender, Member receiver, Member requester) {
         Coupon coupon = new Coupon(null, sender, receiver, "한턱쏘는", "추가 메세지", "#241223", CouponType.COFFEE,
             CouponStatus.READY);
 
@@ -142,9 +140,7 @@ public class CouponTest {
 
     @ParameterizedTest
     @MethodSource("provideSenderAndReceiver")
-    void REQUESTED_상태의_쿠폰에_대한_사용_완료를_보낼_수_있다(Member requester) {
-        Member sender = MemberFixture.ROOKIE;
-        Member receiver = MemberFixture.ARTHUR;
+    void REQUESTED_상태의_쿠폰에_대한_사용_완료를_보낼_수_있다(Member sender, Member receiver, Member requester) {
         Coupon coupon = new Coupon(null, sender, receiver, "한턱쏘는", "추가 메세지", "#241223", CouponType.COFFEE,
             CouponStatus.REQUESTED);
 
@@ -172,6 +168,18 @@ public class CouponTest {
 
         assertThatThrownBy(() -> coupon.changeStatus(CouponEvent.FINISH, requester))
             .isInstanceOf(InvalidRequestException.class);
+    }
+
+    @Test
+    void 보낸_사람과_받은_사람이_아니면_FINISHED_상태의_쿠폰에_대한_사용_완료를_보낼_수_없다() {
+        Member sender = MemberFixture.ROOKIE;
+        Member receiver = MemberFixture.ARTHUR;
+        Member requester = MemberFixture.JEONG;
+        Coupon coupon = new Coupon(null, sender, receiver, "한턱쏘는", "추가 메세지", "#241223", CouponType.COFFEE,
+            CouponStatus.READY);
+
+        assertThatThrownBy(() -> coupon.changeStatus(CouponEvent.ACCEPT, requester))
+            .isInstanceOf(ForbiddenException.class);
     }
 
     public static Stream<Arguments> provideSenderAndReceiver() {

--- a/backend/src/test/java/com/woowacourse/kkogkkog/domain/CouponTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/domain/CouponTest.java
@@ -122,4 +122,98 @@ public class CouponTest {
         assertThatThrownBy(() -> coupon.changeStatus(CouponEvent.ACCEPT, receiver))
                 .isInstanceOf(ForbiddenException.class);
     }
+
+    @Test
+    void 받은_사람은_READY_상태의_쿠폰에_대한_사용_완료를_보낼_수_있다() {
+        Member sender = MemberFixture.ROOKIE;
+        Member receiver = MemberFixture.ARTHUR;
+        Coupon coupon = new Coupon(null, sender, receiver, "한턱쏘는", "추가 메세지", "#241223", CouponType.COFFEE,
+            CouponStatus.READY);
+
+        coupon.changeStatus(CouponEvent.FINISH, receiver);
+
+        assertThat(coupon.getCouponStatus()).isEqualTo(CouponStatus.FINISHED);
+    }
+
+    @Test
+    void 받은_사람은_REQUESTED_상태의_쿠폰에_대한_사용_완료를_보낼_수_있다() {
+        Member sender = MemberFixture.ROOKIE;
+        Member receiver = MemberFixture.ARTHUR;
+        Coupon coupon = new Coupon(null, sender, receiver, "한턱쏘는", "추가 메세지", "#241223", CouponType.COFFEE,
+            CouponStatus.REQUESTED);
+
+        coupon.changeStatus(CouponEvent.FINISH, receiver);
+
+        assertThat(coupon.getCouponStatus()).isEqualTo(CouponStatus.FINISHED);
+    }
+
+    @Test
+    void 받은_사람은_ACCEPTED_상태의_쿠폰에_대한_사용_완료를_보낼_수_있다() {
+        Member sender = MemberFixture.ROOKIE;
+        Member receiver = MemberFixture.ARTHUR;
+        Coupon coupon = new Coupon(null, sender, receiver, "한턱쏘는", "추가 메세지", "#241223", CouponType.COFFEE,
+            CouponStatus.ACCEPTED);
+
+        coupon.changeStatus(CouponEvent.FINISH, receiver);
+
+        assertThat(coupon.getCouponStatus()).isEqualTo(CouponStatus.FINISHED);
+    }
+
+    @Test
+    void 받은_사람은_FINISHED_상태의_쿠폰에_대한_사용_완료를_보낼_수_없다() {
+        Member sender = MemberFixture.ROOKIE;
+        Member receiver = MemberFixture.ARTHUR;
+        Coupon coupon = new Coupon(null, sender, receiver, "한턱쏘는", "추가 메세지", "#241223", CouponType.COFFEE,
+            CouponStatus.FINISHED);
+
+        assertThatThrownBy(() -> coupon.changeStatus(CouponEvent.FINISH, receiver))
+            .isInstanceOf(InvalidRequestException.class);
+    }
+
+    @Test
+    void 보낸_사람은_READY_상태의_쿠폰에_대한_사용_완료를_보낼_수_있다() {
+        Member sender = MemberFixture.ROOKIE;
+        Member receiver = MemberFixture.ARTHUR;
+        Coupon coupon = new Coupon(null, sender, receiver, "한턱쏘는", "추가 메세지", "#241223", CouponType.COFFEE,
+            CouponStatus.READY);
+
+        coupon.changeStatus(CouponEvent.FINISH, sender);
+
+        assertThat(coupon.getCouponStatus()).isEqualTo(CouponStatus.FINISHED);
+    }
+
+    @Test
+    void 보낸_사람은_REQUESTED_상태의_쿠폰에_대한_사용_완료를_보낼_수_있다() {
+        Member sender = MemberFixture.ROOKIE;
+        Member receiver = MemberFixture.ARTHUR;
+        Coupon coupon = new Coupon(null, sender, receiver, "한턱쏘는", "추가 메세지", "#241223", CouponType.COFFEE,
+            CouponStatus.REQUESTED);
+
+        coupon.changeStatus(CouponEvent.FINISH, sender);
+
+        assertThat(coupon.getCouponStatus()).isEqualTo(CouponStatus.FINISHED);
+    }
+
+    @Test
+    void 보낸_사람은_ACCEPTED_상태의_쿠폰에_대한_사용_완료를_보낼_수_있다() {
+        Member sender = MemberFixture.ROOKIE;
+        Member receiver = MemberFixture.ARTHUR;
+        Coupon coupon = new Coupon(null, sender, receiver, "한턱쏘는", "추가 메세지", "#241223", CouponType.COFFEE,
+            CouponStatus.ACCEPTED);
+
+        coupon.changeStatus(CouponEvent.FINISH, sender);
+
+        assertThat(coupon.getCouponStatus()).isEqualTo(CouponStatus.FINISHED);
+    }
+
+    @Test
+    void 보낸_사람은_FINISHED_상태의_쿠폰에_대한_사용_완료를_보낼_수_없다() {
+        Member sender = MemberFixture.ROOKIE;
+        Member receiver = MemberFixture.ARTHUR;
+        Coupon coupon = new Coupon(null, sender, receiver, "한턱쏘는", "추가 메세지", "#241223", CouponType.COFFEE,
+            CouponStatus.FINISHED);
+
+        assertThatThrownBy(() -> coupon.changeStatus(CouponEvent.FINISH, sender))
+            .isInstanceOf(InvalidRequestException.class);
+    }
 }

--- a/backend/src/test/java/com/woowacourse/kkogkkog/domain/CouponTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/domain/CouponTest.java
@@ -7,7 +7,11 @@ import com.woowacourse.kkogkkog.exception.ForbiddenException;
 import com.woowacourse.kkogkkog.exception.InvalidRequestException;
 import com.woowacourse.kkogkkog.exception.coupon.SameSenderReceiverException;
 import com.woowacourse.kkogkkog.fixture.MemberFixture;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 @SuppressWarnings("NonAsciiCharacters")
 public class CouponTest {
@@ -123,97 +127,57 @@ public class CouponTest {
                 .isInstanceOf(ForbiddenException.class);
     }
 
-    @Test
-    void 받은_사람은_READY_상태의_쿠폰에_대한_사용_완료를_보낼_수_있다() {
+    @ParameterizedTest
+    @MethodSource("provideSenderAndReceiver")
+    void READY_상태의_쿠폰에_대한_사용_완료를_보낼_수_있다(Member requester) {
         Member sender = MemberFixture.ROOKIE;
         Member receiver = MemberFixture.ARTHUR;
         Coupon coupon = new Coupon(null, sender, receiver, "한턱쏘는", "추가 메세지", "#241223", CouponType.COFFEE,
             CouponStatus.READY);
 
-        coupon.changeStatus(CouponEvent.FINISH, receiver);
+        coupon.changeStatus(CouponEvent.FINISH, requester);
 
         assertThat(coupon.getCouponStatus()).isEqualTo(CouponStatus.FINISHED);
     }
 
-    @Test
-    void 받은_사람은_REQUESTED_상태의_쿠폰에_대한_사용_완료를_보낼_수_있다() {
+    @ParameterizedTest
+    @MethodSource("provideSenderAndReceiver")
+    void REQUESTED_상태의_쿠폰에_대한_사용_완료를_보낼_수_있다(Member requester) {
         Member sender = MemberFixture.ROOKIE;
         Member receiver = MemberFixture.ARTHUR;
         Coupon coupon = new Coupon(null, sender, receiver, "한턱쏘는", "추가 메세지", "#241223", CouponType.COFFEE,
             CouponStatus.REQUESTED);
 
-        coupon.changeStatus(CouponEvent.FINISH, receiver);
+        coupon.changeStatus(CouponEvent.FINISH, requester);
 
         assertThat(coupon.getCouponStatus()).isEqualTo(CouponStatus.FINISHED);
     }
 
-    @Test
-    void 받은_사람은_ACCEPTED_상태의_쿠폰에_대한_사용_완료를_보낼_수_있다() {
-        Member sender = MemberFixture.ROOKIE;
-        Member receiver = MemberFixture.ARTHUR;
+    @ParameterizedTest
+    @MethodSource("provideSenderAndReceiver")
+    void ACCEPTED_상태의_쿠폰에_대한_사용_완료를_보낼_수_있다(Member sender, Member receiver, Member requester) {
         Coupon coupon = new Coupon(null, sender, receiver, "한턱쏘는", "추가 메세지", "#241223", CouponType.COFFEE,
             CouponStatus.ACCEPTED);
 
-        coupon.changeStatus(CouponEvent.FINISH, receiver);
+        coupon.changeStatus(CouponEvent.FINISH, requester);
 
         assertThat(coupon.getCouponStatus()).isEqualTo(CouponStatus.FINISHED);
     }
 
-    @Test
-    void 받은_사람은_FINISHED_상태의_쿠폰에_대한_사용_완료를_보낼_수_없다() {
-        Member sender = MemberFixture.ROOKIE;
-        Member receiver = MemberFixture.ARTHUR;
+    @ParameterizedTest
+    @MethodSource("provideSenderAndReceiver")
+    void FINISHED_상태의_쿠폰에_대한_사용_완료를_보낼_수_없다(Member sender, Member receiver, Member requester) {
         Coupon coupon = new Coupon(null, sender, receiver, "한턱쏘는", "추가 메세지", "#241223", CouponType.COFFEE,
             CouponStatus.FINISHED);
 
-        assertThatThrownBy(() -> coupon.changeStatus(CouponEvent.FINISH, receiver))
+        assertThatThrownBy(() -> coupon.changeStatus(CouponEvent.FINISH, requester))
             .isInstanceOf(InvalidRequestException.class);
     }
 
-    @Test
-    void 보낸_사람은_READY_상태의_쿠폰에_대한_사용_완료를_보낼_수_있다() {
-        Member sender = MemberFixture.ROOKIE;
-        Member receiver = MemberFixture.ARTHUR;
-        Coupon coupon = new Coupon(null, sender, receiver, "한턱쏘는", "추가 메세지", "#241223", CouponType.COFFEE,
-            CouponStatus.READY);
-
-        coupon.changeStatus(CouponEvent.FINISH, sender);
-
-        assertThat(coupon.getCouponStatus()).isEqualTo(CouponStatus.FINISHED);
-    }
-
-    @Test
-    void 보낸_사람은_REQUESTED_상태의_쿠폰에_대한_사용_완료를_보낼_수_있다() {
-        Member sender = MemberFixture.ROOKIE;
-        Member receiver = MemberFixture.ARTHUR;
-        Coupon coupon = new Coupon(null, sender, receiver, "한턱쏘는", "추가 메세지", "#241223", CouponType.COFFEE,
-            CouponStatus.REQUESTED);
-
-        coupon.changeStatus(CouponEvent.FINISH, sender);
-
-        assertThat(coupon.getCouponStatus()).isEqualTo(CouponStatus.FINISHED);
-    }
-
-    @Test
-    void 보낸_사람은_ACCEPTED_상태의_쿠폰에_대한_사용_완료를_보낼_수_있다() {
-        Member sender = MemberFixture.ROOKIE;
-        Member receiver = MemberFixture.ARTHUR;
-        Coupon coupon = new Coupon(null, sender, receiver, "한턱쏘는", "추가 메세지", "#241223", CouponType.COFFEE,
-            CouponStatus.ACCEPTED);
-
-        coupon.changeStatus(CouponEvent.FINISH, sender);
-
-        assertThat(coupon.getCouponStatus()).isEqualTo(CouponStatus.FINISHED);
-    }
-
-    @Test
-    void 보낸_사람은_FINISHED_상태의_쿠폰에_대한_사용_완료를_보낼_수_없다() {
-        Member sender = MemberFixture.ROOKIE;
-        Member receiver = MemberFixture.ARTHUR;
-        Coupon coupon = new Coupon(null, sender, receiver, "한턱쏘는", "추가 메세지", "#241223", CouponType.COFFEE,
-            CouponStatus.FINISHED);
-
-        assertThatThrownBy(() -> coupon.changeStatus(CouponEvent.FINISH, sender))
-            .isInstanceOf(InvalidRequestException.class);
+    public static Stream<Arguments> provideSenderAndReceiver() {
+        return Stream.of(
+            Arguments.of(MemberFixture.ROOKIE,MemberFixture.ARTHUR,MemberFixture.ROOKIE),
+            Arguments.of(MemberFixture.ROOKIE,MemberFixture.ARTHUR,MemberFixture.ARTHUR)
+        );
     }
 }


### PR DESCRIPTION
## 작업 내용

- 보낸 사람(Sender)과 받은 사람(Receiver)이 쿠폰 사용을 완료하는 기능 구현

## 공유사항

- CouponTest는 보낸 사람과 받은 사람 모든 경우 구현
- CouponTest 구현하다 어느정도 테스트 해야될까 아서와 이야기했습니다. 그래서 CouponServiceTest는 보낸 사람일 경우의 테스트만 구현해 봤습니다. 의견 남겨주시면 감사하겠습니다.

Resolves #109 
