### PR TITLE
refactor: 중간 리팩터링 - react query 기반의 훅 구조 리팩터링

### DIFF
--- a/frontend/src/@components/coupon/CouponItem/big.tsx
+++ b/frontend/src/@components/coupon/CouponItem/big.tsx
@@ -2,7 +2,7 @@ import { MouseEventHandler } from 'react';
 
 import Placeholder from '@/@components/@shared/Placeholder';
 import CouponStatus from '@/@components/coupon/CouponStatus';
-import { useMe } from '@/@hooks/@queries/user';
+import { useFetchMe } from '@/@hooks/@queries/user';
 import { THUMBNAIL } from '@/types/client/coupon';
 import { CouponResponse } from '@/types/remote/response';
 import { extractDate } from '@/utils';
@@ -27,7 +27,6 @@ const BigCouponItem = (props: BigCouponItemProps) => {
     backgroundColor,
     modifier,
     couponStatus,
-    couponType,
     message,
     meetingDate,
     thumbnail,
@@ -36,7 +35,7 @@ const BigCouponItem = (props: BigCouponItemProps) => {
     thumbnail: THUMBNAIL[coupon.couponType],
   };
 
-  const { data: me } = useMe();
+  const { me } = useFetchMe();
 
   const meetingDateText = extractDate(meetingDate);
 

--- a/frontend/src/@components/coupon/CouponItem/small.tsx
+++ b/frontend/src/@components/coupon/CouponItem/small.tsx
@@ -2,7 +2,7 @@ import { MouseEventHandler } from 'react';
 
 import Placeholder from '@/@components/@shared/Placeholder';
 import CouponStatus from '@/@components/coupon/CouponStatus';
-import { useMe } from '@/@hooks/@queries/user';
+import { useFetchMe } from '@/@hooks/@queries/user';
 import { THUMBNAIL } from '@/types/client/coupon';
 import { CouponResponse } from '@/types/remote/response';
 
@@ -21,7 +21,7 @@ const SmallCouponItem = (props: SmallCouponItemProps) => {
     thumbnail: THUMBNAIL[coupon.couponType],
   };
 
-  const { data: me } = useMe();
+  const { me } = useFetchMe();
 
   return (
     <Styled.Root hasCursor={!!onClick} onClick={onClick}>

--- a/frontend/src/@components/coupon/CouponModal/index.tsx
+++ b/frontend/src/@components/coupon/CouponModal/index.tsx
@@ -93,7 +93,7 @@ const CouponModal = (props: CouponItemProps) => {
 
   const onClickCancelButton = () => {
     cancelCoupon({
-      onSuccessCallback: () => {
+      onSuccessCallback() {
         onCloseModal();
       },
     });
@@ -109,7 +109,7 @@ const CouponModal = (props: CouponItemProps) => {
     requestCoupon(
       { meetingDate },
       {
-        onSuccessCallback: () => {
+        onSuccessCallback() {
           onCloseModal();
         },
       }
@@ -118,7 +118,7 @@ const CouponModal = (props: CouponItemProps) => {
 
   const onClickFinishButton = () => {
     finishCoupon({
-      onSuccessCallback: () => {
+      onSuccessCallback() {
         onCloseModal();
       },
     });
@@ -126,7 +126,7 @@ const CouponModal = (props: CouponItemProps) => {
 
   const onClickAcceptButton = () => {
     acceptCoupon({
-      onSuccessCallback: () => {
+      onSuccessCallback() {
         onCloseModal();
       },
     });

--- a/frontend/src/@components/coupon/CouponModal/index.tsx
+++ b/frontend/src/@components/coupon/CouponModal/index.tsx
@@ -3,9 +3,10 @@ import React, { ChangeEventHandler, useState } from 'react';
 
 import Button from '@/@components/@shared/Button';
 import Modal from '@/@components/@shared/Modal';
-import { useMe } from '@/@hooks/@queries/user';
+import { useFetchMe } from '@/@hooks/@queries/user';
 import useChangeCouponStatus from '@/@hooks/coupon/useChangeCouponStatus';
 import { ANIMATION_DURATION } from '@/constants/animation';
+import { COUPON_STATUS } from '@/types/client/coupon';
 import { CouponResponse } from '@/types/remote/response';
 import { getToday } from '@/utils';
 
@@ -17,7 +18,9 @@ interface CouponItemProps {
   closeModal: () => void;
 }
 
-const receivedCouponModalMapper = {
+type buttonType = '취소' | '완료' | '요청' | '승인';
+
+const receivedCouponModalMapper: Record<COUPON_STATUS, { title: string; buttons: buttonType[] }> = {
   REQUESTED: {
     title: '쿠폰 사용 요청을 취소하시겠어요?',
     buttons: ['취소'],
@@ -36,7 +39,7 @@ const receivedCouponModalMapper = {
   },
 };
 
-const sentCouponModalMapper = {
+const sentCouponModalMapper: Record<COUPON_STATUS, { title: string; buttons: buttonType[] }> = {
   REQUESTED: {
     title: '쿠폰 사용 요청을 승인하시겠어요?',
     buttons: ['승인'],
@@ -55,15 +58,11 @@ const sentCouponModalMapper = {
   },
 };
 
-// 꼭꼭의 상태에 따라, 로그인 한 유저에게 어떤 꼭꼭인지에 따라 (내가 보낸건지, 받은건지) -> 모달은 이 정보에만 따라야함
-// 꼭꼭의 상태를 변경하는 모달이니.. 이름을 제대로 줘봐야하지 않을까?
-// 버튼은 상태 변경 액션 별로 한개씩 있다.
-
 const CouponModal = (props: CouponItemProps) => {
   const { coupon, closeModal } = props;
   const { id, sender, couponStatus } = coupon;
 
-  const { data: me } = useMe();
+  const { me } = useFetchMe();
 
   const [animation, setAnimation] = useState(false);
 
@@ -94,7 +93,7 @@ const CouponModal = (props: CouponItemProps) => {
 
   const onClickCancelButton = () => {
     cancelCoupon({
-      onSuccess() {
+      onSuccessCallback: () => {
         onCloseModal();
       },
     });
@@ -106,10 +105,11 @@ const CouponModal = (props: CouponItemProps) => {
 
       return;
     }
+
     requestCoupon(
       { meetingDate },
       {
-        onSuccess() {
+        onSuccessCallback: () => {
           onCloseModal();
         },
       }
@@ -118,7 +118,7 @@ const CouponModal = (props: CouponItemProps) => {
 
   const onClickFinishButton = () => {
     finishCoupon({
-      onSuccess() {
+      onSuccessCallback: () => {
         onCloseModal();
       },
     });
@@ -126,7 +126,7 @@ const CouponModal = (props: CouponItemProps) => {
 
   const onClickAcceptButton = () => {
     acceptCoupon({
-      onSuccess() {
+      onSuccessCallback: () => {
         onCloseModal();
       },
     });

--- a/frontend/src/@hooks/@queries/coupon.ts
+++ b/frontend/src/@hooks/@queries/coupon.ts
@@ -1,9 +1,7 @@
 import { useMemo } from 'react';
 import { useMutation, useQuery, useQueryClient } from 'react-query';
-import { useNavigate } from 'react-router-dom';
 
 import { changeCouponStatus, createCoupon, getCouponList } from '@/apis/coupon';
-import { PATH } from '@/Router';
 import { COUPON_STATUS } from '@/types/client/coupon';
 import { CouponResponse } from '@/types/remote/response';
 
@@ -71,17 +69,9 @@ export const useFetchCouponList = () => {
 export const useCreateCouponMutation = () => {
   const queryClient = useQueryClient();
 
-  const navigate = useNavigate();
-
   return useMutation(createCoupon, {
     onSuccess() {
       queryClient.invalidateQueries(QUERY_KEY.couponList);
-
-      navigate(PATH.LANDING, {
-        state: {
-          action: 'create',
-        },
-      });
     },
     onError() {
       alert('입력창을 확인하고 다시 시도해주세요.');

--- a/frontend/src/@hooks/@queries/user.ts
+++ b/frontend/src/@hooks/@queries/user.ts
@@ -1,9 +1,7 @@
 import { useMutation, useQuery } from 'react-query';
-import { useNavigate } from 'react-router-dom';
 
 import { client } from '@/apis';
 import { getMe, getUserList, join, login, OAuthLogin } from '@/apis/user';
-import { PATH } from '@/Router';
 
 import { useToast } from '../@common/useToast';
 
@@ -40,8 +38,6 @@ export const useFetchUserList = () => {
 /** Mutation */
 
 export const useOAuthLoginMutation = () => {
-  const navigate = useNavigate();
-
   return useMutation(OAuthLogin, {
     onSuccess(response) {
       const { accessToken } = response.data;
@@ -49,8 +45,6 @@ export const useOAuthLoginMutation = () => {
       localStorage.setItem('user-token', accessToken);
 
       client.defaults.headers['Authorization'] = `Bearer ${accessToken}`;
-
-      navigate(PATH.LANDING);
     },
   });
 };
@@ -58,12 +52,8 @@ export const useOAuthLoginMutation = () => {
 export const useJoinMutation = () => {
   const { displayMessage } = useToast();
 
-  const navigate = useNavigate();
-
   return useMutation(join, {
-    onSuccess: () => {
-      navigate(PATH.LOGIN);
-    },
+    onSuccess: () => {},
     onError({
       response: {
         data: { error },
@@ -75,8 +65,6 @@ export const useJoinMutation = () => {
 };
 
 export const useLoginMutation = () => {
-  const navigate = useNavigate();
-
   const { displayMessage } = useToast();
 
   return useMutation(login, {
@@ -88,8 +76,6 @@ export const useLoginMutation = () => {
       localStorage.setItem('user-token', accessToken);
 
       client.defaults.headers['Authorization'] = `Bearer ${accessToken}`;
-
-      navigate(PATH.LANDING);
     },
     onError({
       response: {

--- a/frontend/src/@hooks/coupon/useChangeCouponStatus.ts
+++ b/frontend/src/@hooks/coupon/useChangeCouponStatus.ts
@@ -1,39 +1,57 @@
-import { AxiosResponse } from 'axios';
-import { UseMutationOptions } from 'react-query';
-
-import { ChangeCouponStatusRequest } from '@/types/remote/request';
-
 import { useChangeCouponStatusMutation } from '../@queries/coupon';
 
-type ChangeStatusMutationOptions = Omit<
-  UseMutationOptions<
-    AxiosResponse<any, any>,
-    unknown,
-    { id: number; body: ChangeCouponStatusRequest }
-  >,
-  'mutationFn'
->;
+type changeCouponStatusType = {
+  onSuccessCallback?: () => void;
+};
 
 const useChangeCouponStatus = (id: number) => {
   const changeStatusMutate = useChangeCouponStatusMutation();
 
-  const cancelCoupon = (options: ChangeStatusMutationOptions) => {
-    changeStatusMutate.mutate({ id, body: { couponEvent: 'CANCEL' } }, options);
+  const cancelCoupon = ({ onSuccessCallback }: changeCouponStatusType) => {
+    changeStatusMutate.mutate(
+      { id, body: { couponEvent: 'CANCEL' } },
+      {
+        onSuccess() {
+          onSuccessCallback?.();
+        },
+      }
+    );
   };
 
   const requestCoupon = (
     { meetingDate }: { meetingDate: string },
-    options: ChangeStatusMutationOptions
+    { onSuccessCallback }: changeCouponStatusType
   ) => {
-    changeStatusMutate.mutate({ id, body: { couponEvent: 'REQUEST', meetingDate } }, options);
+    changeStatusMutate.mutate(
+      { id, body: { couponEvent: 'REQUEST', meetingDate } },
+      {
+        onSuccess() {
+          onSuccessCallback?.();
+        },
+      }
+    );
   };
 
-  const finishCoupon = (options: ChangeStatusMutationOptions) => {
-    changeStatusMutate.mutate({ id, body: { couponEvent: 'FINISH' } }, options);
+  const finishCoupon = ({ onSuccessCallback }: changeCouponStatusType) => {
+    changeStatusMutate.mutate(
+      { id, body: { couponEvent: 'FINISH' } },
+      {
+        onSuccess() {
+          onSuccessCallback?.();
+        },
+      }
+    );
   };
 
-  const acceptCoupon = (options: ChangeStatusMutationOptions) => {
-    changeStatusMutate.mutate({ id, body: { couponEvent: 'ACCEPT' } }, options);
+  const acceptCoupon = ({ onSuccessCallback }: changeCouponStatusType) => {
+    changeStatusMutate.mutate(
+      { id, body: { couponEvent: 'ACCEPT' } },
+      {
+        onSuccess() {
+          onSuccessCallback?.();
+        },
+      }
+    );
   };
 
   return {

--- a/frontend/src/@hooks/coupon/useCouponForm.ts
+++ b/frontend/src/@hooks/coupon/useCouponForm.ts
@@ -1,5 +1,7 @@
 import { ChangeEvent, FormEvent, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
+import { PATH } from '@/Router';
 import {
   COUPON_COLORS,
   COUPON_ENG_TYPE,
@@ -13,6 +15,8 @@ import { UserResponse } from '@/types/remote/response';
 import { useCreateCouponMutation } from '../@queries/coupon';
 
 export const useCouponForm = () => {
+  const navigate = useNavigate();
+
   const [receiverList, setReceiverList] = useState<UserResponse[]>([]);
   const [type, setType] = useState<COUPON_ENG_TYPE>(couponTypeCollection[0].engType);
   const [modifier, setModifier] = useState<COUPON_MODIFIERS>(couponModifiers[0]);
@@ -62,13 +66,24 @@ export const useCouponForm = () => {
       return;
     }
 
-    createCouponMutate.mutate({
-      receivers: receiverList.map(({ id }) => id),
-      backgroundColor: color,
-      modifier,
-      message,
-      couponType: type,
-    });
+    createCouponMutate.mutate(
+      {
+        receivers: receiverList.map(({ id }) => id),
+        backgroundColor: color,
+        modifier,
+        message,
+        couponType: type,
+      },
+      {
+        onSuccess() {
+          navigate(PATH.LANDING, {
+            state: {
+              action: 'create',
+            },
+          });
+        },
+      }
+    );
   };
 
   return {

--- a/frontend/src/@hooks/user/useAuthenticateForm.ts
+++ b/frontend/src/@hooks/user/useAuthenticateForm.ts
@@ -1,4 +1,7 @@
 import { ChangeEvent, FormEvent, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import { PATH } from '@/Router';
 
 import { useJoinMutation, useLoginMutation } from '../@queries/user';
 
@@ -16,6 +19,8 @@ export const useAuthenticateForm = (props: UseAuthenticateFormProps = {}) => {
     defaultConfirmPassword = '',
     defaultName = '',
   } = props;
+
+  const navigate = useNavigate();
 
   const [email, setEmail] = useState(defaultEmail);
   const [password, setPassword] = useState(defaultPassword);
@@ -69,20 +74,34 @@ export const useAuthenticateForm = (props: UseAuthenticateFormProps = {}) => {
   const onSubmitJoinForm = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
-    joinMutate.mutate({
-      email,
-      password,
-      nickname: name,
-    });
+    joinMutate.mutate(
+      {
+        email,
+        password,
+        nickname: name,
+      },
+      {
+        onSuccess() {
+          navigate(PATH.JOIN);
+        },
+      }
+    );
   };
 
   const onSubmitLoginForm = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
-    loginMutate.mutate({
-      email,
-      password,
-    });
+    loginMutate.mutate(
+      {
+        email,
+        password,
+      },
+      {
+        onSuccess() {
+          navigate(PATH.LANDING);
+        },
+      }
+    );
   };
 
   return {

--- a/frontend/src/@hooks/user/useSearchUser.ts
+++ b/frontend/src/@hooks/user/useSearchUser.ts
@@ -1,14 +1,13 @@
 import { useEffect, useState } from 'react';
 
-import { useMe, useUserList } from '@/@hooks/@queries/user';
+import { useFetchMe, useFetchUserList } from '@/@hooks/@queries/user';
 import { UserResponse } from '@/types/remote/response';
 
 export const useSearchUser = () => {
-  const { data: me } = useMe();
+  const { me } = useFetchMe();
 
   // 이 부분은 검색 API 도입시 사라지게됨
-  const { data } = useUserList();
-  const userList = data?.data;
+  const { userList } = useFetchUserList();
 
   const [searchedUserList, setSearchedUserList] = useState<UserResponse[] | undefined>();
 

--- a/frontend/src/@pages/landing/index.tsx
+++ b/frontend/src/@pages/landing/index.tsx
@@ -10,7 +10,7 @@ import SmallCouponItem from '@/@components/coupon/CouponItem/small';
 import HorizontalCouponList from '@/@components/coupon/CouponList/horizontal';
 import CouponModal from '@/@components/coupon/CouponModal';
 import { useFetchCouponList } from '@/@hooks/@queries/coupon';
-import { useMe } from '@/@hooks/@queries/user';
+import { useFetchMe } from '@/@hooks/@queries/user';
 import useCouponModal from '@/@hooks/coupon/useCouponModal';
 import { PATH } from '@/Router';
 import { CouponResponse } from '@/types/remote/response';
@@ -67,8 +67,7 @@ const UnAuthorizedLanding = () => {
 /** ListHeaderContainer는 어디에 있어야하는가? */
 
 const AuthorizedLanding = () => {
-  const { data, isLoading } = useFetchCouponList();
-  const couponList = data?.data;
+  const { couponList, isLoading } = useFetchCouponList();
 
   const { currentCoupon, openCouponModal, closeCouponModal } = useCouponModal();
 
@@ -159,7 +158,7 @@ const AuthorizedLanding = () => {
 };
 
 const LandingPage = () => {
-  const { data: me } = useMe();
+  const { me } = useFetchMe();
 
   return me ? <AuthorizedLanding /> : <UnAuthorizedLanding />;
 };

--- a/frontend/src/@pages/login/redirect.tsx
+++ b/frontend/src/@pages/login/redirect.tsx
@@ -1,17 +1,25 @@
 import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 import Loading from '@/@components/@shared/Loading';
 import useGetSearchParam from '@/@hooks/@common/useGetSearchParams';
 import { useOAuthLoginMutation } from '@/@hooks/@queries/user';
+import { PATH } from '@/Router';
 
 const LoginRedirect = () => {
+  const navigate = useNavigate();
+
   const code = useGetSearchParam('code');
 
   const loginMutate = useOAuthLoginMutation();
 
   useEffect(() => {
     if (code) {
-      loginMutate.mutate(code);
+      loginMutate.mutate(code, {
+        onSuccess() {
+          navigate(PATH.LANDING);
+        },
+      });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
     // mutate가 실행된 후 해당 컴포넌트가 리렌더링 되기 때문에 dependency에 loginMutate를 넣으면 무한 렌더링이 발생함.

--- a/frontend/src/@pages/login/redirect.tsx
+++ b/frontend/src/@pages/login/redirect.tsx
@@ -1,31 +1,17 @@
 import { useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
 
 import Loading from '@/@components/@shared/Loading';
 import useGetSearchParam from '@/@hooks/@common/useGetSearchParams';
 import { useOAuthLoginMutation } from '@/@hooks/@queries/user';
-import { client } from '@/apis';
 
 const LoginRedirect = () => {
-  const navigate = useNavigate();
-
   const code = useGetSearchParam('code');
 
   const loginMutate = useOAuthLoginMutation();
 
   useEffect(() => {
     if (code) {
-      loginMutate.mutate(code, {
-        onSuccess(response) {
-          const { accessToken } = response.data;
-
-          localStorage.setItem('user-token', accessToken);
-
-          client.defaults.headers['Authorization'] = `Bearer ${accessToken}`;
-
-          navigate('/');
-        },
-      });
+      loginMutate.mutate(code);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
     // mutate가 실행된 후 해당 컴포넌트가 리렌더링 되기 때문에 dependency에 loginMutate를 넣으면 무한 렌더링이 발생함.

--- a/frontend/src/@pages/profile/index.tsx
+++ b/frontend/src/@pages/profile/index.tsx
@@ -4,14 +4,14 @@ import { useNavigate } from 'react-router-dom';
 
 import Button from '@/@components/@shared/Button';
 import PageTemplate from '@/@components/@shared/PageTemplate';
-import { useMe } from '@/@hooks/@queries/user';
+import { useFetchMe } from '@/@hooks/@queries/user';
 import { client } from '@/apis';
 import { PATH } from '@/Router';
 
 const ProfilePage = () => {
   const navigate = useNavigate();
 
-  const { remove } = useMe();
+  const { remove } = useFetchMe();
 
   const onClickLogoutButton = () => {
     client.defaults.headers['Authorization'] = '';

--- a/frontend/src/Router.tsx
+++ b/frontend/src/Router.tsx
@@ -10,7 +10,7 @@ import JoinPage from '@/@pages/join';
 import LandingPage from '@/@pages/landing';
 import ProfilePage from '@/@pages/profile';
 
-import { useMe } from './@hooks/@queries/user';
+import { useFetchMe } from './@hooks/@queries/user';
 import LoginPage from './@pages/login';
 import LoginRedirect from './@pages/login/redirect';
 
@@ -76,7 +76,7 @@ const Router = () => {
 export default Router;
 
 const PrivateRoute = () => {
-  const { data: me, isLoading } = useMe();
+  const { me, isLoading } = useFetchMe();
 
   return me ? (
     <Outlet />


### PR DESCRIPTION
## 작업 내용

- useQuery 기반의 훅 동작 수정
   - 모든 데이터를 그대로 반환한다에 대한 고민이 필요합니다.
   - 데이터를 일부 가공해서 주기도 합니다. (가공된 데이터 + 날 것 그대로의 데이터를 반환합니다.)
- useMutation 훅 
   - navigate 로직은 비즈니스 로직 훅 혹은 컴포넌트에서 결정합니다.
   - toast 로직은 단순 에러를 출력하기에 useMutation 훅에 강하게 결합시켰습니다.
- useMutation 기반의 비즈니스 로직 훅 수정 
   - 이 훅으로 성공 로직, 실패 로직을 컴포넌트 단에서 주입할 수 도 있습니다. ( 이 경우 성공 로직, 실패 로직은 컴포넌트 UI 로직으로 한정됩니다. ) 

## 공유사항

강조되는 규칙

컴포넌트는 `useMutation 기반의 커스텀 훅`을 호출하거나, 비즈니스 로직 훅을 호출하여 비즈니스 로직을 수행합니다. ( 컴포넌트가 직접 `useMutation 기반의 커스텀 훅`을 호출하는 경우는 드물지만 컴포넌트와 비즈니스 로직의 결합도가 강한 경우 허용합니다.)

컴포넌트는 `useQuery 기반의 커스텀 훅` 훅을 호출할 수 있습니다. 이 경우 가공된 데이터 + 날것 그대로의 데이터를 반환받고, `useQuery`가 반환하는 모든 데이터를 전달받습니다. ( 모든 데이터를 전달받는다에 대한 고민이 필요합니다. `refetch, remove` 같은 함수들은 섬세하게 다루어줄 필요가 있다고 생각됩니다.

Resolves #105
