### PR TITLE
feat: 사용자 닉네임 수정 기능 구현

### DIFF
--- a/backend/src/docs/asciidoc/member.adoc
+++ b/backend/src/docs/asciidoc/member.adoc
@@ -14,4 +14,4 @@ operation::member-showMe[snippets='http-request,http-response,response-fields']
 operation::member-showAll[snippets='http-request,http-response,response-fields']
 
 == 닉네임 수정
-operation::member-updateNickname[snippets='http-request,http-response,response-fields']
+operation::member-update[snippets='http-request,http-response,response-fields']

--- a/backend/src/docs/asciidoc/member.adoc
+++ b/backend/src/docs/asciidoc/member.adoc
@@ -6,11 +6,12 @@
 
 
 == Member
-=== 회원가입
-operation::member-create[snippets='http-request,http-response,request-fields']
 
 === 본인 정보 조회
 operation::member-showMe[snippets='http-request,http-response,response-fields']
 
 === 전체 조회
 operation::member-showAll[snippets='http-request,http-response,response-fields']
+
+== 닉네임 수정
+operation::member-updateNickname[snippets='http-request,http-response,response-fields']

--- a/backend/src/main/java/com/woowacourse/kkogkkog/application/MemberService.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/application/MemberService.java
@@ -61,7 +61,7 @@ public class MemberService {
             .collect(toList());
     }
 
-    public void updateNickname(Long memberId, String nickname) {
+    public void updateProfile(Long memberId, String nickname) {
         Member member = memberRepository.findById(memberId)
             .orElseThrow(MemberNotFoundException::new);
 

--- a/backend/src/main/java/com/woowacourse/kkogkkog/application/MemberService.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/application/MemberService.java
@@ -4,6 +4,7 @@ import static java.util.stream.Collectors.toList;
 
 import com.woowacourse.kkogkkog.application.dto.MemberCreateResponse;
 import com.woowacourse.kkogkkog.application.dto.MemberResponse;
+import com.woowacourse.kkogkkog.application.dto.MemberUpdateRequest;
 import com.woowacourse.kkogkkog.domain.Member;
 import com.woowacourse.kkogkkog.domain.repository.MemberRepository;
 import com.woowacourse.kkogkkog.exception.member.MemberNotFoundException;
@@ -61,10 +62,10 @@ public class MemberService {
             .collect(toList());
     }
 
-    public void updateProfile(Long memberId, String nickname) {
-        Member member = memberRepository.findById(memberId)
+    public void update(MemberUpdateRequest memberUpdateRequest) {
+        Member member = memberRepository.findById(memberUpdateRequest.getMemberId())
             .orElseThrow(MemberNotFoundException::new);
 
-        member.updateNickname(nickname);
+        member.updateNickname(memberUpdateRequest.getNickname());
     }
 }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/application/MemberService.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/application/MemberService.java
@@ -2,11 +2,11 @@ package com.woowacourse.kkogkkog.application;
 
 import static java.util.stream.Collectors.toList;
 
+import com.woowacourse.kkogkkog.application.dto.MemberCreateResponse;
 import com.woowacourse.kkogkkog.application.dto.MemberResponse;
 import com.woowacourse.kkogkkog.domain.Member;
 import com.woowacourse.kkogkkog.domain.repository.MemberRepository;
 import com.woowacourse.kkogkkog.exception.member.MemberNotFoundException;
-import com.woowacourse.kkogkkog.application.dto.MemberCreateResponse;
 import com.woowacourse.kkogkkog.infrastructure.SlackUserInfo;
 import java.util.List;
 import org.springframework.stereotype.Service;
@@ -30,13 +30,13 @@ public class MemberService {
 
         return memberRepository.findByUserId(userId)
             .stream()
-            .map(member -> update(member, imageUrl))
+            .map(member -> updateImageUrl(member, imageUrl))
             .findFirst()
             .orElseGet(() ->
                 save(new Member(null, userId, workspaceId, nickname, imageUrl)));
     }
 
-    private MemberCreateResponse update(Member member, String imageUrl) {
+    private MemberCreateResponse updateImageUrl(Member member, String imageUrl) {
         member.updateImageURL(imageUrl);
         return new MemberCreateResponse(member.getId(), false);
     }
@@ -54,9 +54,17 @@ public class MemberService {
         return MemberResponse.of(findMember);
     }
 
+    @Transactional(readOnly = true)
     public List<MemberResponse> findAll() {
         return memberRepository.findAll().stream()
             .map(MemberResponse::of)
             .collect(toList());
+    }
+
+    public void updateNickname(Long memberId, String nickname) {
+        Member member = memberRepository.findById(memberId)
+            .orElseThrow(MemberNotFoundException::new);
+
+        member.updateNickname(nickname);
     }
 }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/application/dto/MemberUpdateRequest.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/application/dto/MemberUpdateRequest.java
@@ -1,0 +1,18 @@
+package com.woowacourse.kkogkkog.application.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class MemberUpdateRequest {
+
+    private Long memberId;
+    private String nickname;
+
+    public MemberUpdateRequest(Long memberId, String nickname) {
+        this.memberId = memberId;
+        this.nickname = nickname;
+    }
+}

--- a/backend/src/main/java/com/woowacourse/kkogkkog/config/InterceptorConfig.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/config/InterceptorConfig.java
@@ -19,6 +19,7 @@ public class InterceptorConfig implements WebMvcConfigurer {
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(new LoginInterceptor(jwtTokenProvider))
             .addPathPatterns("/api/members/me")
+            .addPathPatterns("/api/members/me/nickname")
             .addPathPatterns("/api/coupons")
             .addPathPatterns("/api/coupons/*/event")
             .addPathPatterns("/api/coupons/*/event/*");

--- a/backend/src/main/java/com/woowacourse/kkogkkog/domain/Member.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/domain/Member.java
@@ -41,4 +41,8 @@ public class Member {
     public void updateImageURL(String imageUrl) {
         this.imageUrl = imageUrl;
     }
+
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
+    }
 }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/presentation/MemberController.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/presentation/MemberController.java
@@ -2,10 +2,13 @@ package com.woowacourse.kkogkkog.presentation;
 
 import com.woowacourse.kkogkkog.application.MemberService;
 import com.woowacourse.kkogkkog.application.dto.MemberResponse;
+import com.woowacourse.kkogkkog.presentation.dto.MemberNicknameUpdateRequest;
 import com.woowacourse.kkogkkog.presentation.dto.SuccessResponse;
 import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -29,5 +32,14 @@ public class MemberController {
     @GetMapping
     public ResponseEntity<SuccessResponse<List<MemberResponse>>> showAll() {
         return ResponseEntity.ok(new SuccessResponse<>(memberService.findAll()));
+    }
+
+    @PutMapping("/me/nickname")
+    public ResponseEntity<Void> updateNickname(@LoginMember Long id,
+        @RequestBody MemberNicknameUpdateRequest memberNicknameUpdateRequest) {
+
+        memberService.updateNickname(id, memberNicknameUpdateRequest.getNickname());
+
+        return ResponseEntity.ok().build();
     }
 }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/presentation/MemberController.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/presentation/MemberController.java
@@ -22,16 +22,16 @@ public class MemberController {
         this.memberService = memberService;
     }
 
+    @GetMapping
+    public ResponseEntity<SuccessResponse<List<MemberResponse>>> showAll() {
+        return ResponseEntity.ok(new SuccessResponse<>(memberService.findAll()));
+    }
+
     @GetMapping("/me")
     public ResponseEntity<MemberResponse> showMe(@LoginMember Long id) {
         MemberResponse memberResponse = memberService.findById(id);
 
         return ResponseEntity.ok(memberResponse);
-    }
-
-    @GetMapping
-    public ResponseEntity<SuccessResponse<List<MemberResponse>>> showAll() {
-        return ResponseEntity.ok(new SuccessResponse<>(memberService.findAll()));
     }
 
     @PutMapping("/me/nickname")

--- a/backend/src/main/java/com/woowacourse/kkogkkog/presentation/MemberController.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/presentation/MemberController.java
@@ -37,7 +37,7 @@ public class MemberController {
     @PutMapping("/me")
     public ResponseEntity<Void> updateMe(@LoginMember Long id,
                                          @RequestBody MemberUpdateMeRequest memberUpdateMeRequest) {
-        memberService.updateProfile(id, memberUpdateMeRequest.getNickname());
+        memberService.update(memberUpdateMeRequest.toMemberUpdateRequest(id));
 
         return ResponseEntity.ok().build();
     }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/presentation/MemberController.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/presentation/MemberController.java
@@ -2,7 +2,7 @@ package com.woowacourse.kkogkkog.presentation;
 
 import com.woowacourse.kkogkkog.application.MemberService;
 import com.woowacourse.kkogkkog.application.dto.MemberResponse;
-import com.woowacourse.kkogkkog.presentation.dto.MemberNicknameUpdateRequest;
+import com.woowacourse.kkogkkog.presentation.dto.MemberUpdateMeRequest;
 import com.woowacourse.kkogkkog.presentation.dto.SuccessResponse;
 import java.util.List;
 import org.springframework.http.ResponseEntity;
@@ -34,11 +34,10 @@ public class MemberController {
         return ResponseEntity.ok(memberResponse);
     }
 
-    @PutMapping("/me/nickname")
-    public ResponseEntity<Void> updateNickname(@LoginMember Long id,
-        @RequestBody MemberNicknameUpdateRequest memberNicknameUpdateRequest) {
-
-        memberService.updateNickname(id, memberNicknameUpdateRequest.getNickname());
+    @PutMapping("/me")
+    public ResponseEntity<Void> updateMe(@LoginMember Long id,
+                                         @RequestBody MemberUpdateMeRequest memberUpdateMeRequest) {
+        memberService.updateNickname(id, memberUpdateMeRequest.getNickname());
 
         return ResponseEntity.ok().build();
     }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/presentation/MemberController.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/presentation/MemberController.java
@@ -37,7 +37,7 @@ public class MemberController {
     @PutMapping("/me")
     public ResponseEntity<Void> updateMe(@LoginMember Long id,
                                          @RequestBody MemberUpdateMeRequest memberUpdateMeRequest) {
-        memberService.updateNickname(id, memberUpdateMeRequest.getNickname());
+        memberService.updateProfile(id, memberUpdateMeRequest.getNickname());
 
         return ResponseEntity.ok().build();
     }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/presentation/dto/MemberNicknameUpdateRequest.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/presentation/dto/MemberNicknameUpdateRequest.java
@@ -1,0 +1,16 @@
+package com.woowacourse.kkogkkog.presentation.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class MemberNicknameUpdateRequest {
+
+    private String nickname;
+
+    public MemberNicknameUpdateRequest(String nickname) {
+        this.nickname = nickname;
+    }
+}

--- a/backend/src/main/java/com/woowacourse/kkogkkog/presentation/dto/MemberUpdateMeRequest.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/presentation/dto/MemberUpdateMeRequest.java
@@ -6,11 +6,11 @@ import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class MemberNicknameUpdateRequest {
+public class MemberUpdateMeRequest {
 
     private String nickname;
 
-    public MemberNicknameUpdateRequest(String nickname) {
+    public MemberUpdateMeRequest(String nickname) {
         this.nickname = nickname;
     }
 }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/presentation/dto/MemberUpdateMeRequest.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/presentation/dto/MemberUpdateMeRequest.java
@@ -1,5 +1,6 @@
 package com.woowacourse.kkogkkog.presentation.dto;
 
+import com.woowacourse.kkogkkog.application.dto.MemberUpdateRequest;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,5 +13,9 @@ public class MemberUpdateMeRequest {
 
     public MemberUpdateMeRequest(String nickname) {
         this.nickname = nickname;
+    }
+
+    public MemberUpdateRequest toMemberUpdateRequest(Long memberId) {
+        return new MemberUpdateRequest(memberId, nickname);
     }
 }

--- a/backend/src/test/java/com/woowacourse/kkogkkog/acceptance/MemberAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/acceptance/MemberAcceptanceTest.java
@@ -26,12 +26,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
         회원가입_또는_로그인에_성공한다(MemberResponse.of(ROOKIE));
         회원가입_또는_로그인에_성공한다(MemberResponse.of(ARTHUR));
 
-        ExtractableResponse<Response> extract = RestAssured.given().log().all()
-            .when()
-            .get("/api/members")
-            .then().log().all()
-            .extract();
-
+        ExtractableResponse<Response> extract = 전체_사용자_조회를_요청한다();
         List<MemberResponse> members = extract.body().jsonPath()
             .getList("data", MemberResponse.class);
         SuccessResponse<List<MemberResponse>> membersResponse = new SuccessResponse<>(members);
@@ -54,13 +49,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
         String rookieAccessToken = 회원가입_또는_로그인에_성공한다(MemberResponse.of(ROOKIE)).getAccessToken();
         회원가입_또는_로그인에_성공한다(MemberResponse.of(ARTHUR));
 
-        ExtractableResponse<Response> extract = RestAssured.given().log().all()
-            .when()
-            .auth().oauth2(rookieAccessToken)
-            .get("/api/members/me")
-            .then().log().all()
-            .extract();
-
+        ExtractableResponse<Response> extract = 본인_정보_조회를_요청한다(rookieAccessToken);
         MemberResponse memberResponse = extract.as(MemberResponse.class);
 
         assertAll(
@@ -76,24 +65,38 @@ public class MemberAcceptanceTest extends AcceptanceTest {
         String newNickname = "새로운_닉네임";
         String rookieAccessToken = 회원가입_또는_로그인에_성공한다(MemberResponse.of(ROOKIE)).getAccessToken();
 
-        RestAssured.given().log().all()
-            .when()
-            .auth().oauth2(rookieAccessToken)
-            .contentType(MediaType.APPLICATION_JSON_VALUE)
-            .body(new MemberNicknameUpdateRequest(newNickname))
-            .put("/api/members/me/nickname")
-            .then().log().all()
-            .extract();
-
-        ExtractableResponse<Response> extract = RestAssured.given().log().all()
-            .when()
-            .auth().oauth2(rookieAccessToken)
-            .get("/api/members/me")
-            .then().log().all()
-            .extract();
-
+        닉네임_수정을_성공하고(newNickname, rookieAccessToken);
+        ExtractableResponse<Response> extract = 본인_정보_조회를_요청한다(rookieAccessToken);
         String actual = extract.as(MemberResponse.class).getNickname();
 
         assertThat(actual).isEqualTo(newNickname);
+    }
+
+    private ExtractableResponse<Response> 본인_정보_조회를_요청한다(String accessToken) {
+        return RestAssured.given().log().all()
+            .when()
+            .auth().oauth2(accessToken)
+            .get("/api/members/me")
+            .then().log().all()
+            .extract();
+    }
+
+    private ExtractableResponse<Response> 전체_사용자_조회를_요청한다() {
+        return RestAssured.given().log().all()
+            .when()
+            .get("/api/members")
+            .then().log().all()
+            .extract();
+    }
+
+    private void 닉네임_수정을_성공하고(String nickname, String accessToken) {
+        RestAssured.given().log().all()
+            .when()
+            .auth().oauth2(accessToken)
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .body(new MemberNicknameUpdateRequest(nickname))
+            .put("/api/members/me/nickname")
+            .then().log().all()
+            .extract();
     }
 }

--- a/backend/src/test/java/com/woowacourse/kkogkkog/acceptance/MemberAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/acceptance/MemberAcceptanceTest.java
@@ -8,7 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.woowacourse.kkogkkog.application.dto.MemberResponse;
 import com.woowacourse.kkogkkog.domain.Member;
-import com.woowacourse.kkogkkog.presentation.dto.MemberNicknameUpdateRequest;
+import com.woowacourse.kkogkkog.presentation.dto.MemberUpdateMeRequest;
 import com.woowacourse.kkogkkog.presentation.dto.SuccessResponse;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
@@ -65,7 +65,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
         String newNickname = "새로운_닉네임";
         String rookieAccessToken = 회원가입_또는_로그인에_성공한다(MemberResponse.of(ROOKIE)).getAccessToken();
 
-        닉네임_수정을_성공하고(newNickname, rookieAccessToken);
+        프로필_수정을_성공하고(newNickname, rookieAccessToken);
         ExtractableResponse<Response> extract = 본인_정보_조회를_요청한다(rookieAccessToken);
         String actual = extract.as(MemberResponse.class).getNickname();
 
@@ -89,13 +89,13 @@ public class MemberAcceptanceTest extends AcceptanceTest {
             .extract();
     }
 
-    private void 닉네임_수정을_성공하고(String nickname, String accessToken) {
+    private void 프로필_수정을_성공하고(String nickname, String accessToken) {
         RestAssured.given().log().all()
             .when()
             .auth().oauth2(accessToken)
             .contentType(MediaType.APPLICATION_JSON_VALUE)
-            .body(new MemberNicknameUpdateRequest(nickname))
-            .put("/api/members/me/nickname")
+            .body(new MemberUpdateMeRequest(nickname))
+            .put("/api/members/me")
             .then().log().all()
             .extract();
     }

--- a/backend/src/test/java/com/woowacourse/kkogkkog/acceptance/MemberAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/acceptance/MemberAcceptanceTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.woowacourse.kkogkkog.application.dto.MemberResponse;
 import com.woowacourse.kkogkkog.domain.Member;
+import com.woowacourse.kkogkkog.presentation.dto.MemberNicknameUpdateRequest;
 import com.woowacourse.kkogkkog.presentation.dto.SuccessResponse;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
@@ -15,6 +16,7 @@ import io.restassured.response.Response;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 
 @SuppressWarnings("NonAsciiCharacters")
 public class MemberAcceptanceTest extends AcceptanceTest {
@@ -67,5 +69,31 @@ public class MemberAcceptanceTest extends AcceptanceTest {
                 MemberResponse.of(new Member(1L, "URookie", "T03LX3C5540",
                     "루키", "image")))
         );
+    }
+
+    @Test
+    void 본인의_닉네임을_수정할_수_있다() {
+        String newNickname = "새로운_닉네임";
+        String rookieAccessToken = 회원가입_또는_로그인에_성공한다(MemberResponse.of(ROOKIE)).getAccessToken();
+
+        RestAssured.given().log().all()
+            .when()
+            .auth().oauth2(rookieAccessToken)
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .body(new MemberNicknameUpdateRequest(newNickname))
+            .put("/api/members/me/nickname")
+            .then().log().all()
+            .extract();
+
+        ExtractableResponse<Response> extract = RestAssured.given().log().all()
+            .when()
+            .auth().oauth2(rookieAccessToken)
+            .get("/api/members/me")
+            .then().log().all()
+            .extract();
+
+        String actual = extract.as(MemberResponse.class).getNickname();
+
+        assertThat(actual).isEqualTo(newNickname);
     }
 }

--- a/backend/src/test/java/com/woowacourse/kkogkkog/application/MemberServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/application/MemberServiceTest.java
@@ -108,8 +108,8 @@ class MemberServiceTest extends ServiceTest {
     }
 
     @Nested
-    @DisplayName("updateNickname 메서드는")
-    class UpdateNickname {
+    @DisplayName("updateProfile 메서드는")
+    class UpdateProfile {
 
         @Test
         @DisplayName("사용자의 닉네임을 수정한다.")
@@ -119,7 +119,7 @@ class MemberServiceTest extends ServiceTest {
             Long memberId = memberService.saveOrFind(rookieUserInfo).getId();
 
             String expected = "새로운_닉네임";
-            memberService.updateNickname(memberId, expected);
+            memberService.updateProfile(memberId, expected);
             String actual = memberService.findById(memberId).getNickname();
 
             assertThat(actual).isEqualTo(expected);

--- a/backend/src/test/java/com/woowacourse/kkogkkog/application/MemberServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/application/MemberServiceTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.woowacourse.kkogkkog.application.dto.MemberCreateResponse;
 import com.woowacourse.kkogkkog.application.dto.MemberResponse;
+import com.woowacourse.kkogkkog.application.dto.MemberUpdateRequest;
 import com.woowacourse.kkogkkog.domain.Member;
 import com.woowacourse.kkogkkog.exception.member.MemberNotFoundException;
 import com.woowacourse.kkogkkog.fixture.MemberFixture;
@@ -108,8 +109,8 @@ class MemberServiceTest extends ServiceTest {
     }
 
     @Nested
-    @DisplayName("updateProfile 메서드는")
-    class UpdateProfile {
+    @DisplayName("update 메서드는")
+    class Update {
 
         @Test
         @DisplayName("사용자의 닉네임을 수정한다.")
@@ -119,7 +120,7 @@ class MemberServiceTest extends ServiceTest {
             Long memberId = memberService.saveOrFind(rookieUserInfo).getId();
 
             String expected = "새로운_닉네임";
-            memberService.updateProfile(memberId, expected);
+            memberService.update(new MemberUpdateRequest(memberId, expected));
             String actual = memberService.findById(memberId).getNickname();
 
             assertThat(actual).isEqualTo(expected);

--- a/backend/src/test/java/com/woowacourse/kkogkkog/application/MemberServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/application/MemberServiceTest.java
@@ -3,12 +3,12 @@ package com.woowacourse.kkogkkog.application;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-import com.woowacourse.kkogkkog.application.dto.MemberResponse;
 import com.woowacourse.kkogkkog.application.dto.MemberCreateResponse;
-import com.woowacourse.kkogkkog.infrastructure.SlackUserInfo;
+import com.woowacourse.kkogkkog.application.dto.MemberResponse;
 import com.woowacourse.kkogkkog.domain.Member;
 import com.woowacourse.kkogkkog.exception.member.MemberNotFoundException;
 import com.woowacourse.kkogkkog.fixture.MemberFixture;
+import com.woowacourse.kkogkkog.infrastructure.SlackUserInfo;
 import java.util.List;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
@@ -104,6 +104,25 @@ class MemberServiceTest extends ServiceTest {
             List<MemberResponse> membersResponse = memberService.findAll();
 
             assertThat(membersResponse).hasSize(2);
+        }
+    }
+
+    @Nested
+    @DisplayName("updateNickname 메서드는")
+    class UpdateNickname {
+
+        @Test
+        @DisplayName("사용자의 닉네임을 수정한다.")
+        void success() {
+            SlackUserInfo rookieUserInfo = new SlackUserInfo("URookie", "T03LX3C5540", "루키",
+                "image");
+            Long memberId = memberService.saveOrFind(rookieUserInfo).getId();
+
+            String expected = "새로운_닉네임";
+            memberService.updateNickname(memberId, expected);
+            String actual = memberService.findById(memberId).getNickname();
+
+            assertThat(actual).isEqualTo(expected);
         }
     }
 }

--- a/backend/src/test/java/com/woowacourse/kkogkkog/documentation/MemberControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/documentation/MemberControllerTest.java
@@ -17,7 +17,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.woowacourse.kkogkkog.application.dto.MemberResponse;
-import com.woowacourse.kkogkkog.presentation.dto.MemberNicknameUpdateRequest;
+import com.woowacourse.kkogkkog.presentation.dto.MemberUpdateMeRequest;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
@@ -105,14 +105,14 @@ public class MemberControllerTest extends Documentation {
     @Test
     void 나의_닉네임_수정을_요청할_수_있다() throws Exception {
         // given
-        MemberNicknameUpdateRequest memberNicknameUpdateRequest = new MemberNicknameUpdateRequest(
+        MemberUpdateMeRequest memberUpdateMeRequest = new MemberUpdateMeRequest(
             "새로운_닉네임");
         given(jwtTokenProvider.getValidatedPayload(any())).willReturn("1");
 
         // when
         ResultActions perform = mockMvc.perform(put("/api/members/me/nickname")
             .header("Authorization", "Bearer AccessToken")
-            .content(objectMapper.writeValueAsString(memberNicknameUpdateRequest))
+            .content(objectMapper.writeValueAsString(memberUpdateMeRequest))
             .contentType(MediaType.APPLICATION_JSON));
 
         // then

--- a/backend/src/test/java/com/woowacourse/kkogkkog/documentation/MemberControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/documentation/MemberControllerTest.java
@@ -8,15 +8,19 @@ import static org.springframework.restdocs.headers.HeaderDocumentation.headerWit
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.woowacourse.kkogkkog.application.dto.MemberResponse;
+import com.woowacourse.kkogkkog.presentation.dto.MemberNicknameUpdateRequest;
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.ResultActions;
 
@@ -47,9 +51,11 @@ public class MemberControllerTest extends Documentation {
                 responseFields(
                     fieldWithPath("data.[].id").type(JsonFieldType.NUMBER).description("ID"),
                     fieldWithPath("data.[].userId").type(JsonFieldType.STRING).description("유저 Id"),
-                    fieldWithPath("data.[].workspaceId").type(JsonFieldType.STRING).description("워크스페이스 ID"),
+                    fieldWithPath("data.[].workspaceId").type(JsonFieldType.STRING)
+                        .description("워크스페이스 ID"),
                     fieldWithPath("data.[].nickname").type(JsonFieldType.STRING).description("닉네임"),
-                    fieldWithPath("data.[].imageUrl").type(JsonFieldType.STRING).description("이미지 주소")
+                    fieldWithPath("data.[].imageUrl").type(JsonFieldType.STRING)
+                        .description("이미지 주소")
                 ))
             );
     }
@@ -57,7 +63,8 @@ public class MemberControllerTest extends Documentation {
     @Test
     void 나의_회원정보를_요청할_수_있다() throws Exception {
         // given
-        MemberResponse memberResponse = new MemberResponse(1L, "User1", "TWorkspace1", "user_nickname1",
+        MemberResponse memberResponse = new MemberResponse(1L, "User1", "TWorkspace1",
+            "user_nickname1",
             "image");
 
         given(jwtTokenProvider.getValidatedPayload(any())).willReturn("1");
@@ -87,9 +94,41 @@ public class MemberControllerTest extends Documentation {
                 responseFields(
                     fieldWithPath("id").type(JsonFieldType.NUMBER).description("ID"),
                     fieldWithPath("userId").type(JsonFieldType.STRING).description("유저 Id"),
-                    fieldWithPath("workspaceId").type(JsonFieldType.STRING).description("워크스페이스 ID"),
+                    fieldWithPath("workspaceId").type(JsonFieldType.STRING)
+                        .description("워크스페이스 ID"),
                     fieldWithPath("nickname").type(JsonFieldType.STRING).description("닉네임"),
                     fieldWithPath("imageUrl").type(JsonFieldType.STRING).description("이미지 주소")
+                ))
+            );
+    }
+
+    @Test
+    void 나의_닉네임_수정을_요청할_수_있다() throws Exception {
+        // given
+        MemberNicknameUpdateRequest memberNicknameUpdateRequest = new MemberNicknameUpdateRequest(
+            "새로운_닉네임");
+        given(jwtTokenProvider.getValidatedPayload(any())).willReturn("1");
+
+        // when
+        ResultActions perform = mockMvc.perform(put("/api/members/me/nickname")
+            .header("Authorization", "Bearer AccessToken")
+            .content(objectMapper.writeValueAsString(memberNicknameUpdateRequest))
+            .contentType(MediaType.APPLICATION_JSON));
+
+        // then
+        perform.andExpect(status().isOk());
+
+        // docs
+        perform
+            .andDo(print())
+            .andDo(document("member-updateNickname",
+                getDocumentRequest(),
+                getDocumentResponse(),
+                requestHeaders(
+                    headerWithName("Authorization").description("Bearer {accessToken}")
+                ),
+                requestFields(
+                    fieldWithPath("nickname").type(JsonFieldType.STRING).description("ID")
                 ))
             );
     }

--- a/backend/src/test/java/com/woowacourse/kkogkkog/documentation/MemberControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/documentation/MemberControllerTest.java
@@ -121,7 +121,7 @@ public class MemberControllerTest extends Documentation {
         // docs
         perform
             .andDo(print())
-            .andDo(document("member-updateNickname",
+            .andDo(document("member-update",
                 getDocumentRequest(),
                 getDocumentResponse(),
                 requestHeaders(


### PR DESCRIPTION
## 작업 내용

- 사용자의 닉네임을 수정하는 기능 구현

## 공유사항

기능 구현 완료 후 회원 인수 테스트의 메서드를 분리하고 MemberController 메서드의 순서를 정렬하였습니다.

Resolves #149
