### PR TITLE
feat: 사용자 도메인에 email 필드 추가

### DIFF
--- a/backend/src/main/java/com/woowacourse/kkogkkog/application/MemberService.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/application/MemberService.java
@@ -27,18 +27,19 @@ public class MemberService {
         String userId = slackUserInfo.getUserId();
         String workspaceId = slackUserInfo.getTeamId();
         String nickname = slackUserInfo.getName();
+        String email = slackUserInfo.getEmail();
         String imageUrl = slackUserInfo.getPicture();
 
         return memberRepository.findByUserId(userId)
             .stream()
-            .map(member -> updateImageUrl(member, imageUrl))
+            .map(member -> updateToMatchSlack(member, email, imageUrl))
             .findFirst()
             .orElseGet(() ->
-                save(new Member(null, userId, workspaceId, nickname, "email", imageUrl)));
-        // TODO: replace with email data from Slack OAuth
+                save(new Member(null, userId, workspaceId, nickname, email, imageUrl)));
     }
 
-    private MemberCreateResponse updateImageUrl(Member member, String imageUrl) {
+    private MemberCreateResponse updateToMatchSlack(Member member, String email, String imageUrl) {
+        member.updateEmail(email);
         member.updateImageURL(imageUrl);
         return new MemberCreateResponse(member.getId(), false);
     }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/application/MemberService.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/application/MemberService.java
@@ -34,7 +34,8 @@ public class MemberService {
             .map(member -> updateImageUrl(member, imageUrl))
             .findFirst()
             .orElseGet(() ->
-                save(new Member(null, userId, workspaceId, nickname, imageUrl)));
+                save(new Member(null, userId, workspaceId, nickname, "email", imageUrl)));
+        // TODO: replace with email data from Slack OAuth
     }
 
     private MemberCreateResponse updateImageUrl(Member member, String imageUrl) {

--- a/backend/src/main/java/com/woowacourse/kkogkkog/application/dto/CouponMemberResponse.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/application/dto/CouponMemberResponse.java
@@ -13,14 +13,16 @@ public class CouponMemberResponse {
     private String userId;
     private String workspaceId;
     private String nickname;
+    private String email;
     private String imageUrl;
 
     public CouponMemberResponse(Long id, String userId, String workspaceId, String nickname,
-        String imageUrl) {
+                                String email, String imageUrl) {
         this.id = id;
         this.userId = userId;
         this.workspaceId = workspaceId;
         this.nickname = nickname;
+        this.email = email;
         this.imageUrl = imageUrl;
     }
 
@@ -30,6 +32,7 @@ public class CouponMemberResponse {
             member.getUserId(),
             member.getWorkspaceId(),
             member.getNickname(),
+            member.getEmail(),
             member.getImageUrl()
         );
     }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/application/dto/MemberResponse.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/application/dto/MemberResponse.java
@@ -13,14 +13,16 @@ public class MemberResponse {
     private String userId;
     private String workspaceId;
     private String nickname;
+    private String email;
     private String imageUrl;
 
     public MemberResponse(Long id, String userId, String workspaceId, String nickname,
-        String imageUrl) {
+                          String email, String imageUrl) {
         this.id = id;
         this.userId = userId;
         this.workspaceId = workspaceId;
         this.nickname = nickname;
+        this.email = email;
         this.imageUrl = imageUrl;
     }
 
@@ -30,6 +32,7 @@ public class MemberResponse {
             member.getUserId(),
             member.getWorkspaceId(),
             member.getNickname(),
+            member.getEmail(),
             member.getImageUrl()
         );
     }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/domain/Member.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/domain/Member.java
@@ -43,8 +43,13 @@ public class Member {
         this.imageUrl = imageUrl;
     }
 
+    // TODO: sort by field order
     public void updateImageURL(String imageUrl) {
         this.imageUrl = imageUrl;
+    }
+
+    public void updateEmail(String email) {
+        this.email = email;
     }
 
     public void updateNickname(String nickname) {

--- a/backend/src/main/java/com/woowacourse/kkogkkog/domain/Member.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/domain/Member.java
@@ -28,13 +28,18 @@ public class Member {
     private String nickname;
 
     @Column(nullable = false)
+    private String email;
+
+    @Column(nullable = false)
     private String imageUrl;
 
-    public Member(Long id, String userId, String workspaceId, String nickname, String imageUrl) {
+    public Member(Long id, String userId, String workspaceId, String nickname, String email,
+                  String imageUrl) {
         this.id = id;
         this.userId = userId;
         this.workspaceId = workspaceId;
         this.nickname = nickname;
+        this.email = email;
         this.imageUrl = imageUrl;
     }
 

--- a/backend/src/main/java/com/woowacourse/kkogkkog/infrastructure/SlackUserInfo.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/infrastructure/SlackUserInfo.java
@@ -18,12 +18,14 @@ public class SlackUserInfo {
     private String teamId;
 
     private String name;
+    private String email;
     private String picture;
 
-    public SlackUserInfo(String userId, String teamId, String name, String picture) {
+    public SlackUserInfo(String userId, String teamId, String name, String email, String picture) {
         this.userId = userId;
         this.teamId = teamId;
         this.name = name;
+        this.email = email;
         this.picture = picture;
     }
 }

--- a/backend/src/test/java/com/woowacourse/kkogkkog/acceptance/AuthAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/acceptance/AuthAcceptanceTest.java
@@ -45,7 +45,7 @@ public class AuthAcceptanceTest extends AcceptanceTest {
                     memberResponse.getUserId(),
                     memberResponse.getWorkspaceId(),
                     memberResponse.getNickname(),
-                    "email", // TODO: 깨지는 테스트 고치기 - 대안이 없음
+                    memberResponse.getEmail(),
                     memberResponse.getImageUrl()));
 
         ExtractableResponse<Response> extract = RestAssured.given().log().all()

--- a/backend/src/test/java/com/woowacourse/kkogkkog/acceptance/AuthAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/acceptance/AuthAcceptanceTest.java
@@ -45,6 +45,7 @@ public class AuthAcceptanceTest extends AcceptanceTest {
                     memberResponse.getUserId(),
                     memberResponse.getWorkspaceId(),
                     memberResponse.getNickname(),
+                    "email", // TODO: 깨지는 테스트 고치기 - 대안이 없음
                     memberResponse.getImageUrl()));
 
         ExtractableResponse<Response> extract = RestAssured.given().log().all()

--- a/backend/src/test/java/com/woowacourse/kkogkkog/acceptance/CouponAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/acceptance/CouponAcceptanceTest.java
@@ -17,7 +17,6 @@ import com.woowacourse.kkogkkog.presentation.dto.SuccessResponse;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
-import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.DisplayName;
@@ -29,10 +28,14 @@ import org.springframework.http.MediaType;
 @SuppressWarnings("NonAsciiCharacters")
 public class CouponAcceptanceTest extends AcceptanceTest {
 
-    private static final Member JEONG = new Member(1L, "UJeong", "T03LX3C5540", "정", "image");
-    private static final Member LEO = new Member(2L, "ULeo", "T03LX3C5540", "레오", "image");
-    private static final Member ARTHUR = new Member(3L, "UArthur", "T03LX3C5540", "아서", "image");
-    private static final Member ROOKIE = new Member(4L, "URookie", "T03LX3C5540", "루키", "image");
+    private static final Member JEONG = new Member(1L, "UJeong", "T03LX3C5540",
+        "정", "jeong@gmail.com", "image");
+    private static final Member LEO = new Member(2L, "ULeo", "T03LX3C5540",
+        "레오", "leothelion@gmail.com", "image");
+    private static final Member ARTHUR = new Member(3L, "UArthur", "T03LX3C5540",
+        "아서", "arthur@gmail.com", "image");
+    private static final Member ROOKIE = new Member(4L, "URookie", "T03LX3C5540",
+        "루키", "rookie@gmail.com", "image");
 
     private static final String BACKGROUND_COLOR = "#123456";
     private static final String MODIFIER = "한턱내는";

--- a/backend/src/test/java/com/woowacourse/kkogkkog/acceptance/MemberAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/acceptance/MemberAcceptanceTest.java
@@ -37,9 +37,9 @@ public class MemberAcceptanceTest extends AcceptanceTest {
             () -> assertThat(membersResponse.getData()).usingRecursiveComparison().isEqualTo(
                 List.of(
                     MemberResponse.of(new Member(1L, "URookie", "T03LX3C5540",
-                        "루키", "image")),
+                        "루키", "rookie@gmail.com", "image")),
                     MemberResponse.of(new Member(2L, "UArthur", "T03LX3C5540",
-                        "아서", "image"))
+                        "아서", "arthur@gmail.com", "image"))
                 )
             ));
     }
@@ -56,7 +56,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
             () -> assertThat(extract.statusCode()).isEqualTo(HttpStatus.OK.value()),
             () -> assertThat(memberResponse).usingRecursiveComparison().isEqualTo(
                 MemberResponse.of(new Member(1L, "URookie", "T03LX3C5540",
-                    "루키", "image")))
+                    "루키", "rookie@gmail.com", "image")))
         );
     }
 

--- a/backend/src/test/java/com/woowacourse/kkogkkog/application/AuthServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/application/AuthServiceTest.java
@@ -36,7 +36,7 @@ class AuthServiceTest extends ServiceTest {
                         memberResponse.getUserId(),
                         memberResponse.getWorkspaceId(),
                         memberResponse.getNickname(),
-                        "email", // TODO: 깨지는 테스트 고치기 - 대안이 없음
+                        memberResponse.getEmail(),
                         memberResponse.getImageUrl()));
 
             TokenResponse tokenResponse = authService.login("code");

--- a/backend/src/test/java/com/woowacourse/kkogkkog/application/AuthServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/application/AuthServiceTest.java
@@ -36,6 +36,7 @@ class AuthServiceTest extends ServiceTest {
                         memberResponse.getUserId(),
                         memberResponse.getWorkspaceId(),
                         memberResponse.getNickname(),
+                        "email", // TODO: 깨지는 테스트 고치기 - 대안이 없음
                         memberResponse.getImageUrl()));
 
             TokenResponse tokenResponse = authService.login("code");

--- a/backend/src/test/java/com/woowacourse/kkogkkog/application/CouponServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/application/CouponServiceTest.java
@@ -30,10 +30,14 @@ import org.springframework.transaction.annotation.Transactional;
 @DisplayName("CouponService 클래스의")
 public class CouponServiceTest extends ServiceTest {
 
-    private static final Member JEONG = new Member(null, "UJeong", "T03LX3C5540", "정", "image");
-    private static final Member LEO = new Member(null, "ULeo", "T03LX3C5540", "레오", "image");
-    private static final Member ROOKIE = new Member(null, "URookie", "T03LX3C5540", "루키", "image");
-    private static final Member ARTHUR = new Member(null, "UArthur", "T03LX3C5540", "아서", "image");
+    private static final Member JEONG = new Member(null, "UJeong", "T03LX3C5540", "정",
+        "jeong@gmail.com", "image");
+    private static final Member LEO = new Member(null, "ULeo", "T03LX3C5540", "레오",
+        "leothelion@gmail.com", "image");
+    private static final Member ROOKIE = new Member(null, "URookie", "T03LX3C5540", "루키",
+        "rookie@gmail.com", "image");
+    private static final Member ARTHUR = new Member(null, "UArthur", "T03LX3C5540", "아서",
+        "arthur@gmail.com", "image");
 
     @Autowired
     private CouponService couponService;

--- a/backend/src/test/java/com/woowacourse/kkogkkog/application/MemberServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/application/MemberServiceTest.java
@@ -73,7 +73,8 @@ class MemberServiceTest extends ServiceTest {
             MemberResponse memberResponse = memberService.findById(memberId);
 
             assertThat(memberResponse).usingRecursiveComparison().ignoringFields("id").isEqualTo(
-                new MemberResponse(null, "URookie", "T03LX3C5540", "루키", "image")
+                new MemberResponse(null, "URookie", "T03LX3C5540", "루키", "rookie@gmail.com",
+                    "image")
             );
         }
 

--- a/backend/src/test/java/com/woowacourse/kkogkkog/application/MemberServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/application/MemberServiceTest.java
@@ -33,7 +33,7 @@ class MemberServiceTest extends ServiceTest {
         @DisplayName("가입되지 않은 회원 정보를 받으면, 회원을 저장하고 저장된 Id와 회원가입 여부를 반환한다.")
         void success_save() {
             SlackUserInfo slackUserInfo = new SlackUserInfo("URookie", "T03LX3C5540", "루키",
-                "image");
+                "rookie@gmail.com", "image");
 
             MemberCreateResponse memberCreateResponse = memberService.saveOrFind(slackUserInfo);
 
@@ -47,7 +47,7 @@ class MemberServiceTest extends ServiceTest {
         @DisplayName("가입된 회원 정보를 받으면, 해당 회원의 Id와 회원가입 여부를 반환한다.")
         void success_find() {
             SlackUserInfo slackUserInfo = new SlackUserInfo("URookie", "T03LX3C5540", "루키",
-                "image");
+                "rookie@gmail.com", "image");
 
             memberService.saveOrFind(slackUserInfo);
             MemberCreateResponse memberCreateResponse = memberService.saveOrFind(slackUserInfo);
@@ -67,7 +67,7 @@ class MemberServiceTest extends ServiceTest {
         @DisplayName("저장된 회원의 Id를 받으면, 해당 회원의 정보를 반환한다.")
         void success() {
             SlackUserInfo slackUserInfo = new SlackUserInfo("URookie", "T03LX3C5540", "루키",
-                "image");
+                "rookie@gmail.com", "image");
             Long memberId = memberService.saveOrFind(slackUserInfo).getId();
 
             MemberResponse memberResponse = memberService.findById(memberId);
@@ -95,9 +95,9 @@ class MemberServiceTest extends ServiceTest {
         @DisplayName("회원가입된 모든 회원들의 정보를 반환한다.")
         void success() {
             SlackUserInfo rookieUserInfo = new SlackUserInfo("URookie", "T03LX3C5540", "루키",
-                "image");
+                "rookie@gmail.com", "image");
             SlackUserInfo arthurUserInfo = new SlackUserInfo("UArthur", "T03LX3C5540", "아서",
-                "image");
+                "arthur@gmail.com", "image");
 
             memberService.saveOrFind(rookieUserInfo);
             memberService.saveOrFind(arthurUserInfo);
@@ -116,7 +116,7 @@ class MemberServiceTest extends ServiceTest {
         @DisplayName("사용자의 닉네임을 수정한다.")
         void success() {
             SlackUserInfo rookieUserInfo = new SlackUserInfo("URookie", "T03LX3C5540", "루키",
-                "image");
+                "rookie@gmail.com", "image");
             Long memberId = memberService.saveOrFind(rookieUserInfo).getId();
 
             String expected = "새로운_닉네임";

--- a/backend/src/test/java/com/woowacourse/kkogkkog/documentation/CouponControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/documentation/CouponControllerTest.java
@@ -101,6 +101,8 @@ class CouponControllerTest extends Documentation {
                         .description("쿠폰을 보낸 사람의 워크스페이스 ID"),
                     fieldWithPath("data.[].sender.nickname").type(JsonFieldType.STRING)
                         .description("쿠폰을 보낸 사람의 닉네임"),
+                    fieldWithPath("data.[].sender.email").type(JsonFieldType.STRING)
+                        .description("쿠폰을 보낸 사람의 이메일"),
                     fieldWithPath("data.[].sender.imageUrl").type(JsonFieldType.STRING)
                         .description("쿠폰을 보낸 사람의 이미지 URL"),
                     fieldWithPath("data.[].receiver.id").type(JsonFieldType.NUMBER)
@@ -111,6 +113,8 @@ class CouponControllerTest extends Documentation {
                         .description("쿠폰을 받을 사람의 워크스페이스 ID"),
                     fieldWithPath("data.[].receiver.nickname").type(JsonFieldType.STRING)
                         .description("쿠폰을 받을 사람의 닉네임"),
+                    fieldWithPath("data.[].receiver.email").type(JsonFieldType.STRING)
+                        .description("쿠폰을 받을 사람의 이메일"),
                     fieldWithPath("data.[].receiver.imageUrl").type(JsonFieldType.STRING)
                         .description("쿠폰을 받을 사람의 이미지 URL"),
                     fieldWithPath("data.[].backgroundColor").type(JsonFieldType.STRING)
@@ -158,6 +162,8 @@ class CouponControllerTest extends Documentation {
                         .description("보낸 사람 워크스페이스 ID"),
                     fieldWithPath("sender.nickname").type(JsonFieldType.STRING)
                         .description("보낸 사람 닉네임"),
+                    fieldWithPath("sender.email").type(JsonFieldType.STRING)
+                        .description("보낸 사람 이메일"),
                     fieldWithPath("sender.imageUrl").type(JsonFieldType.STRING)
                         .description("보낸 사람 이미지"),
                     fieldWithPath("receiver.id").type(JsonFieldType.NUMBER)
@@ -168,6 +174,8 @@ class CouponControllerTest extends Documentation {
                         .description("받는 사람 워크스페이스 ID"),
                     fieldWithPath("receiver.nickname").type(JsonFieldType.STRING)
                         .description("받는 사람 닉네임"),
+                    fieldWithPath("receiver.email").type(JsonFieldType.STRING)
+                        .description("받는 사람 이메일"),
                     fieldWithPath("receiver.imageUrl").type(JsonFieldType.STRING)
                         .description("받는 사람 이미지"),
                     fieldWithPath("backgroundColor").type(JsonFieldType.STRING)
@@ -223,6 +231,8 @@ class CouponControllerTest extends Documentation {
                         .description("보낸 사람 워크스페이스 ID"),
                     fieldWithPath("data.received.[].sender.nickname").type(JsonFieldType.STRING)
                         .description("보낸 사람 닉네임"),
+                    fieldWithPath("data.received.[].sender.email").type(JsonFieldType.STRING)
+                        .description("보낸 사람 이메일"),
                     fieldWithPath("data.received.[].sender.imageUrl").type(JsonFieldType.STRING)
                         .description("보낸 사람 이미지"),
                     fieldWithPath("data.received.[].receiver.id").type(JsonFieldType.NUMBER)
@@ -234,6 +244,8 @@ class CouponControllerTest extends Documentation {
                         .description("받는 사람 워크스페이스 ID"),
                     fieldWithPath("data.received.[].receiver.nickname").type(JsonFieldType.STRING)
                         .description("받는 사람 닉네임"),
+                    fieldWithPath("data.received.[].receiver.email").type(JsonFieldType.STRING)
+                        .description("받는 사람 이메일"),
                     fieldWithPath("data.received.[].receiver.imageUrl").type(JsonFieldType.STRING)
                         .description("받는 사람 이미지"),
                     fieldWithPath("data.received.[].backgroundColor").type(JsonFieldType.STRING)
@@ -259,6 +271,8 @@ class CouponControllerTest extends Documentation {
                         .description("보낸 사람 워크스페이스 ID"),
                     fieldWithPath("data.sent.[].sender.nickname").type(JsonFieldType.STRING)
                         .description("보낸 사람 닉네임"),
+                    fieldWithPath("data.sent.[].sender.email").type(JsonFieldType.STRING)
+                        .description("보낸 사람 이메일"),
                     fieldWithPath("data.sent.[].sender.imageUrl").type(JsonFieldType.STRING)
                         .description("보낸 사람 이미지"),
                     fieldWithPath("data.sent.[].receiver.id").type(JsonFieldType.NUMBER)
@@ -269,6 +283,8 @@ class CouponControllerTest extends Documentation {
                         .description("받는 사람 워크스페이스 ID"),
                     fieldWithPath("data.sent.[].receiver.nickname").type(JsonFieldType.STRING)
                         .description("받는 사람 닉네임"),
+                    fieldWithPath("data.sent.[].receiver.email").type(JsonFieldType.STRING)
+                        .description("보낸 사람 이메일"),
                     fieldWithPath("data.sent.[].receiver.imageUrl").type(JsonFieldType.STRING)
                         .description("받는 사람 이미지"),
                     fieldWithPath("data.sent.[].backgroundColor").type(JsonFieldType.STRING)

--- a/backend/src/test/java/com/woowacourse/kkogkkog/documentation/CouponControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/documentation/CouponControllerTest.java
@@ -42,9 +42,12 @@ class CouponControllerTest extends Documentation {
     private static final String MODIFIER = "한턱내는";
     private static final String MESSAGE = "추가 메세지";
     private static final CouponType COUPON_TYPE = CouponType.COFFEE;
-    public static final Member JEONG = new Member(1L, "UJeong", "T03LX3C5540", "정", "image");
-    public static final Member LEO = new Member(2L, "ULeo", "T03LX3C5540", "레오", "image");
-    public static final Member ARTHUR = new Member(3L, "UArthur", "T03LX3C5540", "아서", "image");
+    private static final Member JEONG = new Member(1L, "UJeong", "T03LX3C5540", "정",
+        "jeong@gmail.com", "image");
+    private static final Member LEO = new Member(2L, "ULeo", "T03LX3C5540", "레오",
+        "leothelion@gmail.com", "image");
+    private static final Member ARTHUR = new Member(3L, "UArthur", "T03LX3C5540", "아서",
+        "arthur@gmail.com", "image");
 
     @Test
     void 쿠폰_발급을_요청한다() throws Exception {
@@ -67,7 +70,8 @@ class CouponControllerTest extends Documentation {
         perform.andExpect(status().isCreated())
             .andExpect(
                 content().string(objectMapper.writeValueAsString(new SuccessResponse<>(List.of(
-                    toCreateCouponResponse(1L, JEONG, LEO), toCreateCouponResponse(2L, JEONG, ARTHUR))))));
+                    toCreateCouponResponse(1L, JEONG, LEO),
+                    toCreateCouponResponse(2L, JEONG, ARTHUR))))));
 
         // docs
         perform
@@ -225,7 +229,8 @@ class CouponControllerTest extends Documentation {
                         .description("받는 사람의 ID"),
                     fieldWithPath("data.received.[].receiver.userId").type(JsonFieldType.STRING)
                         .description("받는 사람 소셜 ID"),
-                    fieldWithPath("data.received.[].receiver.workspaceId").type(JsonFieldType.STRING)
+                    fieldWithPath("data.received.[].receiver.workspaceId").type(
+                            JsonFieldType.STRING)
                         .description("받는 사람 워크스페이스 ID"),
                     fieldWithPath("data.received.[].receiver.nickname").type(JsonFieldType.STRING)
                         .description("받는 사람 닉네임"),
@@ -316,7 +321,8 @@ class CouponControllerTest extends Documentation {
         CouponMemberResponse senderResponse = CouponMemberResponse.of(sender);
         CouponMemberResponse receiverResponse = CouponMemberResponse.of(receiver);
         return new CouponResponse(couponId, senderResponse, receiverResponse,
-            BACKGROUND_COLOR, LocalDate.of(2022, 07, 27), MODIFIER, MESSAGE, COUPON_TYPE.name(), CouponStatus.READY.name());
+            BACKGROUND_COLOR, LocalDate.of(2022, 07, 27), MODIFIER, MESSAGE, COUPON_TYPE.name(),
+            CouponStatus.READY.name());
     }
 
     private CouponResponse toCreateCouponResponse(Long couponId, Member sender, Member receiver) {

--- a/backend/src/test/java/com/woowacourse/kkogkkog/documentation/MemberControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/documentation/MemberControllerTest.java
@@ -31,8 +31,10 @@ public class MemberControllerTest extends Documentation {
     void 회원_전체를_조회할_수_있다() throws Exception {
         // given
         List<MemberResponse> membersResponse = List.of(
-            new MemberResponse(1L, "User1", "TWorkspace1", "user_nickname1", "image"),
-            new MemberResponse(2L, "User2", "TWorkspace2", "user_nickname2", "image")
+            new MemberResponse(1L, "User1", "TWorkspace1", "user_nickname1", "email1@gmail.com",
+                "image"),
+            new MemberResponse(2L, "User2", "TWorkspace2", "user_nickname2", "email2@gmail.com",
+                "image")
         );
         given(memberService.findAll()).willReturn(membersResponse);
 
@@ -54,6 +56,7 @@ public class MemberControllerTest extends Documentation {
                     fieldWithPath("data.[].workspaceId").type(JsonFieldType.STRING)
                         .description("워크스페이스 ID"),
                     fieldWithPath("data.[].nickname").type(JsonFieldType.STRING).description("닉네임"),
+                    fieldWithPath("data.[].email").type(JsonFieldType.STRING).description("이메일"),
                     fieldWithPath("data.[].imageUrl").type(JsonFieldType.STRING)
                         .description("이미지 주소")
                 ))
@@ -64,8 +67,7 @@ public class MemberControllerTest extends Documentation {
     void 나의_회원정보를_요청할_수_있다() throws Exception {
         // given
         MemberResponse memberResponse = new MemberResponse(1L, "User1", "TWorkspace1",
-            "user_nickname1",
-            "image");
+            "user_nickname1", "email1@gmail.com", "image");
 
         given(jwtTokenProvider.getValidatedPayload(any())).willReturn("1");
         given(memberService.findById(any())).willReturn(memberResponse);
@@ -80,6 +82,7 @@ public class MemberControllerTest extends Documentation {
             .andExpect(jsonPath("$.userId").value("User1"))
             .andExpect(jsonPath("$.workspaceId").value("TWorkspace1"))
             .andExpect(jsonPath("$.nickname").value("user_nickname1"))
+            .andExpect(jsonPath("$.email").value("email1@gmail.com"))
             .andExpect(jsonPath("$.imageUrl").value("image"));
 
         // docs
@@ -97,6 +100,7 @@ public class MemberControllerTest extends Documentation {
                     fieldWithPath("workspaceId").type(JsonFieldType.STRING)
                         .description("워크스페이스 ID"),
                     fieldWithPath("nickname").type(JsonFieldType.STRING).description("닉네임"),
+                    fieldWithPath("email").type(JsonFieldType.STRING).description("이메일"),
                     fieldWithPath("imageUrl").type(JsonFieldType.STRING).description("이미지 주소")
                 ))
             );

--- a/backend/src/test/java/com/woowacourse/kkogkkog/documentation/MemberControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/documentation/MemberControllerTest.java
@@ -110,8 +110,8 @@ public class MemberControllerTest extends Documentation {
         given(jwtTokenProvider.getValidatedPayload(any())).willReturn("1");
 
         // when
-        ResultActions perform = mockMvc.perform(put("/api/members/me/nickname")
-            .header("Authorization", "Bearer AccessToken")
+        ResultActions perform = mockMvc.perform(put("/api/members/me")
+            .header("Authorization", "Bearer accessToken")
             .content(objectMapper.writeValueAsString(memberUpdateMeRequest))
             .contentType(MediaType.APPLICATION_JSON));
 

--- a/backend/src/test/java/com/woowacourse/kkogkkog/fixture/MemberFixture.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/fixture/MemberFixture.java
@@ -5,11 +5,13 @@ import com.woowacourse.kkogkkog.domain.Member;
 public class MemberFixture {
 
     public static Member ROOKIE = new Member(null, "URookie", "T03LX3C5540",
-        "루키", "image");
+        "루키", "rookie@gmail.com", "image");
     public static Member ARTHUR = new Member(null, "UArthur", "T03LX3C5540",
-        "아서", "image");
-    public static Member JEONG = new Member(null, "UJeong", "T03LX3C5540", "정", "image");
-    public static Member LEO = new Member(null, "ULeo", "T03LX3C5540", "레오", "image");
-    public static Member NON_EXISTING_MEMBER = new Member(99999L, "UNonExistingMember", "T03LX3C5540",
-        "존재하지_않는_사용자", "image");
+        "아서", "arthur@gmail.com", "image");
+    public static Member JEONG = new Member(null, "UJeong", "T03LX3C5540",
+        "정", "jeong@gmail.com", "image");
+    public static Member LEO = new Member(null, "ULeo", "T03LX3C5540",
+        "레오", "leothelion@gmail.com", "image");
+    public static Member NON_EXISTING_MEMBER = new Member(99999L, "UNonExistingMember",
+        "T03LX3C5540", "존재하지_않는_사용자", "abc@gmail.com", "image");
 }


### PR DESCRIPTION
## 작업 내용

- 사용자 도메인에 email 필드 추가
- 사용자, 쿠폰 관련 API들 응답에 email 정보 추가 
- 슬랙 로그인시, 프로필과 함께 이메일도 함께 자동 업데이트되도록 설정

## 공유사항

- Member 도메인 수정이 좀 많이 힘드네요.
- REST DOCS에 수식어, 배경색이 있다거나, 테스트의 DisplayName 내용이라던가 짜잘하게 수정하고 싶은게 계속 보이네요.

Resolves #155
