### PR TITLE
chore: MySQL DB 마이그레이션 및 Spring Profile 적용

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 
+    runtimeOnly 'mysql:mysql-connector-java'
     runtimeOnly 'com.h2database:h2'
 
     asciidoctorExtensions 'org.springframework.restdocs:spring-restdocs-asciidoctor'

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -22,9 +22,9 @@ spring:
     database-platform: org.hibernate.dialect.MySQL5InnoDBDialect
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: ${db-url}
-    username: ${db-user}
-    password: ${db-password}
+    url: ${DB_URL}
+    username: ${DB_USER}
+    password: ${DB_PASSWORD}
 
 ---
 

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,21 +1,40 @@
 spring:
+  profiles.active: test
   jpa:
-    hibernate:
-      ddl-auto: create-drop
     open-in-view: false
     properties:
       hibernate:
         show_sql: true
         format_sql: true
-
-  datasource:
-    driver-class-name: org.h2.Driver
-    url: jdbc:h2:mem:kkogkkog-test;MODE=MYSQL;DB_CLOSE_DELAY=-1
-    username: sa
-    password:
-
 security:
   jwt:
     token:
       secret-key: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
       expire-length: 3600000
+
+---
+
+spring:
+  config.activate.on-profile: prod
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    database-platform: org.hibernate.dialect.MySQL5InnoDBDialect
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: ${db-url}
+    username: ${db-user}
+    password: ${db-password}
+
+---
+
+spring:
+  config.activate.on-profile: test
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:kkogkkog-test;MODE=MYSQL;DB_CLOSE_DELAY=-1
+    username: sa
+    password:


### PR DESCRIPTION
## 작업 내용

- Spring Profile 적용
  
  - application.yml 구분
  - prod 프로파일을 사용하면 MySQL DB를 사용하도록 설정

- MySQL DB 셋업

  - prod용 & dev용 계정과 database 분류하여 생성 완료
  - 현재 prod EC2 인스턴스의 deploy.sh 스크립트 실행시, prod 프로파일 사용하여 prod DB 연동되어 실행되도록 설정하였습니다.
  - 현재 dev EC2 인스턴스의 deploy_with_db.sh 스크립트 실행시, prod 프로파일 사용하여 dev DB 연동되어 실행되도록 설정하였습니다.

## 공유사항

- DB 정보 및 프로파일 활용 방법은 노션으로 공유할 예정입니다.
- OAuth로 전환하게 되면 환경변수를 다루기 필요할 것 같아 스프링 프로파일 형식을 셋업하였습니다.

Resolves #120
