### PR TITLE
chore: SonarCloud CI 워크플로우 셋업

### DIFF
--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
       - develop
-    types: [opened, ready_for_review, reopened]
+    types: [opened, ready_for_review, reopened, synchronize]
 
 jobs:
   sonar_build:

--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -8,6 +8,40 @@ on:
     types: [opened, ready_for_review, reopened]
 
 jobs:
+  sonar_build:
+    name: SonarCloud Lint
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: ./backend
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Cache SonarCloud packages
+        uses: actions/cache@v1
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+      - name: Cache Gradle packages
+        uses: actions/cache@v1
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: ${{ runner.os }}-gradle
+      - name: Build and analyze
+        env:
+          GITHUB_TOKEN: ${{ secrets.PRIVATE_ACCESS_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: ./gradlew build sonarqube --info
+
   frontend:
     runs-on: ubuntu-latest
 

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -104,7 +104,7 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.projectKey", "woowacourse-teams_2022-kkogkkog"
+        property "sonar.projectKey", "2022-kkogkkog"
         property "sonar.organization", "woowacourse-teams"
         property "sonar.host.url", "https://sonarcloud.io"
         property 'sonar.coverage.jacoco.xmlReportPaths', 'build/reports/jacoco/test/jacocoTestReport.xml'

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -2,6 +2,8 @@ plugins {
     id 'org.springframework.boot' version '2.7.1'
     id 'io.spring.dependency-management' version '1.0.11.RELEASE'
     id 'org.asciidoctor.jvm.convert' version '3.3.2'
+    id "org.sonarqube" version "3.4.0.2513"
+    id 'jacoco'
     id 'java'
 }
 
@@ -56,6 +58,7 @@ dependencies {
 test {
     useJUnitPlatform()
     outputs.dir snippetsDir
+    finalizedBy 'jacocoTestReport'
 }
 
 asciidoctor {
@@ -89,4 +92,20 @@ build {
 bootJar {
     dependsOn copySecret
     dependsOn createDocument
+}
+
+jacocoTestReport {
+    reports {
+        html.enabled true
+        xml.enabled true
+    }
+}
+
+sonarqube {
+    properties {
+        property "sonar.projectKey", "woowacourse-teams_2022-kkogkkog"
+        property "sonar.organization", "woowacourse-teams"
+        property "sonar.host.url", "https://sonarcloud.io"
+        property 'sonar.coverage.jacoco.xmlReportPaths', 'build/reports/jacoco/test/jacocoTestReport.xml'
+    }
 }


### PR DESCRIPTION
## 작업 내용

구구와의 끈밀한 협업을 통해 해당 깃헙 저장소에 Sonar Cloud 앱 설치를 하였으며, 깃헙 CI용 토큰을 전달받은 상황입니다.

## 공유사항

[소나클라우드 사이트의 대쉬보드](https://sonarcloud.io/organizations/woowacourse-teams/projects)에서 프로젝트 조회 가능합니다.
트리거 관련하여 수정하기 전에 제대로 동작하는지 체크해보기 위해 미리 PR 올려봅니다.

Resolves #191
