### PR TITLE
feat: Slack Workspaces 앱 등록 기능 구현

### DIFF
--- a/backend/src/main/java/com/woowacourse/kkogkkog/application/AuthService.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/application/AuthService.java
@@ -1,9 +1,13 @@
 package com.woowacourse.kkogkkog.application;
 
-import com.woowacourse.kkogkkog.application.dto.TokenResponse;
 import com.woowacourse.kkogkkog.application.dto.MemberCreateResponse;
+import com.woowacourse.kkogkkog.application.dto.TokenResponse;
+import com.woowacourse.kkogkkog.domain.Workspace;
+import com.woowacourse.kkogkkog.domain.repository.WorkspaceRepository;
 import com.woowacourse.kkogkkog.infrastructure.SlackClient;
 import com.woowacourse.kkogkkog.infrastructure.SlackUserInfo;
+import com.woowacourse.kkogkkog.infrastructure.WorkspaceResponse;
+import java.util.Optional;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -13,16 +17,17 @@ public class AuthService {
 
     private final JwtTokenProvider jwtTokenProvider;
     private final MemberService memberService;
+    private final WorkspaceRepository workspaceRepository;
     private final SlackClient slackClient;
 
     public AuthService(JwtTokenProvider jwtTokenProvider, MemberService memberService,
-                       SlackClient slackClient) {
+                       WorkspaceRepository workspaceRepository, SlackClient slackClient) {
         this.jwtTokenProvider = jwtTokenProvider;
         this.memberService = memberService;
+        this.workspaceRepository = workspaceRepository;
         this.slackClient = slackClient;
     }
 
-    @Transactional(readOnly = true)
     public TokenResponse login(String code) {
         SlackUserInfo userInfo = slackClient.getUserInfoByCode(code);
         MemberCreateResponse memberCreateResponse = memberService.saveOrFind(userInfo);
@@ -30,5 +35,18 @@ public class AuthService {
         return new TokenResponse(
             jwtTokenProvider.createToken(memberCreateResponse.getId().toString()),
             memberCreateResponse.getIsNew());
+    }
+
+    public void installSlackApp(String code) {
+        WorkspaceResponse botTokenResponse = slackClient.requestBotAccessToken(code);
+        Optional<Workspace> workspace = workspaceRepository.findByWorkspaceId(
+            botTokenResponse.getWorkspaceId());
+
+        if (workspace.isPresent()) {
+            workspace.get().updateAccessToken(botTokenResponse.getAccessToken());
+            return;
+        }
+        workspaceRepository.save(new Workspace(null, botTokenResponse.getWorkspaceId(),
+            botTokenResponse.getWorkspaceName(), botTokenResponse.getAccessToken()));
     }
 }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/domain/Workspace.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/domain/Workspace.java
@@ -18,16 +18,16 @@ public class Workspace {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false)
-    private String name;
-
     @Column(nullable = false, unique = true)
     private String workspaceId;
 
     @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
     private String accessToken;
 
-    public Workspace(Long id, String name, String workspaceId, String accessToken) {
+    public Workspace(Long id, String workspaceId, String name, String accessToken) {
         this.id = id;
         this.name = name;
         this.workspaceId = workspaceId;

--- a/backend/src/main/java/com/woowacourse/kkogkkog/domain/Workspace.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/domain/Workspace.java
@@ -1,0 +1,40 @@
+package com.woowacourse.kkogkkog.domain;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Workspace {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false, unique = true)
+    private String workspaceId;
+
+    @Column(nullable = false)
+    private String accessToken;
+
+    public Workspace(Long id, String name, String workspaceId, String accessToken) {
+        this.id = id;
+        this.name = name;
+        this.workspaceId = workspaceId;
+        this.accessToken = accessToken;
+    }
+
+    public void updateAccessToken(String accessToken) {
+        this.accessToken = accessToken;
+    }
+}

--- a/backend/src/main/java/com/woowacourse/kkogkkog/domain/repository/WorkspaceRepository.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/domain/repository/WorkspaceRepository.java
@@ -1,0 +1,10 @@
+package com.woowacourse.kkogkkog.domain.repository;
+
+import com.woowacourse.kkogkkog.domain.Workspace;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface WorkspaceRepository extends JpaRepository<Workspace, Long> {
+
+    Optional<Workspace> findByWorkspaceId(String workspaceId);
+}

--- a/backend/src/main/java/com/woowacourse/kkogkkog/exception/auth/BotInstallationFailedException.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/exception/auth/BotInstallationFailedException.java
@@ -1,0 +1,8 @@
+package com.woowacourse.kkogkkog.exception.auth;
+
+public class BotInstallationFailedException extends RuntimeException {
+
+    public BotInstallationFailedException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/woowacourse/kkogkkog/infrastructure/BotTokenResponse.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/infrastructure/BotTokenResponse.java
@@ -12,22 +12,22 @@ public class BotTokenResponse {
     private Boolean ok;
     @JsonProperty(value = "access_token")
     private String accessToken;
-    private WorkspaceResponse team;
+    private TeamResponse team;
 
     public BotTokenResponse(Boolean ok, String accessToken, String workspaceId, String workspaceName) {
         this.ok = ok;
         this.accessToken = accessToken;
-        this.team = new WorkspaceResponse(workspaceId, workspaceName);
+        this.team = new TeamResponse(workspaceId, workspaceName);
     }
 
     @NoArgsConstructor(access = AccessLevel.PROTECTED)
     @Getter
-    public static class WorkspaceResponse {
+    public static class TeamResponse {
 
         private String id;
         private String name;
 
-        public WorkspaceResponse(String id, String name) {
+        public TeamResponse(String id, String name) {
             this.id = id;
             this.name = name;
         }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/infrastructure/BotTokenResponse.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/infrastructure/BotTokenResponse.java
@@ -1,0 +1,35 @@
+package com.woowacourse.kkogkkog.infrastructure;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class BotTokenResponse {
+
+    private Boolean ok;
+    @JsonProperty(value = "access_token")
+    private String accessToken;
+    private WorkspaceResponse team;
+
+    public BotTokenResponse(Boolean ok, String accessToken, String workspaceId, String workspaceName) {
+        this.ok = ok;
+        this.accessToken = accessToken;
+        this.team = new WorkspaceResponse(workspaceId, workspaceName);
+    }
+
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @Getter
+    public static class WorkspaceResponse {
+
+        private String id;
+        private String name;
+
+        public WorkspaceResponse(String id, String name) {
+            this.id = id;
+            this.name = name;
+        }
+    }
+}

--- a/backend/src/main/java/com/woowacourse/kkogkkog/infrastructure/SlackClient.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/infrastructure/SlackClient.java
@@ -2,6 +2,7 @@ package com.woowacourse.kkogkkog.infrastructure;
 
 import com.woowacourse.kkogkkog.exception.auth.AccessTokenRequestFailedException;
 import com.woowacourse.kkogkkog.exception.auth.AccessTokenRetrievalFailedException;
+import com.woowacourse.kkogkkog.exception.auth.BotInstallationFailedException;
 import com.woowacourse.kkogkkog.exception.auth.OAuthUserInfoRequestFailedException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
@@ -103,7 +104,7 @@ public class SlackClient {
             .orElseThrow(AccessTokenRequestFailedException::new);
 
         if (!botTokenResponse.getOk()) {
-            throw new AccessTokenRetrievalFailedException("슬랙 봇 등록에 실패하였습니다.");
+            throw new BotInstallationFailedException("슬랙 봇 등록에 실패하였습니다.");
         }
         return new WorkspaceResponse(botTokenResponse.getTeam().getId(),
             botTokenResponse.getTeam().getName(),

--- a/backend/src/main/java/com/woowacourse/kkogkkog/infrastructure/SlackClient.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/infrastructure/SlackClient.java
@@ -92,7 +92,7 @@ public class SlackClient {
             .orElseThrow(OAuthUserInfoRequestFailedException::new);
     }
 
-    public BotTokenResponse requestBotAccessToken(String code) {
+    public WorkspaceResponse requestBotAccessToken(String code) {
         BotTokenResponse botTokenResponse = botTokenClient
             .post()
             .uri(uriBuilder -> toRequestTokenUri(uriBuilder, code, BOT_TOKEN_REDIRECT_URL))
@@ -105,7 +105,9 @@ public class SlackClient {
         if (!botTokenResponse.getOk()) {
             throw new AccessTokenRetrievalFailedException("슬랙 봇 등록에 실패하였습니다.");
         }
-        return botTokenResponse;
+        return new WorkspaceResponse(botTokenResponse.getTeam().getId(),
+            botTokenResponse.getTeam().getName(),
+            botTokenResponse.getAccessToken());
     }
 
     private URI toRequestTokenUri(UriBuilder uriBuilder, String code, String redirectUri) {

--- a/backend/src/main/java/com/woowacourse/kkogkkog/infrastructure/SlackClient.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/infrastructure/SlackClient.java
@@ -18,11 +18,15 @@ import org.springframework.web.util.UriBuilder;
 @Component
 public class SlackClient {
 
-    private static final String OAUTH_LOGIN_URI = "https://slack.com/api/openid.connect.token";
-    private static final String OAUTH_USER_INFO = "https://slack.com/api/openid.connect.userInfo";
+    private static final String LOGIN_URI = "https://slack.com/api/openid.connect.token";
+    private static final String LOGIN_USER_INFO = "https://slack.com/api/openid.connect.userInfo";
+    private static final String LOGIN_REDIRECT_URL = "https://kkogkkog.com/download/redirect";
+    private static final String BOT_TOKEN_URI = "https://slack.com/api/oauth.v2.access";
+    private static final String BOT_TOKEN_REDIRECT_URL = "https://kkogkkog.com/download/redirect";
     private static final String CODE_PARAMETER = "code";
     private static final String CLIENT_ID_PARAMETER = "client_id";
     private static final String SECRET_ID_PARAMETER = "client_secret";
+    private static final String REDIRECT_URI_PARAMETER = "redirect_uri";
     private static final ParameterizedTypeReference<Map<String, Object>> PARAMETERIZED_TYPE_REFERENCE = new ParameterizedTypeReference<>() {
     };
 
@@ -33,8 +37,9 @@ public class SlackClient {
 
     public SlackClient(@Value("${security.slack.client-id}") String clientId,
                        @Value("${security.slack.secret-id}") String secretId,
-                       @Value(OAUTH_LOGIN_URI) String oAuthLoginUri,
-                       @Value(OAUTH_USER_INFO) String userInfoUri,
+                       @Value(LOGIN_URI) String oAuthLoginUri,
+                       @Value(LOGIN_USER_INFO) String userInfoUri,
+                       @Value(BOT_TOKEN_URI) String botTokenUri,
                        WebClient webClient) {
         this.clientId = clientId;
         this.secretId = secretId;
@@ -57,7 +62,7 @@ public class SlackClient {
     private String requestAccessToken(String code) {
         Map<String, Object> responseBody = oAuthLoginClient
             .post()
-            .uri(uriBuilder -> toRequestTokenUri(code, uriBuilder))
+            .uri(uriBuilder -> toRequestTokenUri(uriBuilder, code, LOGIN_REDIRECT_URL))
             .headers(this::setHeaders)
             .retrieve()
             .bodyToMono(PARAMETERIZED_TYPE_REFERENCE)
@@ -68,11 +73,12 @@ public class SlackClient {
         return responseBody.get("access_token").toString();
     }
 
-    private URI toRequestTokenUri(String code, UriBuilder uriBuilder) {
+    private URI toRequestTokenUri(UriBuilder uriBuilder, String code, String redirectUri) {
         return uriBuilder
             .queryParam(CODE_PARAMETER, code)
             .queryParam(CLIENT_ID_PARAMETER, clientId)
             .queryParam(SECRET_ID_PARAMETER, secretId)
+            .queryParam(REDIRECT_URI_PARAMETER, redirectUri)
             .build();
     }
 

--- a/backend/src/main/java/com/woowacourse/kkogkkog/infrastructure/WorkspaceResponse.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/infrastructure/WorkspaceResponse.java
@@ -1,0 +1,20 @@
+package com.woowacourse.kkogkkog.infrastructure;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class WorkspaceResponse {
+
+    private String workspaceId;
+    private String workspaceName;
+    private String accessToken;
+
+    public WorkspaceResponse(String workspaceId, String workspaceName, String accessToken) {
+        this.workspaceId = workspaceId;
+        this.workspaceName = workspaceName;
+        this.accessToken = accessToken;
+    }
+}

--- a/backend/src/main/java/com/woowacourse/kkogkkog/presentation/AuthController.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/presentation/AuthController.java
@@ -2,8 +2,11 @@ package com.woowacourse.kkogkkog.presentation;
 
 import com.woowacourse.kkogkkog.application.AuthService;
 import com.woowacourse.kkogkkog.application.dto.TokenResponse;
+import com.woowacourse.kkogkkog.presentation.dto.InstallSlackAppRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -23,5 +26,12 @@ public class AuthController {
         TokenResponse tokenResponse = authService.login(code);
 
         return ResponseEntity.ok(tokenResponse);
+    }
+
+    @PostMapping("/install/bot")
+    public ResponseEntity<Void> installSlackApp(@RequestBody InstallSlackAppRequest installSlackAppRequest) {
+        authService.installSlackApp(installSlackAppRequest.getCode());
+
+        return ResponseEntity.ok().build();
     }
 }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/presentation/dto/InstallSlackAppRequest.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/presentation/dto/InstallSlackAppRequest.java
@@ -1,0 +1,16 @@
+package com.woowacourse.kkogkkog.presentation.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class InstallSlackAppRequest {
+
+    private String code;
+
+    public InstallSlackAppRequest(String code) {
+        this.code = code;
+    }
+}

--- a/backend/src/test/java/com/woowacourse/kkogkkog/acceptance/AuthAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/acceptance/AuthAcceptanceTest.java
@@ -7,6 +7,8 @@ import com.woowacourse.kkogkkog.application.dto.MemberResponse;
 import com.woowacourse.kkogkkog.application.dto.TokenResponse;
 import com.woowacourse.kkogkkog.fixture.MemberFixture;
 import com.woowacourse.kkogkkog.infrastructure.SlackUserInfo;
+import com.woowacourse.kkogkkog.infrastructure.WorkspaceResponse;
+import com.woowacourse.kkogkkog.presentation.dto.InstallSlackAppRequest;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
@@ -36,6 +38,23 @@ public class AuthAcceptanceTest extends AcceptanceTest {
         Boolean actual = 회원가입_또는_로그인에_성공한다(memberResponse).getIsNew();
 
         assertThat(actual).isFalse();
+    }
+
+    @Test
+    void 슬랙_앱을_등록할_수_있다() {
+        given(slackClient.requestBotAccessToken(AUTHORIZATION_CODE))
+            .willReturn(
+                new WorkspaceResponse("ACCESS_TOKEN", "TEAM_ID", "꼭꼭"));
+
+        ExtractableResponse<Response> extract = RestAssured.given().log().all()
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .when()
+            .body(new InstallSlackAppRequest(AUTHORIZATION_CODE))
+            .post("/api/install/bot")
+            .then().log().all()
+            .extract();
+
+        assertThat(extract.statusCode()).isEqualTo(HttpStatus.OK.value());
     }
 
     public static TokenResponse 회원가입_또는_로그인에_성공한다(MemberResponse memberResponse) {

--- a/backend/src/test/java/com/woowacourse/kkogkkog/application/AuthServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/application/AuthServiceTest.java
@@ -2,6 +2,7 @@ package com.woowacourse.kkogkkog.application;
 
 import static com.woowacourse.kkogkkog.fixture.MemberFixture.ROOKIE;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 
@@ -9,6 +10,7 @@ import com.woowacourse.kkogkkog.application.dto.MemberResponse;
 import com.woowacourse.kkogkkog.application.dto.TokenResponse;
 import com.woowacourse.kkogkkog.exception.auth.AccessTokenRetrievalFailedException;
 import com.woowacourse.kkogkkog.infrastructure.SlackUserInfo;
+import com.woowacourse.kkogkkog.infrastructure.WorkspaceResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -19,6 +21,10 @@ import org.springframework.transaction.annotation.Transactional;
 @DisplayName("AuthService 클래스의")
 class AuthServiceTest extends ServiceTest {
 
+    private static final String AUTHORIZATION_CODE = "code";
+    private static final String ACCESS_TOKEN = "ACCESS_TOKEN";
+    private static final String TEAM_ID = "TEAM_ID";
+
     @Autowired
     private AuthService authService;
 
@@ -27,10 +33,10 @@ class AuthServiceTest extends ServiceTest {
     class Login {
 
         @Test
-        @DisplayName("등록된 회원 이메일과 비밀번호를 입력하면, 토큰을 반환한다.")
+        @DisplayName("임시 코드를 입력받으면, 토큰과 초기 사용자 여부를 반환한다.")
         void success() {
             MemberResponse memberResponse = MemberResponse.of(ROOKIE);
-            given(slackClient.getUserInfoByCode("code"))
+            given(slackClient.getUserInfoByCode(AUTHORIZATION_CODE))
                 .willReturn(
                     new SlackUserInfo(
                         memberResponse.getUserId(),
@@ -38,7 +44,7 @@ class AuthServiceTest extends ServiceTest {
                         memberResponse.getNickname(),
                         memberResponse.getImageUrl()));
 
-            TokenResponse tokenResponse = authService.login("code");
+            TokenResponse tokenResponse = authService.login(AUTHORIZATION_CODE);
 
             assertThat(tokenResponse).isNotNull();
         }
@@ -52,6 +58,34 @@ class AuthServiceTest extends ServiceTest {
             assertThatThrownBy(
                 () -> authService.login("invalid_code")
             ).isInstanceOf(AccessTokenRetrievalFailedException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("installSlackApp 메서드는")
+    class InstallSlackBot {
+
+        @Test
+        @DisplayName("임시 코드를 입력하면, 봇 토큰을 저장한다")
+        void success() {
+            given(slackClient.requestBotAccessToken(AUTHORIZATION_CODE))
+                .willReturn(new WorkspaceResponse(ACCESS_TOKEN, TEAM_ID, "꼭꼭"));
+
+            assertThatNoException()
+                .isThrownBy(() -> authService.installSlackApp(AUTHORIZATION_CODE));
+        }
+
+        @Test
+        @DisplayName("이미 등록된 워크스페이스인 경우, 엑세스 토큰을 업데이트한다.")
+        void success_update() {
+            given(slackClient.requestBotAccessToken(AUTHORIZATION_CODE))
+                .willReturn(new WorkspaceResponse(ACCESS_TOKEN, TEAM_ID, "꼭꼭"));
+            given(slackClient.requestBotAccessToken(AUTHORIZATION_CODE))
+                .willReturn(new WorkspaceResponse(ACCESS_TOKEN, TEAM_ID, "꼭꼭"));
+            authService.installSlackApp(AUTHORIZATION_CODE);
+
+            assertThatNoException()
+                .isThrownBy(() -> authService.installSlackApp(AUTHORIZATION_CODE));
         }
     }
 }

--- a/backend/src/test/java/com/woowacourse/kkogkkog/documentation/MemberControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/documentation/MemberControllerTest.java
@@ -158,7 +158,7 @@ public class MemberControllerTest extends Documentation {
         given(jwtTokenProvider.getValidatedPayload(any())).willReturn("1");
 
         // when
-        ResultActions perform = mockMvc.perform(put("/api/members/me/nickname")
+        ResultActions perform = mockMvc.perform(put("/api/members/me")
             .header("Authorization", "Bearer AccessToken")
             .content(objectMapper.writeValueAsString(memberUpdateMeRequest))
             .contentType(MediaType.APPLICATION_JSON));

--- a/backend/src/test/java/com/woowacourse/kkogkkog/infrastructure/SlackClientTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/infrastructure/SlackClientTest.java
@@ -90,9 +90,9 @@ class SlackClientTest {
         setUpResponse(mockWebServer, BOT_TOKEN_RESPONSE);
         SlackClient slackClient = buildMockSlackClient(mockWebServer);
 
-        BotTokenResponse actual = slackClient.requestBotAccessToken("code");
-        BotTokenResponse expected = new BotTokenResponse(true, "xoxb-bot-access-token", TEAM_ID,
-            "워크스페이스명");
+        WorkspaceResponse actual = slackClient.requestBotAccessToken("code");
+        WorkspaceResponse expected = new WorkspaceResponse(TEAM_ID, "워크스페이스명",
+            "xoxb-bot-access-token");
 
         assertThat(actual).usingRecursiveComparison().isEqualTo(expected);
     }

--- a/backend/src/test/java/com/woowacourse/kkogkkog/infrastructure/SlackClientTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/infrastructure/SlackClientTest.java
@@ -23,7 +23,7 @@ class SlackClientTest {
     private static final String JWT_USER_ID_TOKEN = "aaaaaa.bbbbbb.cccccc";
     private static final Map<String, String> SLACK_TOKEN_RESPONSE = new HashMap<>() {{
         put("ok", "true");
-        put("access_token", "ACCESS_TOKEN");
+        put("access_token", "xoxp-user-access-token");
         put("token_type", "Bearer");
         put("id_token", JWT_USER_ID_TOKEN);
     }};
@@ -39,6 +39,16 @@ class SlackClientTest {
         put("name", "kkogkkog");
         put("picture", "IMAGE_URL");
     }};
+    private static final String BOT_TOKEN_RESPONSE = "{\n"
+        + "    \"ok\": true,\n"
+        + "    \"token_type\": \"bot\",\n"
+        + "    \"access_token\": \"xoxb-bot-access-token\",\n"
+        + "    \"bot_user_id\": \"U03RM5SCKL6\",\n"
+        + "    \"team\": {\n"
+        + "        \"id\": \"" + TEAM_ID + "\",\n"
+        + "        \"name\": \"워크스페이스명\"\n"
+        + "    }\n"
+        + "}";
 
     private final ObjectMapper objectMapper = new ObjectMapper();
 
@@ -71,11 +81,27 @@ class SlackClientTest {
             .isInstanceOf(AccessTokenRetrievalFailedException.class);
     }
 
+    @Test
+    @DisplayName("인증 서버로 코드를 보내 봇의 엑세스 토큰을 받아온다.")
+    void requestBotAccessToken() throws IOException {
+        MockWebServer mockWebServer = new MockWebServer();
+        mockWebServer.start();
+
+        setUpResponse(mockWebServer, BOT_TOKEN_RESPONSE);
+        SlackClient slackClient = buildMockSlackClient(mockWebServer);
+
+        BotTokenResponse actual = slackClient.requestBotAccessToken("code");
+        BotTokenResponse expected = new BotTokenResponse(true, "xoxb-bot-access-token", TEAM_ID,
+            "워크스페이스명");
+
+        assertThat(actual).usingRecursiveComparison().isEqualTo(expected);
+    }
+
     private SlackClient buildMockSlackClient(MockWebServer mockWebServer) {
         String mockWebClientURI = String.format("http://%s:%s",
             mockWebServer.getHostName(), mockWebServer.getPort());
         return new SlackClient("clientId", "secretId",
-            mockWebClientURI, mockWebClientURI, WebClient.create());
+            mockWebClientURI, mockWebClientURI, mockWebClientURI, WebClient.create());
     }
 
     private void setUpResponse(MockWebServer mockWebServer, String responseBody) {

--- a/backend/src/test/java/com/woowacourse/kkogkkog/infrastructure/SlackClientTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/infrastructure/SlackClientTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.woowacourse.kkogkkog.exception.auth.AccessTokenRetrievalFailedException;
+import com.woowacourse.kkogkkog.exception.auth.BotInstallationFailedException;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
@@ -77,7 +78,7 @@ class SlackClientTest {
         setUpResponse(mockWebServer, objectMapper.writeValueAsString(SLACK_USER_INFO_RESPONSE));
         SlackClient slackClient = buildMockSlackClient(mockWebServer);
 
-        assertThatThrownBy(() -> slackClient.getUserInfoByCode("code"))
+        assertThatThrownBy(() -> slackClient.getUserInfoByCode("invalid_code"))
             .isInstanceOf(AccessTokenRetrievalFailedException.class);
     }
 
@@ -95,6 +96,19 @@ class SlackClientTest {
             "xoxb-bot-access-token");
 
         assertThat(actual).usingRecursiveComparison().isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("봇 등록에 실패하면 예외를 던진다")
+    void requestBotAccessToken_fail() throws IOException {
+        MockWebServer mockWebServer = new MockWebServer();
+        mockWebServer.start();
+
+        setUpResponse(mockWebServer, "{\"ok\":false}");
+        SlackClient slackClient = buildMockSlackClient(mockWebServer);
+
+        assertThatThrownBy(() -> slackClient.requestBotAccessToken("invalid_code"))
+            .isInstanceOf(BotInstallationFailedException.class);
     }
 
     private SlackClient buildMockSlackClient(MockWebServer mockWebServer) {


### PR DESCRIPTION
## 작업 내용

- 사용자의 워크스페이스에 앱을 등록
  - Slack 인증 서버에 워크스페이스 봇 토큰을 요청하는 기능 구현
  - 봇 엑세스 토큰 저장 요청 API 구현
  - 워크스페이스 아이디, 이름, 봇 엑세스 토큰을 가지는 Workspace 엔티티 구현

## 공유사항

Restdocs 아직 미작성

Resolves #157