### PR TITLE
feat: 본인 정보 조회 API에 읽지 않은 알림 개수 정보 포함

### DIFF
--- a/backend/src/main/java/com/woowacourse/kkogkkog/application/MemberService.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/application/MemberService.java
@@ -2,10 +2,11 @@ package com.woowacourse.kkogkkog.application;
 
 import static java.util.stream.Collectors.toList;
 
-import com.woowacourse.kkogkkog.application.dto.MemberHistoryResponse;
 import com.woowacourse.kkogkkog.application.dto.MemberCreateResponse;
+import com.woowacourse.kkogkkog.application.dto.MemberHistoryResponse;
 import com.woowacourse.kkogkkog.application.dto.MemberResponse;
 import com.woowacourse.kkogkkog.application.dto.MemberUpdateRequest;
+import com.woowacourse.kkogkkog.application.dto.MyProfileResponse;
 import com.woowacourse.kkogkkog.domain.Member;
 import com.woowacourse.kkogkkog.domain.MemberHistory;
 import com.woowacourse.kkogkkog.domain.repository.MemberHistoryRepository;
@@ -62,6 +63,15 @@ public class MemberService {
             .orElseThrow(MemberNotFoundException::new);
 
         return MemberResponse.of(findMember);
+    }
+
+    @Transactional(readOnly = true)
+    public MyProfileResponse findById2(Long memberId) {
+        Member findMember = memberRepository.findById(memberId)
+            .orElseThrow(MemberNotFoundException::new);
+        long unreadHistoryCount = memberHistoryRepository.countByHostMemberAndIsReadFalse(findMember);
+
+        return MyProfileResponse.of(findMember, unreadHistoryCount);
     }
 
     @Transactional(readOnly = true)

--- a/backend/src/main/java/com/woowacourse/kkogkkog/application/MemberService.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/application/MemberService.java
@@ -58,15 +58,7 @@ public class MemberService {
     }
 
     @Transactional(readOnly = true)
-    public MemberResponse findById(Long memberId) {
-        Member findMember = memberRepository.findById(memberId)
-            .orElseThrow(MemberNotFoundException::new);
-
-        return MemberResponse.of(findMember);
-    }
-
-    @Transactional(readOnly = true)
-    public MyProfileResponse findById2(Long memberId) {
+    public MyProfileResponse findById(Long memberId) {
         Member findMember = memberRepository.findById(memberId)
             .orElseThrow(MemberNotFoundException::new);
         long unreadHistoryCount = memberHistoryRepository.countByHostMemberAndIsReadFalse(findMember);

--- a/backend/src/main/java/com/woowacourse/kkogkkog/application/dto/MyProfileResponse.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/application/dto/MyProfileResponse.java
@@ -1,0 +1,42 @@
+package com.woowacourse.kkogkkog.application.dto;
+
+import com.woowacourse.kkogkkog.domain.Member;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class MyProfileResponse {
+
+    private Long id;
+    private String userId;
+    private String workspaceId;
+    private String nickname;
+    private String email;
+    private String imageUrl;
+    private Long unReadCount;
+
+    public MyProfileResponse(Long id, String userId, String workspaceId, String nickname,
+                             String email, String imageUrl, Long unReadCount) {
+        this.id = id;
+        this.userId = userId;
+        this.workspaceId = workspaceId;
+        this.nickname = nickname;
+        this.email = email;
+        this.imageUrl = imageUrl;
+        this.unReadCount = unReadCount;
+    }
+
+    public static MyProfileResponse of(Member member,  Long unreadHistoryCount) {
+        return new MyProfileResponse(
+            member.getId(),
+            member.getUserId(),
+            member.getWorkspaceId(),
+            member.getNickname(),
+            member.getEmail(),
+            member.getImageUrl(),
+            unreadHistoryCount
+        );
+    }
+}

--- a/backend/src/main/java/com/woowacourse/kkogkkog/domain/repository/MemberHistoryRepository.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/domain/repository/MemberHistoryRepository.java
@@ -8,4 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface MemberHistoryRepository extends JpaRepository<MemberHistory, Long> {
 
     List<MemberHistory> findAllByHostMember(Member member);
+
+    long countByHostMemberAndIsReadFalse(Member member);
 }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/presentation/MemberController.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/presentation/MemberController.java
@@ -2,6 +2,7 @@ package com.woowacourse.kkogkkog.presentation;
 
 import com.woowacourse.kkogkkog.application.MemberService;
 import com.woowacourse.kkogkkog.application.dto.MemberResponse;
+import com.woowacourse.kkogkkog.application.dto.MyProfileResponse;
 import com.woowacourse.kkogkkog.presentation.dto.MemberUpdateMeRequest;
 import com.woowacourse.kkogkkog.presentation.dto.SuccessResponse;
 import com.woowacourse.kkogkkog.presentation.dto.MemberHistoriesResponse;
@@ -31,8 +32,8 @@ public class MemberController {
     }
 
     @GetMapping("/me")
-    public ResponseEntity<MemberResponse> showMe(@LoginMember Long id) {
-        MemberResponse memberResponse = memberService.findById(id);
+    public ResponseEntity<MyProfileResponse> showMe(@LoginMember Long id) {
+        MyProfileResponse memberResponse = memberService.findById(id);
 
         return ResponseEntity.ok(memberResponse);
     }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -13,7 +13,7 @@ spring:
   config.activate.on-profile: prod
   jpa:
     hibernate:
-      ddl-auto: validate
+      ddl-auto: none
     database-platform: org.hibernate.dialect.MySQL5InnoDBDialect
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver

--- a/backend/src/test/java/com/woowacourse/kkogkkog/acceptance/MemberAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/acceptance/MemberAcceptanceTest.java
@@ -8,6 +8,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.woowacourse.kkogkkog.application.dto.MemberResponse;
+import com.woowacourse.kkogkkog.application.dto.MyProfileResponse;
 import com.woowacourse.kkogkkog.domain.Member;
 import com.woowacourse.kkogkkog.presentation.dto.MemberHistoriesResponse;
 import com.woowacourse.kkogkkog.presentation.dto.MemberUpdateMeRequest;
@@ -52,13 +53,13 @@ public class MemberAcceptanceTest extends AcceptanceTest {
         회원가입_또는_로그인에_성공한다(MemberResponse.of(ARTHUR));
 
         ExtractableResponse<Response> extract = 본인_정보_조회를_요청한다(rookieAccessToken);
-        MemberResponse memberResponse = extract.as(MemberResponse.class);
+        MyProfileResponse memberResponse = extract.as(MyProfileResponse.class);
 
         assertAll(
             () -> assertThat(extract.statusCode()).isEqualTo(HttpStatus.OK.value()),
             () -> assertThat(memberResponse).usingRecursiveComparison().isEqualTo(
-                MemberResponse.of(new Member(1L, "URookie", "T03LX3C5540",
-                    "루키", "rookie@gmail.com", "image")))
+                new MyProfileResponse(1L, "URookie", "T03LX3C5540",
+                    "루키", "rookie@gmail.com", "image", 0L))
         );
     }
 
@@ -109,7 +110,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
 
         프로필_수정을_성공하고(newNickname, rookieAccessToken);
         ExtractableResponse<Response> extract = 본인_정보_조회를_요청한다(rookieAccessToken);
-        String actual = extract.as(MemberResponse.class).getNickname();
+        String actual = extract.as(MyProfileResponse.class).getNickname();
 
         assertThat(actual).isEqualTo(newNickname);
     }

--- a/backend/src/test/java/com/woowacourse/kkogkkog/application/MemberServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/application/MemberServiceTest.java
@@ -1,15 +1,15 @@
 package com.woowacourse.kkogkkog.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import com.woowacourse.kkogkkog.application.dto.CouponSaveRequest;
+import com.woowacourse.kkogkkog.application.dto.MemberCreateResponse;
 import com.woowacourse.kkogkkog.application.dto.MemberHistoryResponse;
 import com.woowacourse.kkogkkog.application.dto.MemberResponse;
-import com.woowacourse.kkogkkog.application.dto.MemberCreateResponse;
 import com.woowacourse.kkogkkog.application.dto.MemberUpdateRequest;
+import com.woowacourse.kkogkkog.application.dto.MyProfileResponse;
 import com.woowacourse.kkogkkog.domain.Member;
 import com.woowacourse.kkogkkog.exception.member.MemberNotFoundException;
 import com.woowacourse.kkogkkog.fixture.MemberFixture;
@@ -77,11 +77,11 @@ class MemberServiceTest extends ServiceTest {
                 "rookie@gmail.com", "image");
             Long memberId = memberService.saveOrFind(slackUserInfo).getId();
 
-            MemberResponse memberResponse = memberService.findById(memberId);
+            MyProfileResponse memberResponse = memberService.findById2(memberId);
 
             assertThat(memberResponse).usingRecursiveComparison().ignoringFields("id").isEqualTo(
-                new MemberResponse(null, "URookie", "T03LX3C5540", "루키", "rookie@gmail.com",
-                    "image")
+                new MyProfileResponse(null, "URookie", "T03LX3C5540", "루키", "rookie@gmail.com",
+                    "image", 0L)
             );
         }
 
@@ -90,7 +90,7 @@ class MemberServiceTest extends ServiceTest {
         void fail_noExistMember() {
             Member nonExistingMember = MemberFixture.NON_EXISTING_MEMBER;
 
-            Assertions.assertThatThrownBy(() -> memberService.findById(nonExistingMember.getId()))
+            Assertions.assertThatThrownBy(() -> memberService.findById2(nonExistingMember.getId()))
                 .isInstanceOf(MemberNotFoundException.class);
         }
     }

--- a/backend/src/test/java/com/woowacourse/kkogkkog/application/MemberServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/application/MemberServiceTest.java
@@ -77,7 +77,7 @@ class MemberServiceTest extends ServiceTest {
                 "rookie@gmail.com", "image");
             Long memberId = memberService.saveOrFind(slackUserInfo).getId();
 
-            MyProfileResponse memberResponse = memberService.findById2(memberId);
+            MyProfileResponse memberResponse = memberService.findById(memberId);
 
             assertThat(memberResponse).usingRecursiveComparison().ignoringFields("id").isEqualTo(
                 new MyProfileResponse(null, "URookie", "T03LX3C5540", "루키", "rookie@gmail.com",
@@ -90,7 +90,7 @@ class MemberServiceTest extends ServiceTest {
         void fail_noExistMember() {
             Member nonExistingMember = MemberFixture.NON_EXISTING_MEMBER;
 
-            Assertions.assertThatThrownBy(() -> memberService.findById2(nonExistingMember.getId()))
+            Assertions.assertThatThrownBy(() -> memberService.findById(nonExistingMember.getId()))
                 .isInstanceOf(MemberNotFoundException.class);
         }
     }

--- a/backend/src/test/java/com/woowacourse/kkogkkog/documentation/MemberControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/documentation/MemberControllerTest.java
@@ -21,6 +21,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.woowacourse.kkogkkog.application.dto.MemberHistoryResponse;
 import com.woowacourse.kkogkkog.application.dto.MemberResponse;
+import com.woowacourse.kkogkkog.application.dto.MyProfileResponse;
 import com.woowacourse.kkogkkog.presentation.dto.MemberHistoriesResponse;
 import com.woowacourse.kkogkkog.presentation.dto.MemberUpdateMeRequest;
 import java.util.List;
@@ -71,8 +72,8 @@ public class MemberControllerTest extends Documentation {
     @Test
     void 나의_회원정보를_요청할_수_있다() throws Exception {
         // given
-        MemberResponse memberResponse = new MemberResponse(1L, "User1", "TWorkspace1",
-            "user_nickname1", "email1@gmail.com", "image");
+        MyProfileResponse memberResponse = new MyProfileResponse(1L, "User1", "TWorkspace1",
+            "user_nickname1", "email1@gmail.com", "image", 10L);
 
         given(jwtTokenProvider.getValidatedPayload(any())).willReturn("1");
         given(memberService.findById(any())).willReturn(memberResponse);
@@ -106,7 +107,8 @@ public class MemberControllerTest extends Documentation {
                         .description("워크스페이스 ID"),
                     fieldWithPath("nickname").type(JsonFieldType.STRING).description("닉네임"),
                     fieldWithPath("email").type(JsonFieldType.STRING).description("이메일"),
-                    fieldWithPath("imageUrl").type(JsonFieldType.STRING).description("이미지 주소")
+                    fieldWithPath("imageUrl").type(JsonFieldType.STRING).description("이미지 주소"),
+                    fieldWithPath("unReadCount").type(JsonFieldType.NUMBER).description("읽지 않은 알림 개수")
                 ))
             );
     }

--- a/backend/src/test/java/com/woowacourse/kkogkkog/domain/repository/MemberHistoryRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/domain/repository/MemberHistoryRepositoryTest.java
@@ -8,6 +8,7 @@ import com.woowacourse.kkogkkog.domain.CouponStatus;
 import com.woowacourse.kkogkkog.domain.CouponType;
 import com.woowacourse.kkogkkog.domain.Member;
 import com.woowacourse.kkogkkog.domain.MemberHistory;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
@@ -27,6 +28,7 @@ class MemberHistoryRepositoryTest {
     private MemberHistoryRepository memberHistories;
 
     @Test
+    @DisplayName("countByHostMemberAndIsReadFalse 메서드는 기록의 주인이 읽지 안은 기록들의 개수를 반환한다.")
     void countByHostMemberAndIsReadFalse() {
         Member sender = members.save(new Member(null, "UJeong", "T03LX3C5540",
             "정", "jeong@gmail.com", "image"));

--- a/backend/src/test/java/com/woowacourse/kkogkkog/domain/repository/MemberHistoryRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/domain/repository/MemberHistoryRepositoryTest.java
@@ -1,0 +1,54 @@
+package com.woowacourse.kkogkkog.domain.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.woowacourse.kkogkkog.domain.Coupon;
+import com.woowacourse.kkogkkog.domain.CouponEvent;
+import com.woowacourse.kkogkkog.domain.CouponStatus;
+import com.woowacourse.kkogkkog.domain.CouponType;
+import com.woowacourse.kkogkkog.domain.Member;
+import com.woowacourse.kkogkkog.domain.MemberHistory;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class MemberHistoryRepositoryTest {
+
+    @Autowired
+    private CouponRepository coupons;
+
+    @Autowired
+    private MemberRepository members;
+
+    @Autowired
+    private MemberHistoryRepository memberHistories;
+
+    @Test
+    void countByHostMemberAndIsReadFalse() {
+        Member sender = members.save(new Member(null, "UJeong", "T03LX3C5540",
+            "정", "jeong@gmail.com", "image"));
+        Member receiver = members.save(new Member(null, "ULeo", "T03LX3C5540",
+            "레오", "leothelion@gmail.com", "image"));
+        Coupon coupon = coupons.save(new Coupon(null, sender, receiver, "한턱쏘는",
+            "추가 메세지", "#241223", CouponType.COFFEE, CouponStatus.READY));
+
+        MemberHistory initHistory = toMemberHistory(receiver, sender, coupon, CouponEvent.INIT);
+        initHistory.updateIsRead();
+        memberHistories.save(initHistory);
+        memberHistories.save(toMemberHistory(sender, receiver, coupon, CouponEvent.REQUEST));
+        memberHistories.save(toMemberHistory(receiver, sender, coupon, CouponEvent.DECLINE));
+        memberHistories.flush();
+
+        long actual = memberHistories.countByHostMemberAndIsReadFalse(receiver);
+        assertThat(actual).isEqualTo(1L);
+    }
+
+    private MemberHistory toMemberHistory(Member hostMember, Member targetMember, Coupon coupon,
+                                          CouponEvent event) {
+        return new MemberHistory(null, hostMember, targetMember, coupon.getId(),
+            coupon.getCouponType(), event, coupon.getMeetingDate());
+    }
+}


### PR DESCRIPTION
## 작업 내용

- 기존에 존재하는 본인 정보 조회 API에 읽지 않은 알림 개수 정보를 포함시킴
- prod 프로파일로 배포시, 스키마 검증을 실행하지 않도록 수정

## 공유사항

`MemberHistoryRepositoryTest`를 만든 이유는 
1) `countByHostMemberAndIsReadFalse` 메서드의 정상동작 여부를 다른 테스트에 포함시키자니 너무 더러워져서 
2) 그리고 쿠폰을 보낸 사람과 받은 사람이 `MemberHistoryRepository` 도메인의 hostMember & targetMember에 어떻게 대입되는지 설명을 좀 남기고 싶어서입니다.

Resolves #166
