### PR TITLE
chore: 리뷰 가능 상태로 전환된 draft PR에 대한 CI 트리거 추가

### DIFF
--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
       - develop
-    types: [opened, reopened]
+    types: [opened, ready_for_review, reopened]
 
 jobs:
   frontend:


### PR DESCRIPTION
## 작업 내용

- 현재 PR이 처음에 생성된 시점 + 닫혔다가 다시 열린 시점에만 CI가 동작하도록 설정된 상태입니다.
- PR을 draft로 생성한 경우, 리뷰 가능한 상태로 전환될 때에도 CI가 동작하도록 설정할 필요성이 확인되어 관련 조건을 추가했습니다.