### PR TITLE
feat: MemberHistory Entity에 createdAt를 추가

### DIFF
--- a/backend/src/main/java/com/woowacourse/kkogkkog/KkogKkogApplication.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/KkogKkogApplication.java
@@ -2,8 +2,10 @@ package com.woowacourse.kkogkkog;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class KkogKkogApplication {
 
     public static void main(String[] args) {

--- a/backend/src/main/java/com/woowacourse/kkogkkog/application/MemberService.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/application/MemberService.java
@@ -83,9 +83,8 @@ public class MemberService {
     public List<MemberHistoryResponse> findHistoryById(Long memberId) {
         Member findMember = memberRepository.findById(memberId)
             .orElseThrow(MemberNotFoundException::new);
-        List<MemberHistory> histories = memberHistoryRepository.findAllByHostMember(findMember);
 
-        return histories.stream()
+        return memberHistoryRepository.findAllByHostMemberOrderByCreatedAtDesc(findMember).stream()
             .map(MemberHistoryResponse::of)
             .collect(toList());
     }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/application/dto/MemberHistoryResponse.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/application/dto/MemberHistoryResponse.java
@@ -54,9 +54,6 @@ public class MemberHistoryResponse {
             memberHistory.getCouponEvent().name(),
             memberHistory.getMeetingDate(),
             memberHistory.getIsRead(),
-            LocalDate.of(
-                memberHistory.getCreatedAt().getYear(),
-                memberHistory.getCreatedAt().getMonth(),
-                memberHistory.getCreatedAt().getDayOfMonth()));
+            memberHistory.getCreatedAt().toLocalDate());
     }
 }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/application/dto/MemberHistoryResponse.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/application/dto/MemberHistoryResponse.java
@@ -21,6 +21,8 @@ public class MemberHistoryResponse {
     @JsonFormat(shape = Shape.STRING, pattern = "yyyy-MM-dd")
     private LocalDate meetingDate;
     private Boolean isRead;
+    @JsonFormat(shape = Shape.STRING, pattern = "yyyy-MM-dd")
+    private LocalDate createdAt;
 
     public MemberHistoryResponse(Long id,
                                  String nickname,
@@ -29,7 +31,8 @@ public class MemberHistoryResponse {
                                  String couponType,
                                  String couponEvent,
                                  LocalDate meetingDate,
-                                 Boolean isRead) {
+                                 Boolean isRead,
+                                 LocalDate createdAt) {
         this.id = id;
         this.nickname = nickname;
         this.imageUrl = imageUrl;
@@ -38,6 +41,7 @@ public class MemberHistoryResponse {
         this.couponEvent = couponEvent;
         this.meetingDate = meetingDate;
         this.isRead = isRead;
+        this.createdAt = createdAt;
     }
 
     public static MemberHistoryResponse of(MemberHistory memberHistory) {
@@ -49,6 +53,7 @@ public class MemberHistoryResponse {
             memberHistory.getCouponType().name(),
             memberHistory.getCouponEvent().name(),
             memberHistory.getMeetingDate(),
-            memberHistory.getIsRead());
+            memberHistory.getIsRead(),
+            memberHistory.getCreatedAt());
     }
 }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/application/dto/MemberHistoryResponse.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/application/dto/MemberHistoryResponse.java
@@ -54,6 +54,9 @@ public class MemberHistoryResponse {
             memberHistory.getCouponEvent().name(),
             memberHistory.getMeetingDate(),
             memberHistory.getIsRead(),
-            memberHistory.getCreatedAt());
+            LocalDate.of(
+                memberHistory.getCreatedAt().getYear(),
+                memberHistory.getCreatedAt().getMonth(),
+                memberHistory.getCreatedAt().getDayOfMonth()));
     }
 }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/domain/BaseEntity.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/domain/BaseEntity.java
@@ -1,0 +1,17 @@
+package com.woowacourse.kkogkkog.domain;
+
+import java.time.LocalDateTime;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+@Getter
+public abstract class BaseEntity {
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+}

--- a/backend/src/main/java/com/woowacourse/kkogkkog/domain/BaseEntity.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/domain/BaseEntity.java
@@ -13,5 +13,5 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 public abstract class BaseEntity {
 
     @CreatedDate
-    private LocalDateTime createdAt;
+    protected LocalDateTime createdAt;
 }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/domain/MemberHistory.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/domain/MemberHistory.java
@@ -2,6 +2,7 @@ package com.woowacourse.kkogkkog.domain;
 
 import java.time.LocalDate;
 import javax.persistence.Entity;
+import javax.persistence.EntityListeners;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.FetchType;
@@ -13,7 +14,10 @@ import javax.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+@EntityListeners(AuditingEntityListener.class)
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
@@ -42,6 +46,9 @@ public class MemberHistory {
     private LocalDate meetingDate;
 
     private Boolean isRead = false;
+
+    @CreatedDate
+    private LocalDate createdAt;
 
     public MemberHistory(Long id, Member hostMember,
                          Member targetMember, Long couponId,

--- a/backend/src/main/java/com/woowacourse/kkogkkog/domain/MemberHistory.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/domain/MemberHistory.java
@@ -2,7 +2,6 @@ package com.woowacourse.kkogkkog.domain;
 
 import java.time.LocalDate;
 import javax.persistence.Entity;
-import javax.persistence.EntityListeners;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.FetchType;
@@ -14,14 +13,11 @@ import javax.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-@EntityListeners(AuditingEntityListener.class)
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class MemberHistory {
+public class MemberHistory extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -46,9 +42,6 @@ public class MemberHistory {
     private LocalDate meetingDate;
 
     private Boolean isRead = false;
-
-    @CreatedDate
-    private LocalDate createdAt;
 
     public MemberHistory(Long id, Member hostMember,
                          Member targetMember, Long couponId,

--- a/backend/src/main/java/com/woowacourse/kkogkkog/domain/repository/MemberHistoryRepository.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/domain/repository/MemberHistoryRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberHistoryRepository extends JpaRepository<MemberHistory, Long> {
 
-    List<MemberHistory> findAllByHostMember(Member member);
+    List<MemberHistory> findAllByHostMemberOrderByCreatedAtDesc(Member member);
 
     long countByHostMemberAndIsReadFalse(Member member);
 }

--- a/backend/src/test/java/com/woowacourse/kkogkkog/application/MemberServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/application/MemberServiceTest.java
@@ -137,7 +137,6 @@ class MemberServiceTest extends ServiceTest {
 
             List<MemberHistoryResponse> historiesResponse = memberService.findHistoryById(
                 arthurCreateResponse.getId());
-
             assertThat(historiesResponse).hasSize(1);
         }
     }

--- a/backend/src/test/java/com/woowacourse/kkogkkog/documentation/Documentation.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/documentation/Documentation.java
@@ -17,6 +17,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.test.web.servlet.MockMvc;
@@ -50,6 +51,9 @@ public abstract class Documentation {
 
     @MockBean
     protected JwtTokenProvider jwtTokenProvider;
+
+    @MockBean
+    protected JpaMetamodelMappingContext jpaMetamodelMappingContext;
 
     @BeforeEach
     public void setUp(WebApplicationContext ctx,

--- a/backend/src/test/java/com/woowacourse/kkogkkog/documentation/MemberControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/documentation/MemberControllerTest.java
@@ -24,6 +24,7 @@ import com.woowacourse.kkogkkog.application.dto.MemberResponse;
 import com.woowacourse.kkogkkog.application.dto.MyProfileResponse;
 import com.woowacourse.kkogkkog.presentation.dto.MemberHistoriesResponse;
 import com.woowacourse.kkogkkog.presentation.dto.MemberUpdateMeRequest;
+import java.time.LocalDate;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
@@ -117,7 +118,7 @@ public class MemberControllerTest extends Documentation {
     void 나의_기록들을_조회할_수_있다() throws Exception {
         // given
         List<MemberHistoryResponse> historiesResponse = List.of(
-            new MemberHistoryResponse(1L, "루키", "image", 1L, "COFFEE", "INIT", null, false));
+            new MemberHistoryResponse(1L, "루키", "image", 1L, "COFFEE", "INIT", null, false, LocalDate.now()));
 
         given(jwtTokenProvider.getValidatedPayload(any())).willReturn("1");
         given(memberService.findHistoryById(any())).willReturn(historiesResponse);
@@ -154,7 +155,8 @@ public class MemberControllerTest extends Documentation {
                     fieldWithPath("data.[].couponEvent").type(JsonFieldType.STRING)
                         .description("이벤트에 쿠폰 이벤트"),
                     fieldWithPath("data.[].meetingDate").description("이벤트의 예약 날짜"),
-                    fieldWithPath("data.[].isRead").type(JsonFieldType.BOOLEAN).description("이벤트 클릭(조회) 여부")
+                    fieldWithPath("data.[].isRead").type(JsonFieldType.BOOLEAN).description("이벤트 클릭(조회) 여부"),
+                    fieldWithPath("data.[].createdAt").type(JsonFieldType.STRING).description("이벤트 생성 날짜")
                 ))
             );
     }


### PR DESCRIPTION
## 작업 내용

- MemberHistory에 createdAt를 추가

  - BaseEntity 생성
  - createdAt 컬럼 추가

## 공유사항

추후 모든 Entity가 LocalDateTime을 가질 예정입니다

Resolves #172
