### PR TITLE
config: 깃헙 액션을 통해 PR에 대해 CI 설정 

### DIFF
--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+      - develop
+    types: [opened, reopened]
+
+jobs:
+  backend:
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: ./backend
+
+    steps:
+      - name: Checkout 2022-kkogkkog repository
+        uses: actions/checkout@v3
+      - name: Set up JDK 11 on runner
+        uses: actions/setup-java@v3
+        with:
+          java-version: "11"
+          distribution: "adopt"
+      - name: Test & Build with gradle
+        run: ./gradlew build

--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -8,6 +8,25 @@ on:
     types: [opened, reopened]
 
 jobs:
+  frontend:
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: ./frontend
+
+    steps:
+      - name: Checkout 2022-kkogkkog repository
+        uses: actions/checkout@v3
+      - name: Setup Node.js on runner
+        uses: actions/setup-node@v2
+        with:
+          node-version: "16.1.0"
+      - name: Install yarn dependencies
+        run: yarn
+      - name: yarn build
+        run: yarn build
+
   backend:
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
## 작업 내용

최소한의 CI 과정을 추가하였습니다.

PR이 생성되는 시점에 두 가지 job이 실행되도록 설정하였습니다. frontend 디렉토리의 프로젝트에 대해 `yarn build`를 실행하고, backend 디렉토리의 프로젝트에 대해서는 `./gradlew build`를 실행합니다.

## 공유사항

예를 들어, 해당 yml 파일이 main 브랜치에 머지된 상태에서 main 브랜치에 대한 PR이 생성되었을 때, PR 하단에 아래와 같은 내용이 돌아갈 것입니다.

<img width="486" alt="스크린샷 2022-07-27 오후 5 22 19" src="https://user-images.githubusercontent.com/73531614/181200663-bcb2baed-2ba3-481b-b55b-367700710c1e.png">

해당 깃헙 액션이 성공하면 PR 옆에 아래와 같이 녹색 체크가 표시될 것입니다.

<img width="309" alt="image" src="https://user-images.githubusercontent.com/73531614/181200801-e7a63912-ea0c-4141-a410-c26cd4bb0a45.png">

실행되면서 출력되는 로그는 Actions 탭에서 확인할 수 있습니다.

<img width="762" alt="image" src="https://user-images.githubusercontent.com/73531614/181200973-ca48a5a1-9405-4afc-bd78-617e52ca8556.png">

슬랙 깃헙봇에서도 다음과 같이 표시됩니다.

<img width="340" alt="image" src="https://user-images.githubusercontent.com/73531614/181201709-c7feb26b-6b61-4759-9644-e58200ab951c.png">

Resolves #123