### PR TITLE
[BE] 회원 정보 조회 워크스페이스의 이름과 사진 정보 기능 추가

### DIFF
--- a/backend/src/main/java/com/woowacourse/kkogkkog/application/MemberService.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/application/MemberService.java
@@ -36,7 +36,7 @@ public class MemberService {
         String workspaceId = slackUserInfo.getTeamId();
         String nickname = slackUserInfo.getName();
         String email = slackUserInfo.getEmail();
-        String imageUrl = slackUserInfo.getPicture();
+        String imageUrl = slackUserInfo.getUserImageUrl();
 
         return memberRepository.findByUserId(userId)
             .stream()

--- a/backend/src/main/java/com/woowacourse/kkogkkog/application/MemberService.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/application/MemberService.java
@@ -9,10 +9,13 @@ import com.woowacourse.kkogkkog.application.dto.MemberUpdateRequest;
 import com.woowacourse.kkogkkog.application.dto.MyProfileResponse;
 import com.woowacourse.kkogkkog.domain.Member;
 import com.woowacourse.kkogkkog.domain.MemberHistory;
+import com.woowacourse.kkogkkog.domain.Workspace;
 import com.woowacourse.kkogkkog.domain.repository.MemberHistoryRepository;
 import com.woowacourse.kkogkkog.domain.repository.MemberRepository;
+import com.woowacourse.kkogkkog.domain.repository.WorkspaceRepository;
 import com.woowacourse.kkogkkog.exception.member.MemberHistoryNotFoundException;
 import com.woowacourse.kkogkkog.exception.member.MemberNotFoundException;
+import com.woowacourse.kkogkkog.exception.workspace.WorkspaceNotFoundException;
 import com.woowacourse.kkogkkog.infrastructure.SlackUserInfo;
 import java.util.List;
 import org.springframework.stereotype.Service;
@@ -24,11 +27,14 @@ public class MemberService {
 
     private final MemberRepository memberRepository;
     private final MemberHistoryRepository memberHistoryRepository;
+    private final WorkspaceRepository workspaceRepository;
 
     public MemberService(MemberRepository memberRepository,
-                         MemberHistoryRepository memberHistoryRepository) {
+                         MemberHistoryRepository memberHistoryRepository,
+                         WorkspaceRepository workspaceRepository) {
         this.memberRepository = memberRepository;
         this.memberHistoryRepository = memberHistoryRepository;
+        this.workspaceRepository = workspaceRepository;
     }
 
     public MemberCreateResponse saveOrFind(SlackUserInfo slackUserInfo) {
@@ -61,9 +67,10 @@ public class MemberService {
     public MyProfileResponse findById(Long memberId) {
         Member findMember = memberRepository.findById(memberId)
             .orElseThrow(MemberNotFoundException::new);
+        Workspace workspace = workspaceRepository.findByWorkspaceId(findMember.getWorkspaceId())
+            .orElseThrow(WorkspaceNotFoundException::new);
         long unreadHistoryCount = memberHistoryRepository.countByHostMemberAndIsReadFalse(findMember);
-
-        return MyProfileResponse.of(findMember, unreadHistoryCount);
+        return MyProfileResponse.of(findMember, workspace, unreadHistoryCount);
     }
 
     @Transactional(readOnly = true)

--- a/backend/src/main/java/com/woowacourse/kkogkkog/application/WorkspaceService.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/application/WorkspaceService.java
@@ -1,0 +1,48 @@
+package com.woowacourse.kkogkkog.application;
+
+import com.woowacourse.kkogkkog.domain.Workspace;
+import com.woowacourse.kkogkkog.domain.repository.WorkspaceRepository;
+import com.woowacourse.kkogkkog.exception.workspace.WorkspaceNotFoundException;
+import com.woowacourse.kkogkkog.infrastructure.SlackClient;
+import com.woowacourse.kkogkkog.infrastructure.SlackUserInfo;
+import com.woowacourse.kkogkkog.infrastructure.WorkspaceResponse;
+import javax.transaction.Transactional;
+import org.springframework.stereotype.Service;
+
+@Transactional
+@Service
+public class WorkspaceService {
+
+    private final WorkspaceRepository workspaceRepository;
+    private final SlackClient slackClient;
+
+    public WorkspaceService(WorkspaceRepository workspaceRepository, SlackClient slackClient) {
+        this.workspaceRepository = workspaceRepository;
+        this.slackClient = slackClient;
+    }
+
+    public void saveOrUpdate(SlackUserInfo slackUserInfo) {
+        String workspaceId = slackUserInfo.getTeamId();
+        String name = slackUserInfo.getTeamName();
+        String imageUrl = slackUserInfo.getTeamImageUrl();
+
+        workspaceRepository.findByWorkspaceId(workspaceId)
+            .ifPresentOrElse(workspace -> updateToMatchSlack(workspace, name, imageUrl),
+                () -> workspaceRepository.save(
+                    new Workspace(null, workspaceId, name, imageUrl, null)));
+    }
+
+    private void updateToMatchSlack(Workspace workspace, String name, String imageUrl) {
+        workspace.updateName(name);
+        workspace.updateImageUrl(imageUrl);
+    }
+
+    public void installSlackApp(String code) {
+        WorkspaceResponse botTokenResponse = slackClient.requestBotAccessToken(code);
+        Workspace workspace = workspaceRepository.findByWorkspaceId(
+                botTokenResponse.getWorkspaceId())
+            .orElseThrow(WorkspaceNotFoundException::new);
+
+        workspace.updateAccessToken(botTokenResponse.getAccessToken());
+    }
+}

--- a/backend/src/main/java/com/woowacourse/kkogkkog/application/dto/MyProfileResponse.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/application/dto/MyProfileResponse.java
@@ -1,6 +1,7 @@
 package com.woowacourse.kkogkkog.application.dto;
 
 import com.woowacourse.kkogkkog.domain.Member;
+import com.woowacourse.kkogkkog.domain.Workspace;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -11,31 +12,39 @@ public class MyProfileResponse {
 
     private Long id;
     private String userId;
-    private String workspaceId;
     private String nickname;
     private String email;
-    private String imageUrl;
+    private String userImageUrl;
+    private String workspaceId;
+    private String workspaceName;
+    private String workspaceImageUrl;
     private Long unReadCount;
 
-    public MyProfileResponse(Long id, String userId, String workspaceId, String nickname,
-                             String email, String imageUrl, Long unReadCount) {
+    public MyProfileResponse(Long id, String userId, String nickname, String email,
+                             String userImageUrl,
+                             String workspaceId, String workspaceName, String workspaceImageUrl,
+                             Long unReadCount) {
         this.id = id;
         this.userId = userId;
-        this.workspaceId = workspaceId;
         this.nickname = nickname;
         this.email = email;
-        this.imageUrl = imageUrl;
+        this.userImageUrl = userImageUrl;
+        this.workspaceId = workspaceId;
+        this.workspaceName = workspaceName;
+        this.workspaceImageUrl = workspaceImageUrl;
         this.unReadCount = unReadCount;
     }
 
-    public static MyProfileResponse of(Member member,  Long unreadHistoryCount) {
+    public static MyProfileResponse of(Member member, Workspace workspace, Long unreadHistoryCount) {
         return new MyProfileResponse(
             member.getId(),
             member.getUserId(),
-            member.getWorkspaceId(),
             member.getNickname(),
             member.getEmail(),
             member.getImageUrl(),
+            workspace.getWorkspaceId(),
+            workspace.getName(),
+            workspace.getImageUrl(),
             unreadHistoryCount
         );
     }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/domain/Workspace.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/domain/Workspace.java
@@ -25,13 +25,25 @@ public class Workspace {
     private String name;
 
     @Column(nullable = false)
+    private String imageUrl;
+
     private String accessToken;
 
-    public Workspace(Long id, String workspaceId, String name, String accessToken) {
+    public Workspace(Long id, String workspaceId, String name, String imageUrl,
+                     String accessToken) {
         this.id = id;
-        this.name = name;
         this.workspaceId = workspaceId;
+        this.name = name;
+        this.imageUrl = imageUrl;
         this.accessToken = accessToken;
+    }
+
+    public void updateName(String name) {
+        this.name = name;
+    }
+
+    public void updateImageUrl(String imageUrl) {
+        this.imageUrl = imageUrl;
     }
 
     public void updateAccessToken(String accessToken) {

--- a/backend/src/main/java/com/woowacourse/kkogkkog/exception/workspace/WorkspaceNotFoundException.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/exception/workspace/WorkspaceNotFoundException.java
@@ -1,0 +1,10 @@
+package com.woowacourse.kkogkkog.exception.workspace;
+
+import com.woowacourse.kkogkkog.exception.NotFoundException;
+
+public class WorkspaceNotFoundException extends NotFoundException {
+
+    public WorkspaceNotFoundException() {
+        super("존재하지 않는 워크스페이스입니다.");
+    }
+}

--- a/backend/src/main/java/com/woowacourse/kkogkkog/infrastructure/SlackUserInfo.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/infrastructure/SlackUserInfo.java
@@ -14,18 +14,30 @@ public class SlackUserInfo {
     @JsonProperty(SLACK_URI + "/user_id")
     private String userId;
 
+    private String name;
+    private String email;
+
+    @JsonProperty(SLACK_URI + "/user_image_512")
+    private String userImageUrl;
+
     @JsonProperty(SLACK_URI + "/team_id")
     private String teamId;
 
-    private String name;
-    private String email;
-    private String picture;
+    @JsonProperty(SLACK_URI + "/team_name")
+    private String teamName;
 
-    public SlackUserInfo(String userId, String teamId, String name, String email, String picture) {
+    @JsonProperty(SLACK_URI + "/team_image_230")
+    private String teamImageUrl;
+
+    public SlackUserInfo(String userId, String name, String email, String userImageUrl,
+                         String teamId,
+                         String teamName, String teamImageUrl) {
         this.userId = userId;
-        this.teamId = teamId;
         this.name = name;
         this.email = email;
-        this.picture = picture;
+        this.userImageUrl = userImageUrl;
+        this.teamId = teamId;
+        this.teamName = teamName;
+        this.teamImageUrl = teamImageUrl;
     }
 }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/presentation/AuthController.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/presentation/AuthController.java
@@ -1,6 +1,7 @@
 package com.woowacourse.kkogkkog.presentation;
 
 import com.woowacourse.kkogkkog.application.AuthService;
+import com.woowacourse.kkogkkog.application.WorkspaceService;
 import com.woowacourse.kkogkkog.application.dto.TokenResponse;
 import com.woowacourse.kkogkkog.presentation.dto.InstallSlackAppRequest;
 import org.springframework.http.ResponseEntity;
@@ -16,9 +17,11 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
 
     private final AuthService authService;
+    private final WorkspaceService workspaceService;
 
-    public AuthController(AuthService authService) {
+    public AuthController(AuthService authService, WorkspaceService workspaceService) {
         this.authService = authService;
+        this.workspaceService = workspaceService;
     }
 
     @GetMapping("/login/token")
@@ -30,7 +33,7 @@ public class AuthController {
 
     @PostMapping("/install/bot")
     public ResponseEntity<Void> installSlackApp(@RequestBody InstallSlackAppRequest installSlackAppRequest) {
-        authService.installSlackApp(installSlackAppRequest.getCode());
+        workspaceService.installSlackApp(installSlackAppRequest.getCode());
 
         return ResponseEntity.ok().build();
     }

--- a/backend/src/test/java/com/woowacourse/kkogkkog/acceptance/AuthAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/acceptance/AuthAcceptanceTest.java
@@ -68,8 +68,8 @@ public class AuthAcceptanceTest extends AcceptanceTest {
                     memberResponse.getEmail(),
                     memberResponse.getImageUrl(),
                     memberResponse.getWorkspaceId(),
-                    "팀_이름",
-                    "팀_이미지_주소"
+                    "workspace_name",
+                    "workspace_image"
                 ));
 
         ExtractableResponse<Response> extract = RestAssured.given().log().all()

--- a/backend/src/test/java/com/woowacourse/kkogkkog/acceptance/AuthAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/acceptance/AuthAcceptanceTest.java
@@ -44,7 +44,9 @@ public class AuthAcceptanceTest extends AcceptanceTest {
     void 슬랙_앱을_등록할_수_있다() {
         given(slackClient.requestBotAccessToken(AUTHORIZATION_CODE))
             .willReturn(
-                new WorkspaceResponse("ACCESS_TOKEN", "TEAM_ID", "꼭꼭"));
+                new WorkspaceResponse("T03LX3C5540", "팀_이름", "ACCESS_TOKEN"));
+        MemberResponse memberResponse = MemberResponse.of(MemberFixture.ROOKIE);
+        회원가입_또는_로그인에_성공한다(memberResponse);
 
         ExtractableResponse<Response> extract = RestAssured.given().log().all()
             .contentType(MediaType.APPLICATION_JSON_VALUE)
@@ -62,10 +64,13 @@ public class AuthAcceptanceTest extends AcceptanceTest {
             .willReturn(
                 new SlackUserInfo(
                     memberResponse.getUserId(),
-                    memberResponse.getWorkspaceId(),
                     memberResponse.getNickname(),
                     memberResponse.getEmail(),
-                    memberResponse.getImageUrl()));
+                    memberResponse.getImageUrl(),
+                    memberResponse.getWorkspaceId(),
+                    "팀_이름",
+                    "팀_이미지_주소"
+                ));
 
         ExtractableResponse<Response> extract = RestAssured.given().log().all()
             .contentType(MediaType.APPLICATION_JSON_VALUE)

--- a/backend/src/test/java/com/woowacourse/kkogkkog/acceptance/MemberAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/acceptance/MemberAcceptanceTest.java
@@ -50,7 +50,6 @@ public class MemberAcceptanceTest extends AcceptanceTest {
     @Test
     void 로그인_한_경우_본인의_정보를_조회할_수_있다() {
         String rookieAccessToken = 회원가입_또는_로그인에_성공한다(MemberResponse.of(ROOKIE)).getAccessToken();
-        회원가입_또는_로그인에_성공한다(MemberResponse.of(ARTHUR));
 
         ExtractableResponse<Response> extract = 본인_정보_조회를_요청한다(rookieAccessToken);
         MyProfileResponse memberResponse = extract.as(MyProfileResponse.class);
@@ -58,8 +57,9 @@ public class MemberAcceptanceTest extends AcceptanceTest {
         assertAll(
             () -> assertThat(extract.statusCode()).isEqualTo(HttpStatus.OK.value()),
             () -> assertThat(memberResponse).usingRecursiveComparison().isEqualTo(
-                new MyProfileResponse(1L, "URookie", "T03LX3C5540",
-                    "루키", "rookie@gmail.com", "image", 0L))
+                new MyProfileResponse(1L, "URookie", "루키", "rookie@gmail.com",
+                    "image", "T03LX3C5540", "workspace_name",
+                    "workspace_image", 0L))
         );
     }
 

--- a/backend/src/test/java/com/woowacourse/kkogkkog/application/CouponServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/application/CouponServiceTest.java
@@ -48,7 +48,7 @@ public class CouponServiceTest extends ServiceTest {
     private static final Member ARTHUR = new Member(null, "UArthur", WORKSPACE_ID, "아서",
         "arthur@gmail.com", "image");
     private static final Workspace KKOGKKOG_WORKSPACE = new Workspace(null, WORKSPACE_ID,
-        "KkogKkog", BOT_ACCESS_TOKEN);
+        "KkogKkog", "image", BOT_ACCESS_TOKEN);
 
     @Autowired
     private CouponService couponService;

--- a/backend/src/test/java/com/woowacourse/kkogkkog/application/MemberServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/application/MemberServiceTest.java
@@ -32,6 +32,9 @@ class MemberServiceTest extends ServiceTest {
     @Autowired
     private CouponService couponService;
 
+    @Autowired
+    private WorkspaceService workspaceService;
+
     @Nested
     @DisplayName("save 메서드는")
     class Save {
@@ -76,12 +79,13 @@ class MemberServiceTest extends ServiceTest {
             SlackUserInfo slackUserInfo = new SlackUserInfo("URookie", "루키", "rookie@gmail.com",
                 "user_image", "T03LX3C5540", "kkogkkog", "workspace_image");
             Long memberId = memberService.saveOrFind(slackUserInfo).getId();
+            workspaceService.saveOrUpdate(slackUserInfo);
 
             MyProfileResponse memberResponse = memberService.findById(memberId);
 
             assertThat(memberResponse).usingRecursiveComparison().ignoringFields("id").isEqualTo(
-                new MyProfileResponse(null, "URookie", "T03LX3C5540", "루키", "rookie@gmail.com",
-                    "user_image", 0L)
+                new MyProfileResponse(null, "URookie", "루키", "rookie@gmail.com", "user_image",
+                    "T03LX3C5540", "kkogkkog", "workspace_image", 0L)
             );
         }
 
@@ -171,8 +175,9 @@ class MemberServiceTest extends ServiceTest {
         @DisplayName("사용자의 닉네임을 수정한다.")
         void success() {
             SlackUserInfo rookieUserInfo = new SlackUserInfo("URookie", "루키", "rookie@gmail.com",
-                "user_image", "T03LX3C5540", "kkogkkog", "workspace_image");
+                "user_image", "workspace_id", "kkogkkog", "workspace_image");
             Long memberId = memberService.saveOrFind(rookieUserInfo).getId();
+            workspaceService.saveOrUpdate(rookieUserInfo);
 
             String expected = "새로운_닉네임";
             memberService.update(new MemberUpdateRequest(memberId, expected));

--- a/backend/src/test/java/com/woowacourse/kkogkkog/application/MemberServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/application/MemberServiceTest.java
@@ -39,8 +39,8 @@ class MemberServiceTest extends ServiceTest {
         @Test
         @DisplayName("가입되지 않은 회원 정보를 받으면, 회원을 저장하고 저장된 Id와 회원가입 여부를 반환한다.")
         void success_save() {
-            SlackUserInfo slackUserInfo = new SlackUserInfo("URookie", "T03LX3C5540", "루키",
-                "rookie@gmail.com", "image");
+            SlackUserInfo slackUserInfo = new SlackUserInfo("URookie", "루키", "rookie@gmail.com",
+                "user_image", "T03LX3C5540", "kkogkkog", "workspace_image");
 
             MemberCreateResponse memberCreateResponse = memberService.saveOrFind(slackUserInfo);
 
@@ -53,8 +53,8 @@ class MemberServiceTest extends ServiceTest {
         @Test
         @DisplayName("가입된 회원 정보를 받으면, 해당 회원의 Id와 회원가입 여부를 반환한다.")
         void success_find() {
-            SlackUserInfo slackUserInfo = new SlackUserInfo("URookie", "T03LX3C5540", "루키",
-                "rookie@gmail.com", "image");
+            SlackUserInfo slackUserInfo = new SlackUserInfo("URookie", "루키", "rookie@gmail.com",
+                "user_image", "T03LX3C5540", "kkogkkog", "workspace_image");
 
             memberService.saveOrFind(slackUserInfo);
             MemberCreateResponse memberCreateResponse = memberService.saveOrFind(slackUserInfo);
@@ -73,15 +73,15 @@ class MemberServiceTest extends ServiceTest {
         @Test
         @DisplayName("저장된 회원의 Id를 받으면, 해당 회원의 정보를 반환한다.")
         void success() {
-            SlackUserInfo slackUserInfo = new SlackUserInfo("URookie", "T03LX3C5540", "루키",
-                "rookie@gmail.com", "image");
+            SlackUserInfo slackUserInfo = new SlackUserInfo("URookie", "루키", "rookie@gmail.com",
+                "user_image", "T03LX3C5540", "kkogkkog", "workspace_image");
             Long memberId = memberService.saveOrFind(slackUserInfo).getId();
 
             MyProfileResponse memberResponse = memberService.findById(memberId);
 
             assertThat(memberResponse).usingRecursiveComparison().ignoringFields("id").isEqualTo(
                 new MyProfileResponse(null, "URookie", "T03LX3C5540", "루키", "rookie@gmail.com",
-                    "image", 0L)
+                    "user_image", 0L)
             );
         }
 
@@ -102,10 +102,10 @@ class MemberServiceTest extends ServiceTest {
         @Test
         @DisplayName("회원가입된 모든 회원들의 정보를 반환한다.")
         void success() {
-            SlackUserInfo rookieUserInfo = new SlackUserInfo("URookie", "T03LX3C5540", "루키",
-                "rookie@gmail.com", "image");
-            SlackUserInfo arthurUserInfo = new SlackUserInfo("UArthur", "T03LX3C5540", "아서",
-                "arthur@gmail.com", "image");
+            SlackUserInfo rookieUserInfo = new SlackUserInfo("URookie", "루키", "rookie@gmail.com",
+                "user_image", "T03LX3C5540", "kkogkkog", "workspace_image");
+            SlackUserInfo arthurUserInfo = new SlackUserInfo("UArthur", "아서", "arthur@gmail.com",
+                "user_image", "T03LX3C5540", "kkogkkog", "workspace_image");
 
             memberService.saveOrFind(rookieUserInfo);
             memberService.saveOrFind(arthurUserInfo);
@@ -123,10 +123,10 @@ class MemberServiceTest extends ServiceTest {
         @Test
         @DisplayName("로그인된 사용자의 history를 반환한다.")
         void success() {
-            SlackUserInfo rookieUserInfo = new SlackUserInfo("URookie", "T03LX3C5540", "루키",
-                "rookie@gmail.com", "image");
-            SlackUserInfo arthurUserInfo = new SlackUserInfo("UArthur", "T03LX3C5540", "아서",
-                "arthur@gmail.com", "image");
+            SlackUserInfo rookieUserInfo = new SlackUserInfo("URookie", "루키", "rookie@gmail.com",
+                "user_image", "T03LX3C5540", "kkogkkog", "workspace_image");
+            SlackUserInfo arthurUserInfo = new SlackUserInfo("UArthur", "아서", "arthur@gmail.com",
+                "user_image", "T03LX3C5540", "kkogkkog", "workspace_image");
             MemberCreateResponse rookieCreateResponse = memberService.saveOrFind(rookieUserInfo);
             MemberCreateResponse arthurCreateResponse = memberService.saveOrFind(arthurUserInfo);
 
@@ -148,14 +148,15 @@ class MemberServiceTest extends ServiceTest {
         @Test
         @DisplayName("요청받을 경우 true 로 변경된다.")
         void success() {
-            SlackUserInfo rookieUserInfo = new SlackUserInfo("URookie", "T03LX3C5540", "루키",
-                "rookie@gmail.com", "image");
-            SlackUserInfo arthurUserInfo = new SlackUserInfo("UArthur", "T03LX3C5540", "아서",
-                "arthur@gmail.com", "image");
+            SlackUserInfo rookieUserInfo = new SlackUserInfo("URookie", "루키", "rookie@gmail.com",
+                "user_image", "T03LX3C5540", "kkogkkog", "workspace_image");
+            SlackUserInfo arthurUserInfo = new SlackUserInfo("UArthur", "아서", "arthur@gmail.com",
+                "user_image", "T03LX3C5540", "kkogkkog", "workspace_image");
             MemberCreateResponse rookieCreateResponse = memberService.saveOrFind(rookieUserInfo);
             MemberCreateResponse arthurCreateResponse = memberService.saveOrFind(arthurUserInfo);
             CouponSaveRequest couponSaveRequest = new CouponSaveRequest(
-                rookieCreateResponse.getId(), List.of(arthurCreateResponse.getId()), "한턱쏘는", "추가 메세지", "##11032", "COFFEE");
+                rookieCreateResponse.getId(), List.of(arthurCreateResponse.getId()), "한턱쏘는",
+                "추가 메세지", "##11032", "COFFEE");
             couponService.save(couponSaveRequest);
 
             assertDoesNotThrow(() -> memberService.updateIsReadMemberHistory(1L));
@@ -163,14 +164,14 @@ class MemberServiceTest extends ServiceTest {
     }
 
     @Nested
-    @DisplayName("update 메서드는")
+    @DisplayName("updateToMatchSlack 메서드는")
     class Update {
 
         @Test
         @DisplayName("사용자의 닉네임을 수정한다.")
         void success() {
-            SlackUserInfo rookieUserInfo = new SlackUserInfo("URookie", "T03LX3C5540", "루키",
-                "rookie@gmail.com", "image");
+            SlackUserInfo rookieUserInfo = new SlackUserInfo("URookie", "루키", "rookie@gmail.com",
+                "user_image", "T03LX3C5540", "kkogkkog", "workspace_image");
             Long memberId = memberService.saveOrFind(rookieUserInfo).getId();
 
             String expected = "새로운_닉네임";

--- a/backend/src/test/java/com/woowacourse/kkogkkog/application/WorkspaceServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/application/WorkspaceServiceTest.java
@@ -1,0 +1,58 @@
+package com.woowacourse.kkogkkog.application;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.mockito.BDDMockito.given;
+
+import com.woowacourse.kkogkkog.infrastructure.SlackUserInfo;
+import com.woowacourse.kkogkkog.infrastructure.WorkspaceResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@DisplayName("WorkspaceServiceTest 클래스의")
+public class WorkspaceServiceTest extends ServiceTest{
+
+    private static final String AUTHORIZATION_CODE = "code";
+    private static final String WORKSPACE_ID = "workspace_id";
+    private static final String WORKSPACE_NAME = "workspace_name";
+    private static final String ACCESS_TOKEN = "access_token";
+
+    @Autowired
+    private WorkspaceService workspaceService;
+
+    @Nested
+    @DisplayName("saveOrUpdate 메서드는")
+    class saveOrUpdate {
+
+        @Test
+        @DisplayName("워크스페이스 정보를 저장 또는 업데이트 한다.")
+        void success() {
+            SlackUserInfo slackUserInfo = new SlackUserInfo("URookie", "루키", "rookie@gmail.com",
+                "user_image", "workspace_id", "kkogkkog", "workspace_image");
+
+            assertThatNoException()
+                .isThrownBy(() -> workspaceService.saveOrUpdate(slackUserInfo));
+        }
+    }
+
+    @Nested
+    @DisplayName("installSlackApp 메서드는")
+    class InstallSlackBot {
+
+        @Test
+        @DisplayName("임시 코드를 입력하면, 봇 토큰을 저장한다")
+        void success() {
+            SlackUserInfo slackUserInfo = new SlackUserInfo("URookie", "루키", "rookie@gmail.com",
+                "user_image", WORKSPACE_ID, WORKSPACE_NAME, "workspace_image");
+            given(slackClient.requestBotAccessToken(AUTHORIZATION_CODE))
+                .willReturn(new WorkspaceResponse(WORKSPACE_ID, WORKSPACE_NAME, ACCESS_TOKEN));
+            workspaceService.saveOrUpdate(slackUserInfo);
+
+            assertThatNoException()
+                .isThrownBy(() -> workspaceService.installSlackApp(AUTHORIZATION_CODE));
+        }
+    }
+}

--- a/backend/src/test/java/com/woowacourse/kkogkkog/documentation/Documentation.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/documentation/Documentation.java
@@ -8,6 +8,7 @@ import com.woowacourse.kkogkkog.application.AuthService;
 import com.woowacourse.kkogkkog.application.CouponService;
 import com.woowacourse.kkogkkog.application.JwtTokenProvider;
 import com.woowacourse.kkogkkog.application.MemberService;
+import com.woowacourse.kkogkkog.application.WorkspaceService;
 import com.woowacourse.kkogkkog.presentation.AuthController;
 import com.woowacourse.kkogkkog.presentation.CouponController;
 import com.woowacourse.kkogkkog.presentation.MemberController;
@@ -48,6 +49,9 @@ public abstract class Documentation {
 
     @MockBean
     protected AuthService authService;
+
+    @MockBean
+    protected WorkspaceService workspaceService;
 
     @MockBean
     protected JwtTokenProvider jwtTokenProvider;

--- a/backend/src/test/java/com/woowacourse/kkogkkog/documentation/MemberControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/documentation/MemberControllerTest.java
@@ -73,8 +73,8 @@ public class MemberControllerTest extends Documentation {
     @Test
     void 나의_회원정보를_요청할_수_있다() throws Exception {
         // given
-        MyProfileResponse memberResponse = new MyProfileResponse(1L, "User1", "TWorkspace1",
-            "user_nickname1", "email1@gmail.com", "image", 10L);
+        MyProfileResponse memberResponse = new MyProfileResponse(1L, "User1", "user_nickname1",
+            "email1@gmail.com", "user_image", "TWorkspace1", "workspace_name","workspace_image", 10L);
 
         given(jwtTokenProvider.getValidatedPayload(any())).willReturn("1");
         given(memberService.findById(any())).willReturn(memberResponse);
@@ -87,10 +87,14 @@ public class MemberControllerTest extends Documentation {
         perform.andExpect(status().isOk())
             .andExpect(jsonPath("$.id").value("1"))
             .andExpect(jsonPath("$.userId").value("User1"))
-            .andExpect(jsonPath("$.workspaceId").value("TWorkspace1"))
             .andExpect(jsonPath("$.nickname").value("user_nickname1"))
             .andExpect(jsonPath("$.email").value("email1@gmail.com"))
-            .andExpect(jsonPath("$.imageUrl").value("image"));
+            .andExpect(jsonPath("$.userImageUrl").value("user_image"))
+            .andExpect(jsonPath("$.workspaceId").value("TWorkspace1"))
+            .andExpect(jsonPath("$.workspaceName").value("workspace_name"))
+            .andExpect(jsonPath("$.workspaceImageUrl").value("workspace_image"))
+            .andExpect(jsonPath("$.unReadCount").value(10L));
+
 
         // docs
         perform
@@ -104,12 +108,17 @@ public class MemberControllerTest extends Documentation {
                 responseFields(
                     fieldWithPath("id").type(JsonFieldType.NUMBER).description("ID"),
                     fieldWithPath("userId").type(JsonFieldType.STRING).description("유저 Id"),
-                    fieldWithPath("workspaceId").type(JsonFieldType.STRING)
-                        .description("워크스페이스 ID"),
                     fieldWithPath("nickname").type(JsonFieldType.STRING).description("닉네임"),
                     fieldWithPath("email").type(JsonFieldType.STRING).description("이메일"),
-                    fieldWithPath("imageUrl").type(JsonFieldType.STRING).description("이미지 주소"),
-                    fieldWithPath("unReadCount").type(JsonFieldType.NUMBER).description("읽지 않은 알림 개수")
+                    fieldWithPath("userImageUrl").type(JsonFieldType.STRING).description("유저 이미지 주소"),
+                    fieldWithPath("workspaceId").type(JsonFieldType.STRING)
+                        .description("워크스페이스 ID"),
+                    fieldWithPath("workspaceName").type(JsonFieldType.STRING)
+                        .description("워크스페이스 이름"),
+                    fieldWithPath("workspaceImageUrl").type(JsonFieldType.STRING)
+                        .description("워크스페이스 이미지 주소"),
+                    fieldWithPath("unReadCount").type(JsonFieldType.NUMBER)
+                        .description("읽지 않은 알림 개수")
                 ))
             );
     }
@@ -118,7 +127,8 @@ public class MemberControllerTest extends Documentation {
     void 나의_기록들을_조회할_수_있다() throws Exception {
         // given
         List<MemberHistoryResponse> historiesResponse = List.of(
-            new MemberHistoryResponse(1L, "루키", "image", 1L, "COFFEE", "INIT", null, false, LocalDate.now()));
+            new MemberHistoryResponse(1L, "루키", "image", 1L, "COFFEE", "INIT", null, false,
+                LocalDate.now()));
 
         given(jwtTokenProvider.getValidatedPayload(any())).willReturn("1");
         given(memberService.findHistoryById(any())).willReturn(historiesResponse);
@@ -155,8 +165,10 @@ public class MemberControllerTest extends Documentation {
                     fieldWithPath("data.[].couponEvent").type(JsonFieldType.STRING)
                         .description("이벤트에 쿠폰 이벤트"),
                     fieldWithPath("data.[].meetingDate").description("이벤트의 예약 날짜"),
-                    fieldWithPath("data.[].isRead").type(JsonFieldType.BOOLEAN).description("이벤트 클릭(조회) 여부"),
-                    fieldWithPath("data.[].createdAt").type(JsonFieldType.STRING).description("이벤트 생성 날짜")
+                    fieldWithPath("data.[].isRead").type(JsonFieldType.BOOLEAN)
+                        .description("이벤트 클릭(조회) 여부"),
+                    fieldWithPath("data.[].createdAt").type(JsonFieldType.STRING)
+                        .description("이벤트 생성 날짜")
                 ))
             );
     }


### PR DESCRIPTION
## 작업 내용

- 로그인 시 워크스페이스의 이름과 사진을 저장하는 기능 구현
- 나의 정보 조회 시 Response body에 워크스페이스의 이름, 사진을 추가
- 봇 엑세스 토큰 저장시 워크스페이스 엔티티가 등록되는 부분을 업데이트 되게 변경

## 공유사항

WorkspaceService를 분리하여 로그인시 워크스페이스 추가와 앱 설치 메서드를 분리함.
로그인 인수 테스트에서 워크스페이스 정보가 하드코딩되는 문제가 있음
Member와 Workspace의 연관관계를 맺지 않음

나의 결론: 워크스페이스의 이미지를 넣지 않고 다시 하는게 좋겠다.

Resolves #189
