### PR TITLE
feat: History 방문 여부에 대한 방문 상태 변경 기능

### DIFF
--- a/backend/src/docs/asciidoc/auth.adoc
+++ b/backend/src/docs/asciidoc/auth.adoc
@@ -7,4 +7,4 @@
 
 == Auth
 === 로그인
-operation::auth-login[snippets='http-request,http-response,request-fields,response-fields']
+operation::auth-login[snippets='http-request,http-response,response-fields']

--- a/backend/src/docs/asciidoc/coupon.adoc
+++ b/backend/src/docs/asciidoc/coupon.adoc
@@ -16,4 +16,4 @@ operation::coupon-show[snippets='http-request,http-response,response-fields']
 operation::coupon-showAll[snippets='http-request,http-response,response-fields']
 
 === 쿠폰 상태 변경
-operation::coupon-action[snippets='http-request,http-response,response-fields']
+operation::coupon-action[snippets='http-request,http-response']

--- a/backend/src/docs/asciidoc/member.adoc
+++ b/backend/src/docs/asciidoc/member.adoc
@@ -13,8 +13,11 @@ operation::member-showMe[snippets='http-request,http-response,response-fields']
 === 본인 이벤트 기록 조회
 operation::member-showMeHistory[snippets='http-request,http-response,response-fields']
 
+=== 본인 이벤트 방문 수정
+operation::member-updateMeHistory[snippets='http-request,http-response']
+
 === 전체 조회
 operation::member-showAll[snippets='http-request,http-response,response-fields']
 
 == 본인 정보 수정
-operation::member-update[snippets='http-request,http-response,response-fields']
+operation::member-update[snippets='http-request,http-response']

--- a/backend/src/main/java/com/woowacourse/kkogkkog/application/MemberService.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/application/MemberService.java
@@ -88,7 +88,7 @@ public class MemberService {
             .collect(toList());
     }
 
-    public void updateMemberHistory(Long memberHistoryId) {
+    public void updateIsReadMemberHistory(Long memberHistoryId) {
         MemberHistory memberHistory = memberHistoryRepository.findById(memberHistoryId)
             .orElseThrow(MemberHistoryNotFoundException::new);
 

--- a/backend/src/main/java/com/woowacourse/kkogkkog/application/MemberService.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/application/MemberService.java
@@ -10,6 +10,7 @@ import com.woowacourse.kkogkkog.domain.Member;
 import com.woowacourse.kkogkkog.domain.MemberHistory;
 import com.woowacourse.kkogkkog.domain.repository.MemberHistoryRepository;
 import com.woowacourse.kkogkkog.domain.repository.MemberRepository;
+import com.woowacourse.kkogkkog.exception.member.MemberHistoryNotFoundException;
 import com.woowacourse.kkogkkog.exception.member.MemberNotFoundException;
 import com.woowacourse.kkogkkog.infrastructure.SlackUserInfo;
 import java.util.List;
@@ -70,27 +71,27 @@ public class MemberService {
             .collect(toList());
     }
 
+    public void update(MemberUpdateRequest memberUpdateRequest) {
+        Member member = memberRepository.findById(memberUpdateRequest.getMemberId())
+            .orElseThrow(MemberNotFoundException::new);
+
+        member.updateNickname(memberUpdateRequest.getNickname());
+    }
+
     public List<MemberHistoryResponse> findHistoryById(Long memberId) {
         Member findMember = memberRepository.findById(memberId)
             .orElseThrow(MemberNotFoundException::new);
         List<MemberHistory> histories = memberHistoryRepository.findAllByHostMember(findMember);
 
         return histories.stream()
-            .map(it -> new MemberHistoryResponse(
-                it.getId(),
-                it.getTargetMember().getNickname(),
-                it.getTargetMember().getImageUrl(),
-                it.getCouponId(),
-                it.getCouponType().name(),
-                it.getCouponEvent().name(),
-                it.getMeetingDate()))
+            .map(MemberHistoryResponse::of)
             .collect(toList());
     }
 
-    public void update(MemberUpdateRequest memberUpdateRequest) {
-        Member member = memberRepository.findById(memberUpdateRequest.getMemberId())
-            .orElseThrow(MemberNotFoundException::new);
+    public void updateMemberHistory(Long memberHistoryId) {
+        MemberHistory memberHistory = memberHistoryRepository.findById(memberHistoryId)
+            .orElseThrow(MemberHistoryNotFoundException::new);
 
-        member.updateNickname(memberUpdateRequest.getNickname());
+        memberHistory.updateIsRead();
     }
 }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/application/dto/MemberHistoryResponse.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/application/dto/MemberHistoryResponse.java
@@ -2,6 +2,7 @@ package com.woowacourse.kkogkkog.application.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonFormat.Shape;
+import com.woowacourse.kkogkkog.domain.MemberHistory;
 import java.time.LocalDate;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -36,16 +37,14 @@ public class MemberHistoryResponse {
         this.meetingDate = meetingDate;
     }
 
-    @Override
-    public String toString() {
-        return "MemberHistoryResponse{" +
-            "id=" + id +
-            ", nickname='" + nickname + '\'' +
-            ", imageUrl='" + imageUrl + '\'' +
-            ", couponId=" + couponId +
-            ", couponType='" + couponType + '\'' +
-            ", couponEvent='" + couponEvent + '\'' +
-            ", meetingDate=" + meetingDate +
-            '}';
+    public static MemberHistoryResponse of(MemberHistory memberHistory) {
+        return new MemberHistoryResponse(
+            memberHistory.getId(),
+            memberHistory.getTargetMember().getNickname(),
+            memberHistory.getTargetMember().getImageUrl(),
+            memberHistory.getCouponId(),
+            memberHistory.getCouponType().name(),
+            memberHistory.getCouponEvent().name(),
+            memberHistory.getMeetingDate());
     }
 }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/application/dto/MemberHistoryResponse.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/application/dto/MemberHistoryResponse.java
@@ -20,6 +20,7 @@ public class MemberHistoryResponse {
     private String couponEvent;
     @JsonFormat(shape = Shape.STRING, pattern = "yyyy-MM-dd")
     private LocalDate meetingDate;
+    private Boolean isRead;
 
     public MemberHistoryResponse(Long id,
                                  String nickname,
@@ -27,7 +28,8 @@ public class MemberHistoryResponse {
                                  Long couponId,
                                  String couponType,
                                  String couponEvent,
-                                 LocalDate meetingDate) {
+                                 LocalDate meetingDate,
+                                 Boolean isRead) {
         this.id = id;
         this.nickname = nickname;
         this.imageUrl = imageUrl;
@@ -35,6 +37,7 @@ public class MemberHistoryResponse {
         this.couponType = couponType;
         this.couponEvent = couponEvent;
         this.meetingDate = meetingDate;
+        this.isRead = isRead;
     }
 
     public static MemberHistoryResponse of(MemberHistory memberHistory) {
@@ -45,6 +48,7 @@ public class MemberHistoryResponse {
             memberHistory.getCouponId(),
             memberHistory.getCouponType().name(),
             memberHistory.getCouponEvent().name(),
-            memberHistory.getMeetingDate());
+            memberHistory.getMeetingDate(),
+            memberHistory.getIsRead());
     }
 }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/config/InterceptorConfig.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/config/InterceptorConfig.java
@@ -19,7 +19,7 @@ public class InterceptorConfig implements WebMvcConfigurer {
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(new LoginInterceptor(jwtTokenProvider))
             .addPathPatterns("/api/members/me")
-            .addPathPatterns("/api/members/me/history")
+            .addPathPatterns("/api/members/me/*")
             .addPathPatterns("/api/coupons")
             .addPathPatterns("/api/coupons/*/event")
             .addPathPatterns("/api/coupons/*/event/*");

--- a/backend/src/main/java/com/woowacourse/kkogkkog/domain/Coupon.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/domain/Coupon.java
@@ -34,12 +34,10 @@ public class Coupon {
     @JoinColumn(name = "receiver_member_id")
     private Member receiver;
 
-    @Column(nullable = false)
     private String modifier;
 
     private String message;
 
-    @Column(nullable = false)
     private String backgroundColor;
 
     @Enumerated(EnumType.STRING)

--- a/backend/src/main/java/com/woowacourse/kkogkkog/domain/MemberHistory.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/domain/MemberHistory.java
@@ -58,9 +58,6 @@ public class MemberHistory {
     }
 
     public void updateIsRead() {
-        if (isRead) {
-            throw new InvalidRequestException("이미 변경된 상태입니다.");
-        }
         isRead = true;
     }
 }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/domain/MemberHistory.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/domain/MemberHistory.java
@@ -1,5 +1,6 @@
 package com.woowacourse.kkogkkog.domain;
 
+import com.woowacourse.kkogkkog.exception.InvalidRequestException;
 import java.time.LocalDate;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -37,6 +38,8 @@ public class MemberHistory {
 
     private LocalDate meetingDate;
 
+    private boolean isRead;
+
     public MemberHistory(Long id, Member hostMember,
                          Member targetMember, Long couponId,
                          CouponType couponType, CouponEvent couponEvent,
@@ -48,5 +51,12 @@ public class MemberHistory {
         this.couponType = couponType;
         this.couponEvent = couponEvent;
         this.meetingDate = meetingDate;
+    }
+
+    public void updateIsRead() {
+        if (isRead) {
+            throw new InvalidRequestException("이미 변경된 상태입니다.");
+        }
+        isRead = true;
     }
 }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/domain/MemberHistory.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/domain/MemberHistory.java
@@ -38,7 +38,7 @@ public class MemberHistory {
 
     private LocalDate meetingDate;
 
-    private boolean isRead;
+    private Boolean isRead = false;
 
     public MemberHistory(Long id, Member hostMember,
                          Member targetMember, Long couponId,

--- a/backend/src/main/java/com/woowacourse/kkogkkog/domain/MemberHistory.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/domain/MemberHistory.java
@@ -3,6 +3,8 @@ package com.woowacourse.kkogkkog.domain;
 import com.woowacourse.kkogkkog.exception.InvalidRequestException;
 import java.time.LocalDate;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -32,8 +34,10 @@ public class MemberHistory {
 
     private Long couponId;
 
+    @Enumerated(EnumType.STRING)
     private CouponType couponType;
 
+    @Enumerated(EnumType.STRING)
     private CouponEvent couponEvent;
 
     private LocalDate meetingDate;

--- a/backend/src/main/java/com/woowacourse/kkogkkog/exception/member/MemberHistoryNotFoundException.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/exception/member/MemberHistoryNotFoundException.java
@@ -1,0 +1,10 @@
+package com.woowacourse.kkogkkog.exception.member;
+
+import com.woowacourse.kkogkkog.exception.InvalidRequestException;
+
+public class MemberHistoryNotFoundException extends InvalidRequestException {
+
+    public MemberHistoryNotFoundException() {
+        super("찾을 수 없는 기록입니다.");
+    }
+}

--- a/backend/src/main/java/com/woowacourse/kkogkkog/presentation/MemberController.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/presentation/MemberController.java
@@ -52,7 +52,7 @@ public class MemberController {
 
     @PatchMapping("/me/histories/{historyId}")
     public ResponseEntity<Void> updateMemberHistory(@PathVariable Long historyId) {
-        memberService.updateMemberHistory(historyId);
+        memberService.updateIsReadMemberHistory(historyId);
 
         return ResponseEntity.noContent().build();
     }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/presentation/MemberController.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/presentation/MemberController.java
@@ -8,6 +8,8 @@ import com.woowacourse.kkogkkog.presentation.dto.MemberHistoriesResponse;
 import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -43,8 +45,15 @@ public class MemberController {
         return ResponseEntity.ok().build();
     }
 
-    @GetMapping("/me/history")
+    @GetMapping("/me/histories")
     public ResponseEntity<MemberHistoriesResponse> showHistory(@LoginMember Long id) {
         return ResponseEntity.ok(new MemberHistoriesResponse(memberService.findHistoryById(id)));
+    }
+
+    @PatchMapping("/me/histories/{historyId}")
+    public ResponseEntity<Void> updateMemberHistory(@PathVariable Long historyId) {
+        memberService.updateMemberHistory(historyId);
+
+        return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/test/java/com/woowacourse/kkogkkog/acceptance/MemberAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/acceptance/MemberAcceptanceTest.java
@@ -73,7 +73,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
         ExtractableResponse<Response> extract = RestAssured.given().log().all()
             .when()
             .auth().oauth2(arthurAccessToken)
-            .get("/api/members/me/history")
+            .get("/api/members/me/histories")
             .then().log().all()
             .extract();
 

--- a/backend/src/test/java/com/woowacourse/kkogkkog/acceptance/MemberAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/acceptance/MemberAcceptanceTest.java
@@ -85,6 +85,24 @@ public class MemberAcceptanceTest extends AcceptanceTest {
     }
 
     @Test
+    void 조회하지_않은_알림이면_알림의_방문상태가_변경된다() {
+        Member ROOKIE = new Member(1L, "URookie", "T03LX3C5540", "루키", "rookie@gmail.com", "image");
+        Member ARTHUR = new Member(2L, "UArthur", "T03LX3C5540", "아서", "arthur@gmail.com", "image");
+        String rookieAccessToken = 회원가입_또는_로그인에_성공한다(MemberResponse.of(ROOKIE)).getAccessToken();
+        String arthurAccessToken = 회원가입_또는_로그인에_성공한다(MemberResponse.of(ARTHUR)).getAccessToken();
+        쿠폰_발급에_성공한다(rookieAccessToken, List.of(ARTHUR));
+
+        ExtractableResponse<Response> extract = RestAssured.given().log().all()
+            .when()
+            .auth().oauth2(arthurAccessToken)
+            .patch("/api/members/me/histories/1")
+            .then().log().all()
+            .extract();
+
+        assertThat(extract.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+    }
+
+    @Test
     void 본인의_닉네임을_수정할_수_있다() {
         String newNickname = "새로운_닉네임";
         String rookieAccessToken = 회원가입_또는_로그인에_성공한다(MemberResponse.of(ROOKIE)).getAccessToken();

--- a/backend/src/test/java/com/woowacourse/kkogkkog/application/MemberServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/application/MemberServiceTest.java
@@ -162,24 +162,6 @@ class MemberServiceTest extends ServiceTest {
 
             assertDoesNotThrow(() -> memberService.updateMemberHistory(1L));
         }
-
-        @Test
-        @DisplayName("이미 isRead 가 true일 경우 예외를 던진다.")
-        void fail_isReadTrue() {
-            SlackUserInfo rookieUserInfo = new SlackUserInfo("URookie", "T03LX3C5540", "루키",
-                "rookie@gmail.com", "image");
-            SlackUserInfo arthurUserInfo = new SlackUserInfo("UArthur", "T03LX3C5540", "아서",
-                "arthur@gmail.com", "image");
-            MemberCreateResponse rookieCreateResponse = memberService.saveOrFind(rookieUserInfo);
-            MemberCreateResponse arthurCreateResponse = memberService.saveOrFind(arthurUserInfo);
-            CouponSaveRequest couponSaveRequest = new CouponSaveRequest(
-                rookieCreateResponse.getId(), List.of(arthurCreateResponse.getId()), "한턱쏘는", "추가 메세지", "##11032", "COFFEE");
-            couponService.save(couponSaveRequest);
-            memberService.updateMemberHistory(1L);
-
-            assertThatThrownBy(() -> memberService.updateMemberHistory(1L))
-                .isInstanceOf(InvalidRequestException.class);
-        }
     }
 
     @Nested

--- a/backend/src/test/java/com/woowacourse/kkogkkog/application/MemberServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/application/MemberServiceTest.java
@@ -11,7 +11,6 @@ import com.woowacourse.kkogkkog.application.dto.MemberResponse;
 import com.woowacourse.kkogkkog.application.dto.MemberCreateResponse;
 import com.woowacourse.kkogkkog.application.dto.MemberUpdateRequest;
 import com.woowacourse.kkogkkog.domain.Member;
-import com.woowacourse.kkogkkog.exception.InvalidRequestException;
 import com.woowacourse.kkogkkog.exception.member.MemberNotFoundException;
 import com.woowacourse.kkogkkog.fixture.MemberFixture;
 import com.woowacourse.kkogkkog.infrastructure.SlackUserInfo;
@@ -144,8 +143,8 @@ class MemberServiceTest extends ServiceTest {
     }
 
     @Nested
-    @DisplayName("updateMemberHistory 메서드는")
-    class UpdateMemberHistory {
+    @DisplayName("updateIsReadMemberHistory 메서드는")
+    class UpdateIsReadMemberHistory {
 
         @Test
         @DisplayName("요청받을 경우 true 로 변경된다.")
@@ -160,7 +159,7 @@ class MemberServiceTest extends ServiceTest {
                 rookieCreateResponse.getId(), List.of(arthurCreateResponse.getId()), "한턱쏘는", "추가 메세지", "##11032", "COFFEE");
             couponService.save(couponSaveRequest);
 
-            assertDoesNotThrow(() -> memberService.updateMemberHistory(1L));
+            assertDoesNotThrow(() -> memberService.updateIsReadMemberHistory(1L));
         }
     }
 

--- a/backend/src/test/java/com/woowacourse/kkogkkog/documentation/MemberControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/documentation/MemberControllerTest.java
@@ -160,7 +160,7 @@ public class MemberControllerTest extends Documentation {
     @Test
     void 조회된_기록들의_방문_여부를_업데이트_할_수_있다() throws Exception {
         // given
-        doNothing().when(memberService).updateMemberHistory(any());
+        doNothing().when(memberService).updateIsReadMemberHistory(any());
         given(jwtTokenProvider.getValidatedPayload(any())).willReturn("1");
 
         // when

--- a/backend/src/test/java/com/woowacourse/kkogkkog/documentation/MemberControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/documentation/MemberControllerTest.java
@@ -113,7 +113,7 @@ public class MemberControllerTest extends Documentation {
     void 나의_기록들을_조회할_수_있다() throws Exception {
         // given
         List<MemberHistoryResponse> historiesResponse = List.of(
-            new MemberHistoryResponse(1L, "루키", "image", 1L, "COFFEE", "INIT", null));
+            new MemberHistoryResponse(1L, "루키", "image", 1L, "COFFEE", "INIT", null, false));
 
         given(jwtTokenProvider.getValidatedPayload(any())).willReturn("1");
         given(memberService.findHistoryById(any())).willReturn(historiesResponse);
@@ -149,7 +149,8 @@ public class MemberControllerTest extends Documentation {
                         .description("이벤트에 해당하는 쿠폰 타입"),
                     fieldWithPath("data.[].couponEvent").type(JsonFieldType.STRING)
                         .description("이벤트에 쿠폰 이벤트"),
-                    fieldWithPath("data.[].meetingDate").description("이벤트의 예약 날짜")
+                    fieldWithPath("data.[].meetingDate").description("이벤트의 예약 날짜"),
+                    fieldWithPath("data.[].isRead").type(JsonFieldType.BOOLEAN).description("이벤트 클릭(조회) 여부")
                 ))
             );
     }

--- a/backend/src/test/java/com/woowacourse/kkogkkog/documentation/MemberControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/documentation/MemberControllerTest.java
@@ -4,10 +4,12 @@ import static com.woowacourse.kkogkkog.documentation.support.ApiDocumentUtils.ge
 import static com.woowacourse.kkogkkog.documentation.support.ApiDocumentUtils.getDocumentResponse;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
@@ -119,7 +121,7 @@ public class MemberControllerTest extends Documentation {
         given(memberService.findHistoryById(any())).willReturn(historiesResponse);
 
         // when
-        ResultActions perform = mockMvc.perform(get("/api/members/me/history")
+        ResultActions perform = mockMvc.perform(get("/api/members/me/histories")
             .header("Authorization", "Bearer AccessToken"));
 
         // then
@@ -152,6 +154,27 @@ public class MemberControllerTest extends Documentation {
                     fieldWithPath("data.[].meetingDate").description("이벤트의 예약 날짜"),
                     fieldWithPath("data.[].isRead").type(JsonFieldType.BOOLEAN).description("이벤트 클릭(조회) 여부")
                 ))
+            );
+    }
+
+    @Test
+    void 조회된_기록들의_방문_여부를_업데이트_할_수_있다() throws Exception {
+        // given
+        doNothing().when(memberService).updateMemberHistory(any());
+        given(jwtTokenProvider.getValidatedPayload(any())).willReturn("1");
+
+        // when
+        ResultActions perform = mockMvc.perform(patch("/api/members/me/histories/{historyId}", 1L));
+
+        // then
+        perform.andExpect(status().isNoContent());
+
+        // docs
+        perform
+            .andDo(print())
+            .andDo(document("member-updateMeHistory",
+                getDocumentRequest(),
+                getDocumentResponse())
             );
     }
 

--- a/backend/src/test/java/com/woowacourse/kkogkkog/domain/MemberHistoryTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/domain/MemberHistoryTest.java
@@ -22,6 +22,6 @@ class MemberHistoryTest {
         memberHistory.updateIsRead();
 
         // then
-        assertThat(memberHistory.isRead()).isTrue();
+        assertThat(memberHistory.getIsRead()).isTrue();
     }
 }

--- a/backend/src/test/java/com/woowacourse/kkogkkog/domain/MemberHistoryTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/domain/MemberHistoryTest.java
@@ -1,0 +1,27 @@
+package com.woowacourse.kkogkkog.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class MemberHistoryTest {
+
+    @Test
+    @DisplayName("단일 알림에 대해서 읽지 않았을 경우, 읽음으로 상태를 변경한다")
+    void isRead() {
+        // given
+        Member sender = new Member(1L, "userId", "workspaceId", "sender", "email", "imageUrl");
+        Member receiver = new Member(1L, "userId", "workspaceId", "receiver", "email", "imageUrl");
+        MemberHistory memberHistory = new MemberHistory(
+            1L, sender, receiver, 1L,
+            CouponType.valueOf("COFFEE"), CouponEvent.INIT, LocalDate.now());
+
+        // when
+        memberHistory.updateIsRead();
+
+        // then
+        assertThat(memberHistory.isRead()).isTrue();
+    }
+}


### PR DESCRIPTION
## 작업 내용

- 사용자가 알림함을 상세 조회할 경우 방문 여부가 변경되는 기능을 구현

## 공유사항

해당 PR에서 기능과 무관하게 변경된 부분이 있습니다!!
- /api/history -> /api/histories
- 사용되지 않은 컬럼 임시로 nullable 제거

Resolves #164
