### PR TITLE
feat: 쿠폰 사용 요청 및 조회시 날짜를 추가하는 기능

### DIFF
--- a/backend/src/main/java/com/woowacourse/kkogkkog/application/CouponService.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/application/CouponService.java
@@ -4,11 +4,13 @@ import com.woowacourse.kkogkkog.application.dto.CouponChangeStatusRequest;
 import com.woowacourse.kkogkkog.application.dto.CouponResponse;
 import com.woowacourse.kkogkkog.application.dto.CouponSaveRequest;
 import com.woowacourse.kkogkkog.domain.Coupon;
+import com.woowacourse.kkogkkog.domain.CouponEvent;
 import com.woowacourse.kkogkkog.domain.CouponStatus;
 import com.woowacourse.kkogkkog.domain.CouponType;
 import com.woowacourse.kkogkkog.domain.Member;
 import com.woowacourse.kkogkkog.domain.repository.CouponRepository;
 import com.woowacourse.kkogkkog.domain.repository.MemberRepository;
+import com.woowacourse.kkogkkog.exception.InvalidRequestException;
 import com.woowacourse.kkogkkog.exception.coupon.CouponNotFoundException;
 import com.woowacourse.kkogkkog.exception.member.MemberNotFoundException;
 import java.util.List;
@@ -85,6 +87,13 @@ public class CouponService {
         Member loginMember = findMember(couponChangeStatusRequest.getLoginMemberId());
         Coupon coupon = findCoupon(couponChangeStatusRequest.getCouponId());
         coupon.changeStatus(couponChangeStatusRequest.getEvent(), loginMember);
+
+        if (couponChangeStatusRequest.getEvent() == CouponEvent.REQUEST) {
+            if (couponChangeStatusRequest.getMeetingDate() == null) {
+                throw new InvalidRequestException("사용요청을 보낼땐 약속날짜가 필요합니다.");
+            }
+            coupon.updateMeetingDate(couponChangeStatusRequest.getMeetingDate());
+        }
     }
 
     private Member findMember(Long memberId) {

--- a/backend/src/main/java/com/woowacourse/kkogkkog/application/dto/CouponChangeStatusRequest.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/application/dto/CouponChangeStatusRequest.java
@@ -1,6 +1,7 @@
 package com.woowacourse.kkogkkog.application.dto;
 
 import com.woowacourse.kkogkkog.domain.CouponEvent;
+import java.time.LocalDate;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,10 +13,19 @@ public class CouponChangeStatusRequest {
     private Long loginMemberId;
     private Long couponId;
     private CouponEvent event;
+    private LocalDate meetingDate;
 
     public CouponChangeStatusRequest(Long loginMemberId, Long couponId, CouponEvent event) {
         this.loginMemberId = loginMemberId;
         this.couponId = couponId;
         this.event = event;
+    }
+
+    public CouponChangeStatusRequest(Long loginMemberId, Long couponId, CouponEvent event,
+                                     LocalDate meetingDate) {
+        this.loginMemberId = loginMemberId;
+        this.couponId = couponId;
+        this.event = event;
+        this.meetingDate = meetingDate;
     }
 }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/application/dto/CouponResponse.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/application/dto/CouponResponse.java
@@ -1,6 +1,9 @@
 package com.woowacourse.kkogkkog.application.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonFormat.Shape;
 import com.woowacourse.kkogkkog.domain.Coupon;
+import java.time.LocalDate;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,6 +16,8 @@ public class CouponResponse {
     private CouponMemberResponse sender;
     private CouponMemberResponse receiver;
     private String modifier;
+    @JsonFormat(shape = Shape.STRING, pattern = "yyyy-MM-dd")
+    private LocalDate meetingDate;
     private String message;
     private String backgroundColor;
     private String couponType;
@@ -31,12 +36,28 @@ public class CouponResponse {
         this.couponStatus = couponStatus;
     }
 
+    public CouponResponse(Long id, CouponMemberResponse sender,
+                          CouponMemberResponse receiver, String modifier,
+                          LocalDate meetingDate, String message, String backgroundColor,
+                          String couponType, String couponStatus) {
+        this.id = id;
+        this.sender = sender;
+        this.receiver = receiver;
+        this.modifier = modifier;
+        this.meetingDate = meetingDate;
+        this.message = message;
+        this.backgroundColor = backgroundColor;
+        this.couponType = couponType;
+        this.couponStatus = couponStatus;
+    }
+
     public static CouponResponse of(Coupon coupon) {
         return new CouponResponse(
             coupon.getId(),
             CouponMemberResponse.of(coupon.getSender()),
             CouponMemberResponse.of(coupon.getReceiver()),
             coupon.getModifier(),
+            coupon.getMeetingDate(),
             coupon.getMessage(),
             coupon.getBackgroundColor(),
             coupon.getCouponType().name(),

--- a/backend/src/main/java/com/woowacourse/kkogkkog/config/InterceptorConfig.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/config/InterceptorConfig.java
@@ -20,6 +20,7 @@ public class InterceptorConfig implements WebMvcConfigurer {
         registry.addInterceptor(new LoginInterceptor(jwtTokenProvider))
             .addPathPatterns("/api/members/me")
             .addPathPatterns("/api/coupons")
-            .addPathPatterns("/api/coupons/*/event");
+            .addPathPatterns("/api/coupons/*/event")
+            .addPathPatterns("/api/coupons/*/event/*");
     }
 }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/domain/Coupon.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/domain/Coupon.java
@@ -1,6 +1,7 @@
 package com.woowacourse.kkogkkog.domain;
 
 import com.woowacourse.kkogkkog.exception.coupon.SameSenderReceiverException;
+import java.time.LocalDate;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -48,6 +49,9 @@ public class Coupon {
     @Column(nullable = false)
     private CouponStatus couponStatus;
 
+    @Column
+    private LocalDate meetingDate;
+
     public Coupon(Member sender, Member receiver, String modifier, String message,
                   String backgroundColor,
                   CouponType couponType, CouponStatus couponStatus) {
@@ -76,5 +80,9 @@ public class Coupon {
     public void changeStatus(CouponEvent event, Member member) {
         event.checkExecutable(sender.equals(member), receiver.equals(member));
         this.couponStatus = couponStatus.handle(event);
+    }
+
+    public void updateMeetingDate(LocalDate meetingTime) {
+        this.meetingDate = meetingTime;
     }
 }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/domain/Coupon.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/domain/Coupon.java
@@ -71,6 +71,20 @@ public class Coupon {
         this.couponStatus = couponStatus;
     }
 
+    public Coupon(Long id, Member sender, Member receiver, String modifier, String message,
+                  String backgroundColor, CouponType couponType,
+                  CouponStatus couponStatus, LocalDate meetingDate) {
+        this.id = id;
+        this.sender = sender;
+        this.receiver = receiver;
+        this.modifier = modifier;
+        this.message = message;
+        this.backgroundColor = backgroundColor;
+        this.couponType = couponType;
+        this.couponStatus = couponStatus;
+        this.meetingDate = meetingDate;
+    }
+
     private void validateSameMember(Member sender, Member receiver) {
         if (sender.equals(receiver)) {
             throw new SameSenderReceiverException();

--- a/backend/src/main/java/com/woowacourse/kkogkkog/presentation/CouponController.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/presentation/CouponController.java
@@ -4,6 +4,7 @@ import com.woowacourse.kkogkkog.application.CouponService;
 import com.woowacourse.kkogkkog.application.dto.CouponResponse;
 import com.woowacourse.kkogkkog.presentation.dto.CouponCreateRequest;
 import com.woowacourse.kkogkkog.presentation.dto.CouponEventRequest;
+import com.woowacourse.kkogkkog.presentation.dto.CouponRequestEventRequest;
 import com.woowacourse.kkogkkog.presentation.dto.MyCouponsResponse;
 import com.woowacourse.kkogkkog.presentation.dto.SuccessResponse;
 import java.util.List;
@@ -56,6 +57,16 @@ public class CouponController {
                                        @RequestBody CouponEventRequest couponEventRequest) {
         couponService.changeStatus(
             couponEventRequest.toCouponChangeStatusRequest(loginMemberId, couponId));
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/{couponId}/event/request")
+    public ResponseEntity<Void> requestAction(@LoginMember Long loginMemberId,
+                                              @PathVariable Long couponId,
+                                              @Valid @RequestBody CouponRequestEventRequest couponRequestEventRequest) {
+        couponService.changeStatus(
+            couponRequestEventRequest.toCouponChangeStatusRequest(loginMemberId, couponId)
+        );
         return ResponseEntity.ok().build();
     }
 }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/presentation/dto/CouponEventRequest.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/presentation/dto/CouponEventRequest.java
@@ -2,22 +2,31 @@ package com.woowacourse.kkogkkog.presentation.dto;
 
 import com.woowacourse.kkogkkog.application.dto.CouponChangeStatusRequest;
 import com.woowacourse.kkogkkog.domain.CouponEvent;
+import java.time.LocalDate;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class CouponEventRequest {
 
     private String couponEvent;
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    private LocalDate meetingDate;
 
     public CouponEventRequest(String couponEvent) {
         this.couponEvent = couponEvent;
     }
 
+    public CouponEventRequest(String couponEvent, LocalDate meetingDate) {
+        this.couponEvent = couponEvent;
+        this.meetingDate = meetingDate;
+    }
+
     public CouponChangeStatusRequest toCouponChangeStatusRequest(Long loginMemberId,
                                                                  Long couponId) {
-        return new CouponChangeStatusRequest(loginMemberId, couponId, CouponEvent.of(couponEvent));
+        return new CouponChangeStatusRequest(loginMemberId, couponId, CouponEvent.of(couponEvent), meetingDate);
     }
 }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/presentation/dto/CouponRequestEventRequest.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/presentation/dto/CouponRequestEventRequest.java
@@ -3,6 +3,9 @@ package com.woowacourse.kkogkkog.presentation.dto;
 import com.woowacourse.kkogkkog.application.dto.CouponChangeStatusRequest;
 import com.woowacourse.kkogkkog.domain.CouponEvent;
 import java.time.LocalDate;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,16 +13,20 @@ import org.springframework.format.annotation.DateTimeFormat;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class CouponEventRequest {
+public class CouponRequestEventRequest {
 
     private String couponEvent;
+    @NotNull
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    private LocalDate meetingDate;
 
-    public CouponEventRequest(String couponEvent) {
+    public CouponRequestEventRequest(String couponEvent, LocalDate meetingDate) {
         this.couponEvent = couponEvent;
+        this.meetingDate = meetingDate;
     }
 
     public CouponChangeStatusRequest toCouponChangeStatusRequest(Long loginMemberId,
                                                                  Long couponId) {
-        return new CouponChangeStatusRequest(loginMemberId, couponId, CouponEvent.of(couponEvent));
+        return new CouponChangeStatusRequest(loginMemberId, couponId, CouponEvent.of(couponEvent), meetingDate);
     }
 }

--- a/backend/src/test/java/com/woowacourse/kkogkkog/acceptance/CouponAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/acceptance/CouponAcceptanceTest.java
@@ -194,7 +194,7 @@ public class CouponAcceptanceTest extends AcceptanceTest {
             String leoAccessToken = 로그인에_성공한다(toTokenRequest(LEO)).getAccessToken();
             쿠폰_발급에_성공한다(jeongAccessToken, List.of(LEO));
 
-            ExtractableResponse<Response> response = 쿠폰_상태_변경을_요청한다(leoAccessToken, 1L,
+            ExtractableResponse<Response> response = 쿠폰_사용을_요청한다(leoAccessToken, 1L,
                 CouponEvent.REQUEST.name(), "2022-07-27");
 
             assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
@@ -209,7 +209,7 @@ public class CouponAcceptanceTest extends AcceptanceTest {
             쿠폰_발급에_성공한다(jeongAccessToken, List.of(LEO));
 
             ExtractableResponse<Response> response = 쿠폰_상태_변경을_요청한다(leoAccessToken, 1L,
-                "존재하지_않는_이벤트", null);
+                "존재하지_않는_이벤트");
 
             assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
         }
@@ -222,9 +222,9 @@ public class CouponAcceptanceTest extends AcceptanceTest {
             String leoAccessToken = 로그인에_성공한다(toTokenRequest(LEO)).getAccessToken();
             쿠폰_발급에_성공한다(jeongAccessToken, List.of(LEO));
 
-            쿠폰_상태_변경을_요청한다(leoAccessToken, 1L, CouponEvent.REQUEST.name(), null);
+            쿠폰_사용을_요청한다(leoAccessToken, 1L, CouponEvent.REQUEST.name(), "2022-07-27");
             ExtractableResponse<Response> response = 쿠폰_상태_변경을_요청한다(leoAccessToken, 1L,
-                CouponEvent.CANCEL.name(), null);
+                CouponEvent.CANCEL.name());
 
             assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
         }
@@ -238,7 +238,7 @@ public class CouponAcceptanceTest extends AcceptanceTest {
             쿠폰_발급에_성공한다(jeongAccessToken, List.of(LEO));
 
             ExtractableResponse<Response> response = 쿠폰_상태_변경을_요청한다(leoAccessToken, 1L,
-                CouponEvent.CANCEL.name(), null);
+                CouponEvent.CANCEL.name());
 
             assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
         }
@@ -251,9 +251,9 @@ public class CouponAcceptanceTest extends AcceptanceTest {
             String leoAccessToken = 로그인에_성공한다(toTokenRequest(LEO)).getAccessToken();
             쿠폰_발급에_성공한다(jeongAccessToken, List.of(LEO));
 
-            쿠폰_상태_변경을_요청한다(leoAccessToken, 1L, CouponEvent.REQUEST.name(), null);
+            쿠폰_사용을_요청한다(leoAccessToken, 1L, CouponEvent.REQUEST.name(), "2022-07-27");
             ExtractableResponse<Response> response = 쿠폰_상태_변경을_요청한다(jeongAccessToken, 1L,
-                CouponEvent.DECLINE.name(), null);
+                CouponEvent.DECLINE.name());
 
             assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
         }
@@ -266,7 +266,7 @@ public class CouponAcceptanceTest extends AcceptanceTest {
             쿠폰_발급에_성공한다(jeongAccessToken, List.of(LEO));
 
             ExtractableResponse<Response> response = 쿠폰_상태_변경을_요청한다(jeongAccessToken, 1L,
-                CouponEvent.DECLINE.name(), null);
+                CouponEvent.DECLINE.name());
 
             assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
         }
@@ -279,9 +279,9 @@ public class CouponAcceptanceTest extends AcceptanceTest {
             String leoAccessToken = 로그인에_성공한다(toTokenRequest(LEO)).getAccessToken();
             쿠폰_발급에_성공한다(jeongAccessToken, List.of(LEO));
 
-            쿠폰_상태_변경을_요청한다(leoAccessToken, 1L, CouponEvent.REQUEST.name(), null);
+            쿠폰_사용을_요청한다(leoAccessToken, 1L, CouponEvent.REQUEST.name(), "2022-07-27");
             ExtractableResponse<Response> response = 쿠폰_상태_변경을_요청한다(jeongAccessToken, 1L,
-                CouponEvent.ACCEPT.name(), null);
+                CouponEvent.ACCEPT.name());
 
             assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
         }
@@ -294,7 +294,7 @@ public class CouponAcceptanceTest extends AcceptanceTest {
             쿠폰_발급에_성공한다(jeongAccessToken, List.of(LEO));
 
             ExtractableResponse<Response> response = 쿠폰_상태_변경을_요청한다(jeongAccessToken, 1L,
-                CouponEvent.ACCEPT.name(), null);
+                CouponEvent.ACCEPT.name());
 
             assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
         }
@@ -308,7 +308,7 @@ public class CouponAcceptanceTest extends AcceptanceTest {
             쿠폰_발급에_성공한다(jeongAccessToken, List.of(LEO));
 
             ExtractableResponse<Response> response = 쿠폰_상태_변경을_요청한다(leoAccessToken, 1L,
-                CouponEvent.FINISH.name(), null);
+                CouponEvent.FINISH.name());
 
             assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
         }
@@ -321,9 +321,9 @@ public class CouponAcceptanceTest extends AcceptanceTest {
             String leoAccessToken = 로그인에_성공한다(toTokenRequest(LEO)).getAccessToken();
             쿠폰_발급에_성공한다(jeongAccessToken, List.of(LEO));
 
-            쿠폰_상태_변경을_요청한다(leoAccessToken, 1L, CouponEvent.REQUEST.name(), null);
+            쿠폰_사용을_요청한다(leoAccessToken, 1L, CouponEvent.REQUEST.name(), "2022-07-27");
             ExtractableResponse<Response> response = 쿠폰_상태_변경을_요청한다(leoAccessToken, 1L,
-                CouponEvent.FINISH.name(), null);
+                CouponEvent.FINISH.name());
 
             assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
         }
@@ -336,10 +336,10 @@ public class CouponAcceptanceTest extends AcceptanceTest {
             String leoAccessToken = 로그인에_성공한다(toTokenRequest(LEO)).getAccessToken();
             쿠폰_발급에_성공한다(jeongAccessToken, List.of(LEO));
 
-            쿠폰_상태_변경을_요청한다(leoAccessToken, 1L, CouponEvent.REQUEST.name(), null);
-            쿠폰_상태_변경을_요청한다(jeongAccessToken, 1L, CouponEvent.ACCEPT.name(), null);
+            쿠폰_사용을_요청한다(leoAccessToken, 1L, CouponEvent.REQUEST.name(), "2022-07-27");
+            쿠폰_상태_변경을_요청한다(jeongAccessToken, 1L, CouponEvent.ACCEPT.name());
             ExtractableResponse<Response> response = 쿠폰_상태_변경을_요청한다(leoAccessToken, 1L,
-                CouponEvent.FINISH.name(), null);
+                CouponEvent.FINISH.name());
 
             assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
         }
@@ -352,11 +352,11 @@ public class CouponAcceptanceTest extends AcceptanceTest {
             String leoAccessToken = 로그인에_성공한다(toTokenRequest(LEO)).getAccessToken();
             쿠폰_발급에_성공한다(jeongAccessToken, List.of(LEO));
 
-            쿠폰_상태_변경을_요청한다(leoAccessToken, 1L, CouponEvent.REQUEST.name(), null);
-            쿠폰_상태_변경을_요청한다(jeongAccessToken, 1L, CouponEvent.ACCEPT.name(), null);
-            쿠폰_상태_변경을_요청한다(leoAccessToken, 1L, CouponEvent.FINISH.name(), null);
+            쿠폰_사용을_요청한다(leoAccessToken, 1L, CouponEvent.REQUEST.name(), "2022-07-27");
+            쿠폰_상태_변경을_요청한다(jeongAccessToken, 1L, CouponEvent.ACCEPT.name());
+            쿠폰_상태_변경을_요청한다(leoAccessToken, 1L, CouponEvent.FINISH.name());
             ExtractableResponse<Response> response = 쿠폰_상태_변경을_요청한다(leoAccessToken, 1L,
-                CouponEvent.FINISH.name(), null);
+                CouponEvent.FINISH.name());
 
             assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
         }
@@ -369,7 +369,7 @@ public class CouponAcceptanceTest extends AcceptanceTest {
             쿠폰_발급에_성공한다(jeongAccessToken, List.of(LEO));
 
             ExtractableResponse<Response> response = 쿠폰_상태_변경을_요청한다(jeongAccessToken, 1L,
-                CouponEvent.FINISH.name(), null);
+                CouponEvent.FINISH.name());
 
             assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
         }
@@ -382,9 +382,9 @@ public class CouponAcceptanceTest extends AcceptanceTest {
             String leoAccessToken = 로그인에_성공한다(toTokenRequest(LEO)).getAccessToken();
             쿠폰_발급에_성공한다(jeongAccessToken, List.of(LEO));
 
-            쿠폰_상태_변경을_요청한다(leoAccessToken, 1L, CouponEvent.REQUEST.name(), null);
+            쿠폰_사용을_요청한다(leoAccessToken, 1L, CouponEvent.REQUEST.name(), "2022-07-27");
             ExtractableResponse<Response> response = 쿠폰_상태_변경을_요청한다(jeongAccessToken, 1L,
-                CouponEvent.FINISH.name(), null);
+                CouponEvent.FINISH.name());
 
             assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
         }
@@ -397,10 +397,10 @@ public class CouponAcceptanceTest extends AcceptanceTest {
             String leoAccessToken = 로그인에_성공한다(toTokenRequest(LEO)).getAccessToken();
             쿠폰_발급에_성공한다(jeongAccessToken, List.of(LEO));
 
-            쿠폰_상태_변경을_요청한다(leoAccessToken, 1L, CouponEvent.REQUEST.name(), null);
-            쿠폰_상태_변경을_요청한다(jeongAccessToken, 1L, CouponEvent.ACCEPT.name(), null);
+            쿠폰_사용을_요청한다(leoAccessToken, 1L, CouponEvent.REQUEST.name(), "2022-07-27");
+            쿠폰_상태_변경을_요청한다(jeongAccessToken, 1L, CouponEvent.ACCEPT.name());
             ExtractableResponse<Response> response = 쿠폰_상태_변경을_요청한다(jeongAccessToken, 1L,
-                CouponEvent.FINISH.name(), null);
+                CouponEvent.FINISH.name());
 
             assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
         }
@@ -413,24 +413,34 @@ public class CouponAcceptanceTest extends AcceptanceTest {
             String leoAccessToken = 로그인에_성공한다(toTokenRequest(LEO)).getAccessToken();
             쿠폰_발급에_성공한다(jeongAccessToken, List.of(LEO));
 
-            쿠폰_상태_변경을_요청한다(leoAccessToken, 1L, CouponEvent.REQUEST.name(), null);
-            쿠폰_상태_변경을_요청한다(jeongAccessToken, 1L, CouponEvent.ACCEPT.name(), null);
-            쿠폰_상태_변경을_요청한다(jeongAccessToken, 1L, CouponEvent.FINISH.name(), null);
+            쿠폰_사용을_요청한다(leoAccessToken, 1L, CouponEvent.REQUEST.name(), "2022-07-27");
+            쿠폰_상태_변경을_요청한다(jeongAccessToken, 1L, CouponEvent.ACCEPT.name());
+            쿠폰_상태_변경을_요청한다(jeongAccessToken, 1L, CouponEvent.FINISH.name());
             ExtractableResponse<Response> response = 쿠폰_상태_변경을_요청한다(jeongAccessToken, 1L,
-                CouponEvent.FINISH.name(), null);
+                CouponEvent.FINISH.name());
 
             assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
         }
 
-        private ExtractableResponse<Response> 쿠폰_상태_변경을_요청한다(String accessToken,
-                                                             Long couponId,
-                                                             String couponEvent,
-                                                             String meetingDate) {
+        private ExtractableResponse<Response> 쿠폰_사용을_요청한다(String accessToken, Long couponId, String couponEvent, String meetingDate) {
             return RestAssured.given().log().all()
                 .auth().oauth2(accessToken)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .body("{\"couponEvent\":\"" + couponEvent + "\","
                     + " \"meetingDate\":\"" + meetingDate + "\"}")
+                .when()
+                .post("/api/coupons/{couponId}/event/request", couponId)
+                .then().log().all()
+                .extract();
+        }
+
+        private ExtractableResponse<Response> 쿠폰_상태_변경을_요청한다(String accessToken,
+                                                             Long couponId,
+                                                             String couponEvent) {
+            return RestAssured.given().log().all()
+                .auth().oauth2(accessToken)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(new CouponEventRequest(couponEvent))
                 .when()
                 .post("/api/coupons/{couponId}/event", couponId)
                 .then().log().all()

--- a/backend/src/test/java/com/woowacourse/kkogkkog/acceptance/CouponAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/acceptance/CouponAcceptanceTest.java
@@ -19,6 +19,7 @@ import com.woowacourse.kkogkkog.presentation.dto.TokenRequest;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.DisplayName;
@@ -194,7 +195,7 @@ public class CouponAcceptanceTest extends AcceptanceTest {
             쿠폰_발급에_성공한다(jeongAccessToken, List.of(LEO));
 
             ExtractableResponse<Response> response = 쿠폰_상태_변경을_요청한다(leoAccessToken, 1L,
-                CouponEvent.REQUEST.name());
+                CouponEvent.REQUEST.name(), "2022-07-27");
 
             assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
         }
@@ -208,7 +209,7 @@ public class CouponAcceptanceTest extends AcceptanceTest {
             쿠폰_발급에_성공한다(jeongAccessToken, List.of(LEO));
 
             ExtractableResponse<Response> response = 쿠폰_상태_변경을_요청한다(leoAccessToken, 1L,
-                "존재하지_않는_이벤트");
+                "존재하지_않는_이벤트", null);
 
             assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
         }
@@ -221,9 +222,9 @@ public class CouponAcceptanceTest extends AcceptanceTest {
             String leoAccessToken = 로그인에_성공한다(toTokenRequest(LEO)).getAccessToken();
             쿠폰_발급에_성공한다(jeongAccessToken, List.of(LEO));
 
-            쿠폰_상태_변경을_요청한다(leoAccessToken, 1L, CouponEvent.REQUEST.name());
+            쿠폰_상태_변경을_요청한다(leoAccessToken, 1L, CouponEvent.REQUEST.name(), null);
             ExtractableResponse<Response> response = 쿠폰_상태_변경을_요청한다(leoAccessToken, 1L,
-                CouponEvent.CANCEL.name());
+                CouponEvent.CANCEL.name(), null);
 
             assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
         }
@@ -237,7 +238,7 @@ public class CouponAcceptanceTest extends AcceptanceTest {
             쿠폰_발급에_성공한다(jeongAccessToken, List.of(LEO));
 
             ExtractableResponse<Response> response = 쿠폰_상태_변경을_요청한다(leoAccessToken, 1L,
-                CouponEvent.CANCEL.name());
+                CouponEvent.CANCEL.name(), null);
 
             assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
         }
@@ -250,9 +251,9 @@ public class CouponAcceptanceTest extends AcceptanceTest {
             String leoAccessToken = 로그인에_성공한다(toTokenRequest(LEO)).getAccessToken();
             쿠폰_발급에_성공한다(jeongAccessToken, List.of(LEO));
 
-            쿠폰_상태_변경을_요청한다(leoAccessToken, 1L, CouponEvent.REQUEST.name());
+            쿠폰_상태_변경을_요청한다(leoAccessToken, 1L, CouponEvent.REQUEST.name(), null);
             ExtractableResponse<Response> response = 쿠폰_상태_변경을_요청한다(jeongAccessToken, 1L,
-                CouponEvent.DECLINE.name());
+                CouponEvent.DECLINE.name(), null);
 
             assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
         }
@@ -265,7 +266,7 @@ public class CouponAcceptanceTest extends AcceptanceTest {
             쿠폰_발급에_성공한다(jeongAccessToken, List.of(LEO));
 
             ExtractableResponse<Response> response = 쿠폰_상태_변경을_요청한다(jeongAccessToken, 1L,
-                CouponEvent.DECLINE.name());
+                CouponEvent.DECLINE.name(), null);
 
             assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
         }
@@ -278,9 +279,9 @@ public class CouponAcceptanceTest extends AcceptanceTest {
             String leoAccessToken = 로그인에_성공한다(toTokenRequest(LEO)).getAccessToken();
             쿠폰_발급에_성공한다(jeongAccessToken, List.of(LEO));
 
-            쿠폰_상태_변경을_요청한다(leoAccessToken, 1L, CouponEvent.REQUEST.name());
+            쿠폰_상태_변경을_요청한다(leoAccessToken, 1L, CouponEvent.REQUEST.name(), null);
             ExtractableResponse<Response> response = 쿠폰_상태_변경을_요청한다(jeongAccessToken, 1L,
-                CouponEvent.ACCEPT.name());
+                CouponEvent.ACCEPT.name(), null);
 
             assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
         }
@@ -293,7 +294,7 @@ public class CouponAcceptanceTest extends AcceptanceTest {
             쿠폰_발급에_성공한다(jeongAccessToken, List.of(LEO));
 
             ExtractableResponse<Response> response = 쿠폰_상태_변경을_요청한다(jeongAccessToken, 1L,
-                CouponEvent.ACCEPT.name());
+                CouponEvent.ACCEPT.name(), null);
 
             assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
         }
@@ -307,7 +308,7 @@ public class CouponAcceptanceTest extends AcceptanceTest {
             쿠폰_발급에_성공한다(jeongAccessToken, List.of(LEO));
 
             ExtractableResponse<Response> response = 쿠폰_상태_변경을_요청한다(leoAccessToken, 1L,
-                CouponEvent.FINISH.name());
+                CouponEvent.FINISH.name(), null);
 
             assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
         }
@@ -320,9 +321,9 @@ public class CouponAcceptanceTest extends AcceptanceTest {
             String leoAccessToken = 로그인에_성공한다(toTokenRequest(LEO)).getAccessToken();
             쿠폰_발급에_성공한다(jeongAccessToken, List.of(LEO));
 
-            쿠폰_상태_변경을_요청한다(leoAccessToken, 1L, CouponEvent.REQUEST.name());
+            쿠폰_상태_변경을_요청한다(leoAccessToken, 1L, CouponEvent.REQUEST.name(), null);
             ExtractableResponse<Response> response = 쿠폰_상태_변경을_요청한다(leoAccessToken, 1L,
-                CouponEvent.FINISH.name());
+                CouponEvent.FINISH.name(), null);
 
             assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
         }
@@ -335,10 +336,10 @@ public class CouponAcceptanceTest extends AcceptanceTest {
             String leoAccessToken = 로그인에_성공한다(toTokenRequest(LEO)).getAccessToken();
             쿠폰_발급에_성공한다(jeongAccessToken, List.of(LEO));
 
-            쿠폰_상태_변경을_요청한다(leoAccessToken, 1L, CouponEvent.REQUEST.name());
-            쿠폰_상태_변경을_요청한다(jeongAccessToken, 1L, CouponEvent.ACCEPT.name());
+            쿠폰_상태_변경을_요청한다(leoAccessToken, 1L, CouponEvent.REQUEST.name(), null);
+            쿠폰_상태_변경을_요청한다(jeongAccessToken, 1L, CouponEvent.ACCEPT.name(), null);
             ExtractableResponse<Response> response = 쿠폰_상태_변경을_요청한다(leoAccessToken, 1L,
-                CouponEvent.FINISH.name());
+                CouponEvent.FINISH.name(), null);
 
             assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
         }
@@ -351,11 +352,11 @@ public class CouponAcceptanceTest extends AcceptanceTest {
             String leoAccessToken = 로그인에_성공한다(toTokenRequest(LEO)).getAccessToken();
             쿠폰_발급에_성공한다(jeongAccessToken, List.of(LEO));
 
-            쿠폰_상태_변경을_요청한다(leoAccessToken, 1L, CouponEvent.REQUEST.name());
-            쿠폰_상태_변경을_요청한다(jeongAccessToken, 1L, CouponEvent.ACCEPT.name());
-            쿠폰_상태_변경을_요청한다(leoAccessToken, 1L, CouponEvent.FINISH.name());
+            쿠폰_상태_변경을_요청한다(leoAccessToken, 1L, CouponEvent.REQUEST.name(), null);
+            쿠폰_상태_변경을_요청한다(jeongAccessToken, 1L, CouponEvent.ACCEPT.name(), null);
+            쿠폰_상태_변경을_요청한다(leoAccessToken, 1L, CouponEvent.FINISH.name(), null);
             ExtractableResponse<Response> response = 쿠폰_상태_변경을_요청한다(leoAccessToken, 1L,
-                CouponEvent.FINISH.name());
+                CouponEvent.FINISH.name(), null);
 
             assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
         }
@@ -368,7 +369,7 @@ public class CouponAcceptanceTest extends AcceptanceTest {
             쿠폰_발급에_성공한다(jeongAccessToken, List.of(LEO));
 
             ExtractableResponse<Response> response = 쿠폰_상태_변경을_요청한다(jeongAccessToken, 1L,
-                CouponEvent.FINISH.name());
+                CouponEvent.FINISH.name(), null);
 
             assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
         }
@@ -381,9 +382,9 @@ public class CouponAcceptanceTest extends AcceptanceTest {
             String leoAccessToken = 로그인에_성공한다(toTokenRequest(LEO)).getAccessToken();
             쿠폰_발급에_성공한다(jeongAccessToken, List.of(LEO));
 
-            쿠폰_상태_변경을_요청한다(leoAccessToken, 1L, CouponEvent.REQUEST.name());
+            쿠폰_상태_변경을_요청한다(leoAccessToken, 1L, CouponEvent.REQUEST.name(), null);
             ExtractableResponse<Response> response = 쿠폰_상태_변경을_요청한다(jeongAccessToken, 1L,
-                CouponEvent.FINISH.name());
+                CouponEvent.FINISH.name(), null);
 
             assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
         }
@@ -396,10 +397,10 @@ public class CouponAcceptanceTest extends AcceptanceTest {
             String leoAccessToken = 로그인에_성공한다(toTokenRequest(LEO)).getAccessToken();
             쿠폰_발급에_성공한다(jeongAccessToken, List.of(LEO));
 
-            쿠폰_상태_변경을_요청한다(leoAccessToken, 1L, CouponEvent.REQUEST.name());
-            쿠폰_상태_변경을_요청한다(jeongAccessToken, 1L, CouponEvent.ACCEPT.name());
+            쿠폰_상태_변경을_요청한다(leoAccessToken, 1L, CouponEvent.REQUEST.name(), null);
+            쿠폰_상태_변경을_요청한다(jeongAccessToken, 1L, CouponEvent.ACCEPT.name(), null);
             ExtractableResponse<Response> response = 쿠폰_상태_변경을_요청한다(jeongAccessToken, 1L,
-                CouponEvent.FINISH.name());
+                CouponEvent.FINISH.name(), null);
 
             assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
         }
@@ -412,22 +413,24 @@ public class CouponAcceptanceTest extends AcceptanceTest {
             String leoAccessToken = 로그인에_성공한다(toTokenRequest(LEO)).getAccessToken();
             쿠폰_발급에_성공한다(jeongAccessToken, List.of(LEO));
 
-            쿠폰_상태_변경을_요청한다(leoAccessToken, 1L, CouponEvent.REQUEST.name());
-            쿠폰_상태_변경을_요청한다(jeongAccessToken, 1L, CouponEvent.ACCEPT.name());
-            쿠폰_상태_변경을_요청한다(jeongAccessToken, 1L, CouponEvent.FINISH.name());
+            쿠폰_상태_변경을_요청한다(leoAccessToken, 1L, CouponEvent.REQUEST.name(), null);
+            쿠폰_상태_변경을_요청한다(jeongAccessToken, 1L, CouponEvent.ACCEPT.name(), null);
+            쿠폰_상태_변경을_요청한다(jeongAccessToken, 1L, CouponEvent.FINISH.name(), null);
             ExtractableResponse<Response> response = 쿠폰_상태_변경을_요청한다(jeongAccessToken, 1L,
-                CouponEvent.FINISH.name());
+                CouponEvent.FINISH.name(), null);
 
             assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
         }
 
         private ExtractableResponse<Response> 쿠폰_상태_변경을_요청한다(String accessToken,
                                                              Long couponId,
-                                                             String couponEvent) {
+                                                             String couponEvent,
+                                                             String meetingDate) {
             return RestAssured.given().log().all()
                 .auth().oauth2(accessToken)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .body(new CouponEventRequest(couponEvent))
+                .body("{\"couponEvent\":\"" + couponEvent + "\","
+                    + " \"meetingDate\":\"" + meetingDate + "\"}")
                 .when()
                 .post("/api/coupons/{couponId}/event", couponId)
                 .then().log().all()

--- a/backend/src/test/java/com/woowacourse/kkogkkog/application/CouponServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/application/CouponServiceTest.java
@@ -242,7 +242,7 @@ public class CouponServiceTest extends ServiceTest {
                 Long couponId = couponService.save(couponSaveRequest).get(0).getId();
                 CouponChangeStatusRequest couponRequest = new CouponChangeStatusRequest(
                     ARTHUR.getId(),
-                    couponId, CouponEvent.REQUEST);
+                    couponId, CouponEvent.REQUEST, LocalDate.of(2022, 07, 27));
                 couponService.changeStatus(couponRequest);
 
                 CouponChangeStatusRequest couponCancel = new CouponChangeStatusRequest(
@@ -261,7 +261,7 @@ public class CouponServiceTest extends ServiceTest {
                 Long couponId = couponService.save(couponSaveRequest).get(0).getId();
                 CouponChangeStatusRequest couponRequest = new CouponChangeStatusRequest(
                     ARTHUR.getId(),
-                    couponId, CouponEvent.REQUEST);
+                    couponId, CouponEvent.REQUEST, LocalDate.of(2022, 07, 27));
                 couponService.changeStatus(couponRequest);
 
                 CouponChangeStatusRequest couponDecline = new CouponChangeStatusRequest(
@@ -280,7 +280,7 @@ public class CouponServiceTest extends ServiceTest {
                 Long couponId = couponService.save(couponSaveRequest).get(0).getId();
                 CouponChangeStatusRequest couponRequest = new CouponChangeStatusRequest(
                     ARTHUR.getId(),
-                    couponId, CouponEvent.REQUEST);
+                    couponId, CouponEvent.REQUEST, LocalDate.of(2022, 07, 27));
                 couponService.changeStatus(couponRequest);
 
                 CouponChangeStatusRequest couponDecline = new CouponChangeStatusRequest(
@@ -299,7 +299,7 @@ public class CouponServiceTest extends ServiceTest {
                 Long couponId = couponService.save(couponSaveRequest).get(0).getId();
                 CouponChangeStatusRequest couponRequest = new CouponChangeStatusRequest(
                     ARTHUR.getId(),
-                    couponId, CouponEvent.REQUEST);
+                    couponId, CouponEvent.REQUEST, LocalDate.of(2022, 07, 27));
                 couponService.changeStatus(couponRequest);
 
                 CouponChangeStatusRequest couponFinish = new CouponChangeStatusRequest(
@@ -318,7 +318,7 @@ public class CouponServiceTest extends ServiceTest {
                 Long couponId = couponService.save(couponSaveRequest).get(0).getId();
                 CouponChangeStatusRequest couponRequest = new CouponChangeStatusRequest(
                     ARTHUR.getId(),
-                    couponId, CouponEvent.REQUEST);
+                    couponId, CouponEvent.REQUEST, LocalDate.of(2022, 07, 27));
                 couponService.changeStatus(couponRequest);
 
                 CouponChangeStatusRequest couponCancel = new CouponChangeStatusRequest(
@@ -336,7 +336,7 @@ public class CouponServiceTest extends ServiceTest {
                 Long couponId = couponService.save(couponSaveRequest).get(0).getId();
                 CouponChangeStatusRequest couponRequest = new CouponChangeStatusRequest(
                     ARTHUR.getId(),
-                    couponId, CouponEvent.REQUEST);
+                    couponId, CouponEvent.REQUEST, LocalDate.of(2022, 07, 27));
                 couponService.changeStatus(couponRequest);
 
                 CouponChangeStatusRequest couponDecline = new CouponChangeStatusRequest(
@@ -354,7 +354,7 @@ public class CouponServiceTest extends ServiceTest {
                 Long couponId = couponService.save(couponSaveRequest).get(0).getId();
                 CouponChangeStatusRequest couponRequest = new CouponChangeStatusRequest(
                     ARTHUR.getId(),
-                    couponId, CouponEvent.REQUEST);
+                    couponId, CouponEvent.REQUEST, LocalDate.of(2022, 07, 27));
                 couponService.changeStatus(couponRequest);
 
                 CouponChangeStatusRequest couponDecline = new CouponChangeStatusRequest(
@@ -377,7 +377,7 @@ public class CouponServiceTest extends ServiceTest {
                 Long couponId = couponService.save(couponSaveRequest).get(0).getId();
                 CouponChangeStatusRequest couponRequest = new CouponChangeStatusRequest(
                     ARTHUR.getId(),
-                    couponId, CouponEvent.REQUEST);
+                    couponId, CouponEvent.REQUEST, LocalDate.of(2022, 07, 27));
                 couponService.changeStatus(couponRequest);
 
                 CouponChangeStatusRequest couponAccept = new CouponChangeStatusRequest(
@@ -406,7 +406,7 @@ public class CouponServiceTest extends ServiceTest {
                 Long couponId = couponService.save(couponSaveRequest).get(0).getId();
                 CouponChangeStatusRequest couponRequest = new CouponChangeStatusRequest(
                     ARTHUR.getId(),
-                    couponId, CouponEvent.REQUEST);
+                    couponId, CouponEvent.REQUEST, LocalDate.of(2022, 07, 27));
                 couponService.changeStatus(couponRequest);
 
                 CouponChangeStatusRequest couponAccept = new CouponChangeStatusRequest(

--- a/backend/src/test/java/com/woowacourse/kkogkkog/documentation/CouponControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/documentation/CouponControllerTest.java
@@ -26,6 +26,7 @@ import com.woowacourse.kkogkkog.presentation.dto.CouponCreateRequest;
 import com.woowacourse.kkogkkog.presentation.dto.CouponEventRequest;
 import com.woowacourse.kkogkkog.presentation.dto.MyCouponsResponse;
 import com.woowacourse.kkogkkog.presentation.dto.SuccessResponse;
+import java.time.LocalDate;
 import java.util.List;
 import org.apache.http.HttpHeaders;
 import org.junit.jupiter.api.Test;
@@ -53,7 +54,7 @@ class CouponControllerTest extends Documentation {
             MESSAGE, COUPON_TYPE.name());
         given(jwtTokenProvider.getValidatedPayload(any())).willReturn("1");
         given(couponService.save(any())).willReturn(List.of(
-            toCouponResponse(1L, JEONG, LEO), toCouponResponse(2L, JEONG, ARTHUR)));
+            toCreateCouponResponse(1L, JEONG, LEO), toCreateCouponResponse(2L, JEONG, ARTHUR)));
 
         // when
         ResultActions perform = mockMvc.perform(post("/api/coupons")
@@ -66,7 +67,7 @@ class CouponControllerTest extends Documentation {
         perform.andExpect(status().isCreated())
             .andExpect(
                 content().string(objectMapper.writeValueAsString(new SuccessResponse<>(List.of(
-                    toCouponResponse(1L, JEONG, LEO), toCouponResponse(2L, JEONG, ARTHUR))))));
+                    toCreateCouponResponse(1L, JEONG, LEO), toCreateCouponResponse(2L, JEONG, ARTHUR))))));
 
         // docs
         perform
@@ -108,7 +109,9 @@ class CouponControllerTest extends Documentation {
                     fieldWithPath("data.[].couponType").type(JsonFieldType.STRING)
                         .description("쿠폰 타입"),
                     fieldWithPath("data.[].couponStatus").type(JsonFieldType.STRING)
-                        .description("쿠폰 상태")
+                        .description("쿠폰 상태"),
+                    fieldWithPath("data.[].meetingDate").type(JsonFieldType.NULL)
+                        .description("쿠폰 발급 날짜")
                 ))
             );
     }
@@ -150,7 +153,8 @@ class CouponControllerTest extends Documentation {
                     fieldWithPath("modifier").type(JsonFieldType.STRING).description("수식어"),
                     fieldWithPath("message").type(JsonFieldType.STRING).description("추가 메시지"),
                     fieldWithPath("couponType").type(JsonFieldType.STRING).description("쿠폰 타입"),
-                    fieldWithPath("couponStatus").type(JsonFieldType.STRING).description("쿠폰 상태")
+                    fieldWithPath("couponStatus").type(JsonFieldType.STRING).description("쿠폰 상태"),
+                    fieldWithPath("meetingDate").type(JsonFieldType.STRING).description("쿠폰 사용 날짜")
                 ))
             );
     }
@@ -211,6 +215,8 @@ class CouponControllerTest extends Documentation {
                         .description("쿠폰 타입"),
                     fieldWithPath("data.received.[].couponStatus").type(JsonFieldType.STRING)
                         .description("쿠폰 상태"),
+                    fieldWithPath("data.received.[].meetingDate").type(JsonFieldType.STRING)
+                        .description("쿠폰 사용 날짜"),
 
                     fieldWithPath("data.sent.[].id").type(JsonFieldType.NUMBER)
                         .description("받은 쿠폰 ID"),
@@ -235,7 +241,9 @@ class CouponControllerTest extends Documentation {
                     fieldWithPath("data.sent.[].couponType").type(JsonFieldType.STRING)
                         .description("쿠폰 타입"),
                     fieldWithPath("data.sent.[].couponStatus").type(JsonFieldType.STRING)
-                        .description("쿠폰 상태")
+                        .description("쿠폰 상태"),
+                    fieldWithPath("data.sent.[].meetingDate").type(JsonFieldType.STRING)
+                        .description("쿠폰 사용 날짜")
                 ))
             );
     }
@@ -271,6 +279,13 @@ class CouponControllerTest extends Documentation {
     }
 
     private CouponResponse toCouponResponse(Long couponId, Member sender, Member receiver) {
+        CouponMemberResponse senderResponse = CouponMemberResponse.of(sender);
+        CouponMemberResponse receiverResponse = CouponMemberResponse.of(receiver);
+        return new CouponResponse(couponId, senderResponse, receiverResponse,
+            BACKGROUND_COLOR, LocalDate.of(2022, 07, 27), MODIFIER, MESSAGE, COUPON_TYPE.name(), CouponStatus.READY.name());
+    }
+
+    private CouponResponse toCreateCouponResponse(Long couponId, Member sender, Member receiver) {
         CouponMemberResponse senderResponse = CouponMemberResponse.of(sender);
         CouponMemberResponse receiverResponse = CouponMemberResponse.of(receiver);
         return new CouponResponse(couponId, senderResponse, receiverResponse,

--- a/backend/src/test/java/com/woowacourse/kkogkkog/domain/CouponTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/domain/CouponTest.java
@@ -7,6 +7,7 @@ import com.woowacourse.kkogkkog.exception.ForbiddenException;
 import com.woowacourse.kkogkkog.exception.InvalidRequestException;
 import com.woowacourse.kkogkkog.exception.coupon.SameSenderReceiverException;
 import com.woowacourse.kkogkkog.fixture.MemberFixture;
+import java.time.LocalDate;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -277,6 +278,24 @@ public class CouponTest {
                 assertThatThrownBy(() -> coupon.changeStatus(CouponEvent.FINISH, receiver))
                     .isInstanceOf(InvalidRequestException.class);
             }
+        }
+    }
+
+    @Nested
+    @DisplayName("updateMeetingDate 메서드는")
+    class UpdateMeetingDate {
+
+        @Test
+        @DisplayName("시간을 받으면 쿠폰의 meetingDate 를 추가한다.")
+        void success() {
+            Member sender = MemberFixture.ROOKIE;
+            Member receiver = MemberFixture.ARTHUR;
+            Coupon coupon = new Coupon(null, sender, receiver, "한턱쏘는", "추가 메세지", "#241223",
+                CouponType.COFFEE, CouponStatus.REQUESTED);
+
+            coupon.updateMeetingDate(LocalDate.of(2022, 07, 27));
+
+            assertThat(coupon.getMeetingDate()).isNotNull();
         }
     }
 }


### PR DESCRIPTION
## 작업 내용

- 쿠폰 사용 요청 시 날짜를 입력받는 기능

  - REQUEST 이벤트 api 분리
  - 해당 API에서만 날짜를 입력받도록 변경

- 쿠폰 조회 시 쿠폰 사용 날짜를 조회하는 기능
  - 단일 조회, 전체 조회에서 쿠폰 사용 날짜를 조회하도록 변경

## 공유사항

일단 기능만 구현한 상태고 내일 전체 리팩토링 과정에서 변경될 내용입니다~!

Resolves #128 
