### PR TITLE
feat: 나의 회원 정보 조회 API ResponseBody 워크스페이스 이름 추가

### DIFF
--- a/backend/src/main/java/com/woowacourse/kkogkkog/application/AuthService.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/application/AuthService.java
@@ -40,17 +40,9 @@ public class AuthService {
 
     private void saveOrUpdateWorkspace(SlackUserInfo userInfo) {
         workspaceRepository.findByWorkspaceId(userInfo.getTeamId())
-            .ifPresentOrElse(workspace -> updateWorkspaceToMatchSlack(workspace, userInfo),
-                () -> saveWorkspace(userInfo));
-    }
-
-    private void saveWorkspace(SlackUserInfo userInfo) {
-        workspaceRepository.save(
-            new Workspace(null, userInfo.getTeamId(), userInfo.getTeamName(), null));
-    }
-
-    private void updateWorkspaceToMatchSlack(Workspace workspace, SlackUserInfo userInfo) {
-        workspace.updateName(userInfo.getTeamName());
+            .ifPresentOrElse(workspace -> workspace.updateName(userInfo.getTeamName()),
+                () -> workspaceRepository.save(
+                    new Workspace(null, userInfo.getTeamId(), userInfo.getTeamName(), null)));
     }
 
     public void installSlackApp(String code) {

--- a/backend/src/main/java/com/woowacourse/kkogkkog/application/AuthService.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/application/AuthService.java
@@ -31,10 +31,17 @@ public class AuthService {
     public TokenResponse login(String code) {
         SlackUserInfo userInfo = slackClient.getUserInfoByCode(code);
         MemberCreateResponse memberCreateResponse = memberService.saveOrFind(userInfo);
-
+        saveOrUpdateWorkspace(userInfo);
+        
         return new TokenResponse(
             jwtTokenProvider.createToken(memberCreateResponse.getId().toString()),
             memberCreateResponse.getIsNew());
+    }
+
+    private void saveOrUpdateWorkspace(SlackUserInfo userInfo) {
+        workspaceRepository.findByWorkspaceId(userInfo.getTeamId())
+            .ifPresentOrElse(workspace -> workspace.updateName(userInfo.getTeamName()),
+                () -> new Workspace(null, userInfo.getTeamId(), userInfo.getTeamName(), null));
     }
 
     public void installSlackApp(String code) {

--- a/backend/src/main/java/com/woowacourse/kkogkkog/application/AuthService.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/application/AuthService.java
@@ -54,6 +54,8 @@ public class AuthService {
                 botTokenResponse.getWorkspaceName(), botTokenResponse.getAccessToken()));
             return;
         }
-        workspace.get().updateAccessToken(botTokenResponse.getAccessToken());
+        Workspace existingWorkspace = workspace.get();
+        existingWorkspace.updateName(botTokenResponse.getWorkspaceName());
+        existingWorkspace.updateAccessToken(botTokenResponse.getAccessToken());
     }
 }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/application/MemberService.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/application/MemberService.java
@@ -9,8 +9,11 @@ import com.woowacourse.kkogkkog.application.dto.MemberUpdateRequest;
 import com.woowacourse.kkogkkog.application.dto.MyProfileResponse;
 import com.woowacourse.kkogkkog.domain.Member;
 import com.woowacourse.kkogkkog.domain.MemberHistory;
+import com.woowacourse.kkogkkog.domain.Workspace;
 import com.woowacourse.kkogkkog.domain.repository.MemberHistoryRepository;
 import com.woowacourse.kkogkkog.domain.repository.MemberRepository;
+import com.woowacourse.kkogkkog.domain.repository.WorkspaceRepository;
+import com.woowacourse.kkogkkog.exception.auth.WorkspaceNotFoundException;
 import com.woowacourse.kkogkkog.exception.member.MemberHistoryNotFoundException;
 import com.woowacourse.kkogkkog.exception.member.MemberNotFoundException;
 import com.woowacourse.kkogkkog.infrastructure.SlackUserInfo;
@@ -24,11 +27,14 @@ public class MemberService {
 
     private final MemberRepository memberRepository;
     private final MemberHistoryRepository memberHistoryRepository;
+    private final WorkspaceRepository workspaceRepository;
 
     public MemberService(MemberRepository memberRepository,
-                         MemberHistoryRepository memberHistoryRepository) {
+                         MemberHistoryRepository memberHistoryRepository,
+                         WorkspaceRepository workspaceRepository) {
         this.memberRepository = memberRepository;
         this.memberHistoryRepository = memberHistoryRepository;
+        this.workspaceRepository = workspaceRepository;
     }
 
     public MemberCreateResponse saveOrFind(SlackUserInfo slackUserInfo) {
@@ -61,9 +67,11 @@ public class MemberService {
     public MyProfileResponse findById(Long memberId) {
         Member findMember = memberRepository.findById(memberId)
             .orElseThrow(MemberNotFoundException::new);
+        Workspace workspace = workspaceRepository.findByWorkspaceId(findMember.getWorkspaceId())
+            .orElseThrow(WorkspaceNotFoundException::new);
         long unreadHistoryCount = memberHistoryRepository.countByHostMemberAndIsReadFalse(findMember);
 
-        return MyProfileResponse.of(findMember, unreadHistoryCount);
+        return MyProfileResponse.of(findMember, workspace.getName(), unreadHistoryCount);
     }
 
     @Transactional(readOnly = true)

--- a/backend/src/main/java/com/woowacourse/kkogkkog/application/dto/MyProfileResponse.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/application/dto/MyProfileResponse.java
@@ -1,6 +1,7 @@
 package com.woowacourse.kkogkkog.application.dto;
 
 import com.woowacourse.kkogkkog.domain.Member;
+import com.woowacourse.kkogkkog.infrastructure.WorkspaceResponse;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,27 +13,31 @@ public class MyProfileResponse {
     private Long id;
     private String userId;
     private String workspaceId;
+    private String workspaceName;
     private String nickname;
     private String email;
     private String imageUrl;
     private Long unReadCount;
 
-    public MyProfileResponse(Long id, String userId, String workspaceId, String nickname,
-                             String email, String imageUrl, Long unReadCount) {
+    public MyProfileResponse(Long id, String userId, String workspaceId, String workspaceName,
+                             String nickname, String email, String imageUrl, Long unReadCount) {
         this.id = id;
         this.userId = userId;
         this.workspaceId = workspaceId;
+        this.workspaceName = workspaceName;
         this.nickname = nickname;
         this.email = email;
         this.imageUrl = imageUrl;
         this.unReadCount = unReadCount;
     }
 
-    public static MyProfileResponse of(Member member,  Long unreadHistoryCount) {
+    public static MyProfileResponse of(Member member, String workspaceName,
+                                       Long unreadHistoryCount) {
         return new MyProfileResponse(
             member.getId(),
             member.getUserId(),
             member.getWorkspaceId(),
+            workspaceName,
             member.getNickname(),
             member.getEmail(),
             member.getImageUrl(),

--- a/backend/src/main/java/com/woowacourse/kkogkkog/domain/Workspace.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/domain/Workspace.java
@@ -33,6 +33,10 @@ public class Workspace {
         this.accessToken = accessToken;
     }
 
+    public void updateName(String name) {
+        this.name = name;
+    }
+
     public void updateAccessToken(String accessToken) {
         this.accessToken = accessToken;
     }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/domain/Workspace.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/domain/Workspace.java
@@ -24,7 +24,6 @@ public class Workspace {
     @Column(nullable = false)
     private String name;
 
-    @Column(nullable = false)
     private String accessToken;
 
     public Workspace(Long id, String workspaceId, String name, String accessToken) {

--- a/backend/src/main/java/com/woowacourse/kkogkkog/exception/auth/WorkspaceNotFoundException.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/exception/auth/WorkspaceNotFoundException.java
@@ -1,0 +1,10 @@
+package com.woowacourse.kkogkkog.exception.auth;
+
+import com.woowacourse.kkogkkog.exception.NotFoundException;
+
+public class WorkspaceNotFoundException extends NotFoundException {
+
+    public WorkspaceNotFoundException() {
+        super("존재하지 않는 워크스페이스입니다.");
+    }
+}

--- a/backend/src/main/java/com/woowacourse/kkogkkog/infrastructure/SlackUserInfo.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/infrastructure/SlackUserInfo.java
@@ -17,20 +17,20 @@ public class SlackUserInfo {
     @JsonProperty(SLACK_URI + "/team_id")
     private String teamId;
 
+    @JsonProperty(SLACK_URI + "/team_name")
+    private String teamName;
+
     private String name;
     private String email;
     private String picture;
 
-    @JsonProperty(SLACK_URI + "/team_name")
-    private String teamName;
-
-    public SlackUserInfo(String userId, String teamId, String name, String email, String picture,
-                         String teamName) {
+    public SlackUserInfo(String userId, String teamId, String teamName, String name, String email,
+                         String picture) {
         this.userId = userId;
         this.teamId = teamId;
+        this.teamName = teamName;
         this.name = name;
         this.email = email;
         this.picture = picture;
-        this.teamName = teamName;
     }
 }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/infrastructure/SlackUserInfo.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/infrastructure/SlackUserInfo.java
@@ -21,11 +21,16 @@ public class SlackUserInfo {
     private String email;
     private String picture;
 
-    public SlackUserInfo(String userId, String teamId, String name, String email, String picture) {
+    @JsonProperty(SLACK_URI + "/team_name")
+    private String teamName;
+
+    public SlackUserInfo(String userId, String teamId, String name, String email, String picture,
+                         String teamName) {
         this.userId = userId;
         this.teamId = teamId;
         this.name = name;
         this.email = email;
         this.picture = picture;
+        this.teamName = teamName;
     }
 }

--- a/backend/src/test/java/com/woowacourse/kkogkkog/acceptance/AuthAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/acceptance/AuthAcceptanceTest.java
@@ -20,7 +20,7 @@ import org.springframework.http.MediaType;
 public class AuthAcceptanceTest extends AcceptanceTest {
 
     private static final String AUTHORIZATION_CODE = "CODE";
-    private static final String WORKSPACE_NAME = "꼭꼭";
+    private static final String WORKSPACE_NAME = "workspace_name";
 
     @Test
     void 가입되지_않은_회원은_정보가_저장되고_로그인을_할_수_있다() {

--- a/backend/src/test/java/com/woowacourse/kkogkkog/acceptance/AuthAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/acceptance/AuthAcceptanceTest.java
@@ -44,7 +44,10 @@ public class AuthAcceptanceTest extends AcceptanceTest {
     void 슬랙_앱을_등록할_수_있다() {
         given(slackClient.requestBotAccessToken(AUTHORIZATION_CODE))
             .willReturn(
-                new WorkspaceResponse("ACCESS_TOKEN", "TEAM_ID", "꼭꼭"));
+                new WorkspaceResponse("T03LX3C5540", "workspace_name", "ACCESS_TOKEN"));
+
+        MemberResponse memberResponse = MemberResponse.of(MemberFixture.ROOKIE);
+        회원가입_또는_로그인에_성공한다(memberResponse);
 
         ExtractableResponse<Response> extract = RestAssured.given().log().all()
             .contentType(MediaType.APPLICATION_JSON_VALUE)

--- a/backend/src/test/java/com/woowacourse/kkogkkog/acceptance/AuthAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/acceptance/AuthAcceptanceTest.java
@@ -66,10 +66,10 @@ public class AuthAcceptanceTest extends AcceptanceTest {
                 new SlackUserInfo(
                     memberResponse.getUserId(),
                     memberResponse.getWorkspaceId(),
+                    "workspace_name",
                     memberResponse.getNickname(),
                     memberResponse.getEmail(),
-                    memberResponse.getImageUrl(),
-                    "workspace_name"));
+                    memberResponse.getImageUrl()));
 
         ExtractableResponse<Response> extract = RestAssured.given().log().all()
             .contentType(MediaType.APPLICATION_JSON_VALUE)

--- a/backend/src/test/java/com/woowacourse/kkogkkog/acceptance/AuthAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/acceptance/AuthAcceptanceTest.java
@@ -20,6 +20,7 @@ import org.springframework.http.MediaType;
 public class AuthAcceptanceTest extends AcceptanceTest {
 
     private static final String AUTHORIZATION_CODE = "CODE";
+    private static final String WORKSPACE_NAME = "꼭꼭";
 
     @Test
     void 가입되지_않은_회원은_정보가_저장되고_로그인을_할_수_있다() {
@@ -44,7 +45,7 @@ public class AuthAcceptanceTest extends AcceptanceTest {
     void 슬랙_앱을_등록할_수_있다() {
         given(slackClient.requestBotAccessToken(AUTHORIZATION_CODE))
             .willReturn(
-                new WorkspaceResponse("T03LX3C5540", "workspace_name", "ACCESS_TOKEN"));
+                new WorkspaceResponse("T03LX3C5540", WORKSPACE_NAME, "ACCESS_TOKEN"));
 
         MemberResponse memberResponse = MemberResponse.of(MemberFixture.ROOKIE);
         회원가입_또는_로그인에_성공한다(memberResponse);
@@ -66,7 +67,7 @@ public class AuthAcceptanceTest extends AcceptanceTest {
                 new SlackUserInfo(
                     memberResponse.getUserId(),
                     memberResponse.getWorkspaceId(),
-                    "workspace_name",
+                    WORKSPACE_NAME,
                     memberResponse.getNickname(),
                     memberResponse.getEmail(),
                     memberResponse.getImageUrl()));

--- a/backend/src/test/java/com/woowacourse/kkogkkog/acceptance/AuthAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/acceptance/AuthAcceptanceTest.java
@@ -65,7 +65,8 @@ public class AuthAcceptanceTest extends AcceptanceTest {
                     memberResponse.getWorkspaceId(),
                     memberResponse.getNickname(),
                     memberResponse.getEmail(),
-                    memberResponse.getImageUrl()));
+                    memberResponse.getImageUrl(),
+                    "workspace_name"));
 
         ExtractableResponse<Response> extract = RestAssured.given().log().all()
             .contentType(MediaType.APPLICATION_JSON_VALUE)

--- a/backend/src/test/java/com/woowacourse/kkogkkog/acceptance/MemberAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/acceptance/MemberAcceptanceTest.java
@@ -58,7 +58,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
         assertAll(
             () -> assertThat(extract.statusCode()).isEqualTo(HttpStatus.OK.value()),
             () -> assertThat(memberResponse).usingRecursiveComparison().isEqualTo(
-                new MyProfileResponse(1L, "URookie", "T03LX3C5540", "workspace_name",
+                new MyProfileResponse(1L, "URookie", "T03LX3C5540", "꼭꼭",
                     "루키", "rookie@gmail.com", "image", 0L))
         );
     }

--- a/backend/src/test/java/com/woowacourse/kkogkkog/acceptance/MemberAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/acceptance/MemberAcceptanceTest.java
@@ -58,7 +58,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
         assertAll(
             () -> assertThat(extract.statusCode()).isEqualTo(HttpStatus.OK.value()),
             () -> assertThat(memberResponse).usingRecursiveComparison().isEqualTo(
-                new MyProfileResponse(1L, "URookie", "T03LX3C5540",
+                new MyProfileResponse(1L, "URookie", "T03LX3C5540", "workspace_name",
                     "루키", "rookie@gmail.com", "image", 0L))
         );
     }

--- a/backend/src/test/java/com/woowacourse/kkogkkog/acceptance/MemberAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/acceptance/MemberAcceptanceTest.java
@@ -58,7 +58,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
         assertAll(
             () -> assertThat(extract.statusCode()).isEqualTo(HttpStatus.OK.value()),
             () -> assertThat(memberResponse).usingRecursiveComparison().isEqualTo(
-                new MyProfileResponse(1L, "URookie", "T03LX3C5540", "꼭꼭",
+                new MyProfileResponse(1L, "URookie", "T03LX3C5540", "workspace_name",
                     "루키", "rookie@gmail.com", "image", 0L))
         );
     }

--- a/backend/src/test/java/com/woowacourse/kkogkkog/application/AuthServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/application/AuthServiceTest.java
@@ -44,7 +44,8 @@ class AuthServiceTest extends ServiceTest {
                         memberResponse.getWorkspaceId(),
                         memberResponse.getNickname(),
                         memberResponse.getEmail(),
-                        memberResponse.getImageUrl()));
+                        memberResponse.getImageUrl(),
+                        "workspace_name"));
 
             TokenResponse tokenResponse = authService.login(AUTHORIZATION_CODE);
 

--- a/backend/src/test/java/com/woowacourse/kkogkkog/application/AuthServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/application/AuthServiceTest.java
@@ -22,7 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 class AuthServiceTest extends ServiceTest {
 
     private static final String AUTHORIZATION_CODE = "code";
-    private static final String WORKSPACE_ID = "workspace_id";
+    private static final String WORKSPACE_ID = "T03LX3C5540";
     private static final String WORKSPACE_NAME = "workspace_name";
     private static final String ACCESS_TOKEN = "ACCESS_TOKEN";
 
@@ -45,7 +45,7 @@ class AuthServiceTest extends ServiceTest {
                         memberResponse.getNickname(),
                         memberResponse.getEmail(),
                         memberResponse.getImageUrl(),
-                        "workspace_name"));
+                        WORKSPACE_NAME));
 
             TokenResponse tokenResponse = authService.login(AUTHORIZATION_CODE);
 
@@ -71,21 +71,20 @@ class AuthServiceTest extends ServiceTest {
         @Test
         @DisplayName("임시 코드를 입력하면, 봇 토큰을 저장한다")
         void success() {
-            given(slackClient.requestBotAccessToken(AUTHORIZATION_CODE))
-                .willReturn(new WorkspaceResponse(WORKSPACE_ID, WORKSPACE_NAME, ACCESS_TOKEN));
+            MemberResponse memberResponse = MemberResponse.of(ROOKIE);
+            given(slackClient.getUserInfoByCode(AUTHORIZATION_CODE))
+                .willReturn(
+                    new SlackUserInfo(
+                        memberResponse.getUserId(),
+                        memberResponse.getWorkspaceId(),
+                        memberResponse.getNickname(),
+                        memberResponse.getEmail(),
+                        memberResponse.getImageUrl(),
+                        WORKSPACE_NAME));
+            authService.login(AUTHORIZATION_CODE);
 
-            assertThatNoException()
-                .isThrownBy(() -> authService.installSlackApp(AUTHORIZATION_CODE));
-        }
-
-        @Test
-        @DisplayName("이미 등록된 워크스페이스인 경우, 엑세스 토큰을 업데이트한다.")
-        void success_update() {
             given(slackClient.requestBotAccessToken(AUTHORIZATION_CODE))
                 .willReturn(new WorkspaceResponse(WORKSPACE_ID, WORKSPACE_NAME, ACCESS_TOKEN));
-            given(slackClient.requestBotAccessToken(AUTHORIZATION_CODE))
-                .willReturn(new WorkspaceResponse(WORKSPACE_ID, WORKSPACE_NAME, ACCESS_TOKEN));
-            authService.installSlackApp(AUTHORIZATION_CODE);
 
             assertThatNoException()
                 .isThrownBy(() -> authService.installSlackApp(AUTHORIZATION_CODE));

--- a/backend/src/test/java/com/woowacourse/kkogkkog/application/AuthServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/application/AuthServiceTest.java
@@ -23,7 +23,7 @@ class AuthServiceTest extends ServiceTest {
 
     private static final String AUTHORIZATION_CODE = "code";
     private static final String WORKSPACE_ID = "T03LX3C5540";
-    private static final String WORKSPACE_NAME = "꼭꼭";
+    private static final String WORKSPACE_NAME = "workspace_name";
     private static final String ACCESS_TOKEN = "ACCESS_TOKEN";
 
     @Autowired

--- a/backend/src/test/java/com/woowacourse/kkogkkog/application/AuthServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/application/AuthServiceTest.java
@@ -23,7 +23,7 @@ class AuthServiceTest extends ServiceTest {
 
     private static final String AUTHORIZATION_CODE = "code";
     private static final String WORKSPACE_ID = "T03LX3C5540";
-    private static final String WORKSPACE_NAME = "workspace_name";
+    private static final String WORKSPACE_NAME = "꼭꼭";
     private static final String ACCESS_TOKEN = "ACCESS_TOKEN";
 
     @Autowired

--- a/backend/src/test/java/com/woowacourse/kkogkkog/application/AuthServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/application/AuthServiceTest.java
@@ -42,10 +42,10 @@ class AuthServiceTest extends ServiceTest {
                     new SlackUserInfo(
                         memberResponse.getUserId(),
                         memberResponse.getWorkspaceId(),
+                        WORKSPACE_NAME,
                         memberResponse.getNickname(),
                         memberResponse.getEmail(),
-                        memberResponse.getImageUrl(),
-                        WORKSPACE_NAME));
+                        memberResponse.getImageUrl()));
 
             TokenResponse tokenResponse = authService.login(AUTHORIZATION_CODE);
 
@@ -77,10 +77,10 @@ class AuthServiceTest extends ServiceTest {
                     new SlackUserInfo(
                         memberResponse.getUserId(),
                         memberResponse.getWorkspaceId(),
+                        WORKSPACE_NAME,
                         memberResponse.getNickname(),
                         memberResponse.getEmail(),
-                        memberResponse.getImageUrl(),
-                        WORKSPACE_NAME));
+                        memberResponse.getImageUrl()));
             authService.login(AUTHORIZATION_CODE);
 
             given(slackClient.requestBotAccessToken(AUTHORIZATION_CODE))

--- a/backend/src/test/java/com/woowacourse/kkogkkog/application/MemberServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/application/MemberServiceTest.java
@@ -44,8 +44,9 @@ class MemberServiceTest extends ServiceTest {
         @Test
         @DisplayName("가입되지 않은 회원 정보를 받으면, 회원을 저장하고 저장된 Id와 회원가입 여부를 반환한다.")
         void success_save() {
-            SlackUserInfo slackUserInfo = new SlackUserInfo("URookie", "T03LX3C5540", "루키",
-                "rookie@gmail.com", "image", "workspace_name");
+            SlackUserInfo slackUserInfo = new SlackUserInfo("URookie", "T03LX3C5540",
+                "workspace_name", "루키",
+                "rookie@gmail.com", "image");
 
             MemberCreateResponse memberCreateResponse = memberService.saveOrFind(slackUserInfo);
 
@@ -58,8 +59,9 @@ class MemberServiceTest extends ServiceTest {
         @Test
         @DisplayName("가입된 회원 정보를 받으면, 해당 회원의 Id와 회원가입 여부를 반환한다.")
         void success_find() {
-            SlackUserInfo slackUserInfo = new SlackUserInfo("URookie", "T03LX3C5540", "루키",
-                "rookie@gmail.com", "image", "workspace_name");
+            SlackUserInfo slackUserInfo = new SlackUserInfo("URookie", "T03LX3C5540",
+                "workspace_name", "루키",
+                "rookie@gmail.com", "image");
 
             memberService.saveOrFind(slackUserInfo);
             MemberCreateResponse memberCreateResponse = memberService.saveOrFind(slackUserInfo);
@@ -78,8 +80,8 @@ class MemberServiceTest extends ServiceTest {
         @Test
         @DisplayName("저장된 회원의 Id를 받으면, 해당 회원의 정보를 반환한다.")
         void success() {
-            SlackUserInfo slackUserInfo = new SlackUserInfo("URookie", "T03LX3C5540", "루키",
-                "rookie@gmail.com", "image", "workspace_name");
+            SlackUserInfo slackUserInfo = new SlackUserInfo("URookie", "T03LX3C5540",
+                "workspace_name", "루키", "rookie@gmail.com", "image");
             Long memberId = memberService.saveOrFind(slackUserInfo).getId();
             workspaceRepository.save(new Workspace(null, "T03LX3C5540", "꼭꼭", null));
 
@@ -107,10 +109,10 @@ class MemberServiceTest extends ServiceTest {
         @Test
         @DisplayName("회원가입된 모든 회원들의 정보를 반환한다.")
         void success() {
-            SlackUserInfo rookieUserInfo = new SlackUserInfo("URookie", "T03LX3C5540", "루키",
-                "rookie@gmail.com", "image", "workspace_name");
-            SlackUserInfo arthurUserInfo = new SlackUserInfo("UArthur", "T03LX3C5540", "아서",
-                "arthur@gmail.com", "image", "workspace_name");
+            SlackUserInfo rookieUserInfo = new SlackUserInfo("URookie", "T03LX3C5540",
+                "workspace_name", "루키", "rookie@gmail.com", "image");
+            SlackUserInfo arthurUserInfo = new SlackUserInfo("UArthur", "T03LX3C5540",
+                "workspace_name", "아서", "arthur@gmail.com", "image");
 
             memberService.saveOrFind(rookieUserInfo);
             memberService.saveOrFind(arthurUserInfo);
@@ -128,8 +130,8 @@ class MemberServiceTest extends ServiceTest {
         @Test
         @DisplayName("로그인된 사용자의 history를 반환한다.")
         void success() {
-            SlackUserInfo rookieUserInfo = new SlackUserInfo("URookie", "T03LX3C5540", "루키",
-                "rookie@gmail.com", "image", "workspace_name");
+            SlackUserInfo rookieUserInfo = new SlackUserInfo("URookie", "T03LX3C5540",
+                "workspace_name", "루키", "rookie@gmail.com", "image");
             SlackUserInfo arthurUserInfo = new SlackUserInfo("UArthur", "T03LX3C5540", "아서",
                 "arthur@gmail.com", "image", "workspace_name");
             MemberCreateResponse rookieCreateResponse = memberService.saveOrFind(rookieUserInfo);
@@ -153,8 +155,8 @@ class MemberServiceTest extends ServiceTest {
         @Test
         @DisplayName("요청받을 경우 true 로 변경된다.")
         void success() {
-            SlackUserInfo rookieUserInfo = new SlackUserInfo("URookie", "T03LX3C5540", "루키",
-                "rookie@gmail.com", "image", "workspace_name");
+            SlackUserInfo rookieUserInfo = new SlackUserInfo("URookie", "T03LX3C5540",
+                "workspace_name", "루키", "rookie@gmail.com", "image");
             SlackUserInfo arthurUserInfo = new SlackUserInfo("UArthur", "T03LX3C5540", "아서",
                 "arthur@gmail.com", "image", "workspace_name");
             MemberCreateResponse rookieCreateResponse = memberService.saveOrFind(rookieUserInfo);
@@ -175,8 +177,8 @@ class MemberServiceTest extends ServiceTest {
         @Test
         @DisplayName("사용자의 닉네임을 수정한다.")
         void success() {
-            SlackUserInfo rookieUserInfo = new SlackUserInfo("URookie", "T03LX3C5540", "루키",
-                "rookie@gmail.com", "image", "workspace_name");
+            SlackUserInfo rookieUserInfo = new SlackUserInfo("URookie", "T03LX3C5540",
+                "workspace_name", "루키", "rookie@gmail.com", "image");
             Long memberId = memberService.saveOrFind(rookieUserInfo).getId();
             workspaceRepository.save(new Workspace(null, "T03LX3C5540", "꼭꼭", null));
 

--- a/backend/src/test/java/com/woowacourse/kkogkkog/application/MemberServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/application/MemberServiceTest.java
@@ -45,7 +45,7 @@ class MemberServiceTest extends ServiceTest {
         @DisplayName("가입되지 않은 회원 정보를 받으면, 회원을 저장하고 저장된 Id와 회원가입 여부를 반환한다.")
         void success_save() {
             SlackUserInfo slackUserInfo = new SlackUserInfo("URookie", "T03LX3C5540",
-                "꼭꼭", "루키",
+                "workspace_name", "루키",
                 "rookie@gmail.com", "image");
 
             MemberCreateResponse memberCreateResponse = memberService.saveOrFind(slackUserInfo);
@@ -60,7 +60,7 @@ class MemberServiceTest extends ServiceTest {
         @DisplayName("가입된 회원 정보를 받으면, 해당 회원의 Id와 회원가입 여부를 반환한다.")
         void success_find() {
             SlackUserInfo slackUserInfo = new SlackUserInfo("URookie", "T03LX3C5540",
-                "꼭꼭", "루키",
+                "workspace_name", "루키",
                 "rookie@gmail.com", "image");
 
             memberService.saveOrFind(slackUserInfo);
@@ -81,14 +81,14 @@ class MemberServiceTest extends ServiceTest {
         @DisplayName("저장된 회원의 Id를 받으면, 해당 회원의 정보를 반환한다.")
         void success() {
             SlackUserInfo slackUserInfo = new SlackUserInfo("URookie", "T03LX3C5540",
-                "꼭꼭", "루키", "rookie@gmail.com", "image");
+                "workspace_name", "루키", "rookie@gmail.com", "image");
             Long memberId = memberService.saveOrFind(slackUserInfo).getId();
-            workspaceRepository.save(new Workspace(null, "T03LX3C5540", "꼭꼭", null));
+            workspaceRepository.save(new Workspace(null, "T03LX3C5540", "workspace_name", null));
 
             MyProfileResponse memberResponse = memberService.findById(memberId);
 
             assertThat(memberResponse).usingRecursiveComparison().ignoringFields("id").isEqualTo(
-                new MyProfileResponse(null, "URookie", "T03LX3C5540", "꼭꼭", "루키",
+                new MyProfileResponse(null, "URookie", "T03LX3C5540", "workspace_name", "루키",
                     "rookie@gmail.com", "image", 0L));
         }
 
@@ -110,9 +110,9 @@ class MemberServiceTest extends ServiceTest {
         @DisplayName("회원가입된 모든 회원들의 정보를 반환한다.")
         void success() {
             SlackUserInfo rookieUserInfo = new SlackUserInfo("URookie", "T03LX3C5540",
-                "꼭꼭", "루키", "rookie@gmail.com", "image");
+                "workspace_name", "루키", "rookie@gmail.com", "image");
             SlackUserInfo arthurUserInfo = new SlackUserInfo("UArthur", "T03LX3C5540",
-                "꼭꼭", "아서", "arthur@gmail.com", "image");
+                "workspace_name", "아서", "arthur@gmail.com", "image");
 
             memberService.saveOrFind(rookieUserInfo);
             memberService.saveOrFind(arthurUserInfo);
@@ -131,9 +131,9 @@ class MemberServiceTest extends ServiceTest {
         @DisplayName("로그인된 사용자의 history를 반환한다.")
         void success() {
             SlackUserInfo rookieUserInfo = new SlackUserInfo("URookie", "T03LX3C5540",
-                "꼭꼭", "루키", "rookie@gmail.com", "image");
+                "workspace_name", "루키", "rookie@gmail.com", "image");
             SlackUserInfo arthurUserInfo = new SlackUserInfo("UArthur", "T03LX3C5540", "아서",
-                "arthur@gmail.com", "image", "꼭꼭");
+                "arthur@gmail.com", "image", "workspace_name");
             MemberCreateResponse rookieCreateResponse = memberService.saveOrFind(rookieUserInfo);
             MemberCreateResponse arthurCreateResponse = memberService.saveOrFind(arthurUserInfo);
 
@@ -156,9 +156,9 @@ class MemberServiceTest extends ServiceTest {
         @DisplayName("요청받을 경우 true 로 변경된다.")
         void success() {
             SlackUserInfo rookieUserInfo = new SlackUserInfo("URookie", "T03LX3C5540",
-                "꼭꼭", "루키", "rookie@gmail.com", "image");
+                "workspace_name", "루키", "rookie@gmail.com", "image");
             SlackUserInfo arthurUserInfo = new SlackUserInfo("UArthur", "T03LX3C5540", "아서",
-                "arthur@gmail.com", "image", "꼭꼭");
+                "arthur@gmail.com", "image", "workspace_name");
             MemberCreateResponse rookieCreateResponse = memberService.saveOrFind(rookieUserInfo);
             MemberCreateResponse arthurCreateResponse = memberService.saveOrFind(arthurUserInfo);
             CouponSaveRequest couponSaveRequest = new CouponSaveRequest(
@@ -178,9 +178,9 @@ class MemberServiceTest extends ServiceTest {
         @DisplayName("사용자의 닉네임을 수정한다.")
         void success() {
             SlackUserInfo rookieUserInfo = new SlackUserInfo("URookie", "T03LX3C5540",
-                "꼭꼭", "루키", "rookie@gmail.com", "image");
+                "workspace_name", "루키", "rookie@gmail.com", "image");
             Long memberId = memberService.saveOrFind(rookieUserInfo).getId();
-            workspaceRepository.save(new Workspace(null, "T03LX3C5540", "꼭꼭", null));
+            workspaceRepository.save(new Workspace(null, "T03LX3C5540", "workspace_name", null));
 
             String expected = "새로운_닉네임";
             memberService.update(new MemberUpdateRequest(memberId, expected));

--- a/backend/src/test/java/com/woowacourse/kkogkkog/application/MemberServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/application/MemberServiceTest.java
@@ -11,6 +11,8 @@ import com.woowacourse.kkogkkog.application.dto.MemberResponse;
 import com.woowacourse.kkogkkog.application.dto.MemberUpdateRequest;
 import com.woowacourse.kkogkkog.application.dto.MyProfileResponse;
 import com.woowacourse.kkogkkog.domain.Member;
+import com.woowacourse.kkogkkog.domain.Workspace;
+import com.woowacourse.kkogkkog.domain.repository.WorkspaceRepository;
 import com.woowacourse.kkogkkog.exception.member.MemberNotFoundException;
 import com.woowacourse.kkogkkog.fixture.MemberFixture;
 import com.woowacourse.kkogkkog.infrastructure.SlackUserInfo;
@@ -28,6 +30,9 @@ class MemberServiceTest extends ServiceTest {
 
     @Autowired
     private MemberService memberService;
+
+    @Autowired
+    private WorkspaceRepository workspaceRepository;
 
     @Autowired
     private CouponService couponService;
@@ -76,13 +81,13 @@ class MemberServiceTest extends ServiceTest {
             SlackUserInfo slackUserInfo = new SlackUserInfo("URookie", "T03LX3C5540", "루키",
                 "rookie@gmail.com", "image", "workspace_name");
             Long memberId = memberService.saveOrFind(slackUserInfo).getId();
+            workspaceRepository.save(new Workspace(null, "T03LX3C5540", "꼭꼭", null));
 
             MyProfileResponse memberResponse = memberService.findById(memberId);
 
             assertThat(memberResponse).usingRecursiveComparison().ignoringFields("id").isEqualTo(
-                new MyProfileResponse(null, "URookie", "T03LX3C5540", "루키", "rookie@gmail.com",
-                    "image", 0L)
-            );
+                new MyProfileResponse(null, "URookie", "T03LX3C5540", "꼭꼭", "루키",
+                    "rookie@gmail.com", "image", 0L));
         }
 
         @Test
@@ -155,7 +160,8 @@ class MemberServiceTest extends ServiceTest {
             MemberCreateResponse rookieCreateResponse = memberService.saveOrFind(rookieUserInfo);
             MemberCreateResponse arthurCreateResponse = memberService.saveOrFind(arthurUserInfo);
             CouponSaveRequest couponSaveRequest = new CouponSaveRequest(
-                rookieCreateResponse.getId(), List.of(arthurCreateResponse.getId()), "한턱쏘는", "추가 메세지", "##11032", "COFFEE");
+                rookieCreateResponse.getId(), List.of(arthurCreateResponse.getId()), "한턱쏘는",
+                "추가 메세지", "##11032", "COFFEE");
             couponService.save(couponSaveRequest);
 
             assertDoesNotThrow(() -> memberService.updateIsReadMemberHistory(1L));
@@ -172,6 +178,7 @@ class MemberServiceTest extends ServiceTest {
             SlackUserInfo rookieUserInfo = new SlackUserInfo("URookie", "T03LX3C5540", "루키",
                 "rookie@gmail.com", "image", "workspace_name");
             Long memberId = memberService.saveOrFind(rookieUserInfo).getId();
+            workspaceRepository.save(new Workspace(null, "T03LX3C5540", "꼭꼭", null));
 
             String expected = "새로운_닉네임";
             memberService.update(new MemberUpdateRequest(memberId, expected));

--- a/backend/src/test/java/com/woowacourse/kkogkkog/application/MemberServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/application/MemberServiceTest.java
@@ -40,7 +40,7 @@ class MemberServiceTest extends ServiceTest {
         @DisplayName("가입되지 않은 회원 정보를 받으면, 회원을 저장하고 저장된 Id와 회원가입 여부를 반환한다.")
         void success_save() {
             SlackUserInfo slackUserInfo = new SlackUserInfo("URookie", "T03LX3C5540", "루키",
-                "rookie@gmail.com", "image");
+                "rookie@gmail.com", "image", "workspace_name");
 
             MemberCreateResponse memberCreateResponse = memberService.saveOrFind(slackUserInfo);
 
@@ -54,7 +54,7 @@ class MemberServiceTest extends ServiceTest {
         @DisplayName("가입된 회원 정보를 받으면, 해당 회원의 Id와 회원가입 여부를 반환한다.")
         void success_find() {
             SlackUserInfo slackUserInfo = new SlackUserInfo("URookie", "T03LX3C5540", "루키",
-                "rookie@gmail.com", "image");
+                "rookie@gmail.com", "image", "workspace_name");
 
             memberService.saveOrFind(slackUserInfo);
             MemberCreateResponse memberCreateResponse = memberService.saveOrFind(slackUserInfo);
@@ -74,7 +74,7 @@ class MemberServiceTest extends ServiceTest {
         @DisplayName("저장된 회원의 Id를 받으면, 해당 회원의 정보를 반환한다.")
         void success() {
             SlackUserInfo slackUserInfo = new SlackUserInfo("URookie", "T03LX3C5540", "루키",
-                "rookie@gmail.com", "image");
+                "rookie@gmail.com", "image", "workspace_name");
             Long memberId = memberService.saveOrFind(slackUserInfo).getId();
 
             MyProfileResponse memberResponse = memberService.findById(memberId);
@@ -103,9 +103,9 @@ class MemberServiceTest extends ServiceTest {
         @DisplayName("회원가입된 모든 회원들의 정보를 반환한다.")
         void success() {
             SlackUserInfo rookieUserInfo = new SlackUserInfo("URookie", "T03LX3C5540", "루키",
-                "rookie@gmail.com", "image");
+                "rookie@gmail.com", "image", "workspace_name");
             SlackUserInfo arthurUserInfo = new SlackUserInfo("UArthur", "T03LX3C5540", "아서",
-                "arthur@gmail.com", "image");
+                "arthur@gmail.com", "image", "workspace_name");
 
             memberService.saveOrFind(rookieUserInfo);
             memberService.saveOrFind(arthurUserInfo);
@@ -124,9 +124,9 @@ class MemberServiceTest extends ServiceTest {
         @DisplayName("로그인된 사용자의 history를 반환한다.")
         void success() {
             SlackUserInfo rookieUserInfo = new SlackUserInfo("URookie", "T03LX3C5540", "루키",
-                "rookie@gmail.com", "image");
+                "rookie@gmail.com", "image", "workspace_name");
             SlackUserInfo arthurUserInfo = new SlackUserInfo("UArthur", "T03LX3C5540", "아서",
-                "arthur@gmail.com", "image");
+                "arthur@gmail.com", "image", "workspace_name");
             MemberCreateResponse rookieCreateResponse = memberService.saveOrFind(rookieUserInfo);
             MemberCreateResponse arthurCreateResponse = memberService.saveOrFind(arthurUserInfo);
 
@@ -149,9 +149,9 @@ class MemberServiceTest extends ServiceTest {
         @DisplayName("요청받을 경우 true 로 변경된다.")
         void success() {
             SlackUserInfo rookieUserInfo = new SlackUserInfo("URookie", "T03LX3C5540", "루키",
-                "rookie@gmail.com", "image");
+                "rookie@gmail.com", "image", "workspace_name");
             SlackUserInfo arthurUserInfo = new SlackUserInfo("UArthur", "T03LX3C5540", "아서",
-                "arthur@gmail.com", "image");
+                "arthur@gmail.com", "image", "workspace_name");
             MemberCreateResponse rookieCreateResponse = memberService.saveOrFind(rookieUserInfo);
             MemberCreateResponse arthurCreateResponse = memberService.saveOrFind(arthurUserInfo);
             CouponSaveRequest couponSaveRequest = new CouponSaveRequest(
@@ -170,7 +170,7 @@ class MemberServiceTest extends ServiceTest {
         @DisplayName("사용자의 닉네임을 수정한다.")
         void success() {
             SlackUserInfo rookieUserInfo = new SlackUserInfo("URookie", "T03LX3C5540", "루키",
-                "rookie@gmail.com", "image");
+                "rookie@gmail.com", "image", "workspace_name");
             Long memberId = memberService.saveOrFind(rookieUserInfo).getId();
 
             String expected = "새로운_닉네임";

--- a/backend/src/test/java/com/woowacourse/kkogkkog/application/MemberServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/application/MemberServiceTest.java
@@ -45,7 +45,7 @@ class MemberServiceTest extends ServiceTest {
         @DisplayName("가입되지 않은 회원 정보를 받으면, 회원을 저장하고 저장된 Id와 회원가입 여부를 반환한다.")
         void success_save() {
             SlackUserInfo slackUserInfo = new SlackUserInfo("URookie", "T03LX3C5540",
-                "workspace_name", "루키",
+                "꼭꼭", "루키",
                 "rookie@gmail.com", "image");
 
             MemberCreateResponse memberCreateResponse = memberService.saveOrFind(slackUserInfo);
@@ -60,7 +60,7 @@ class MemberServiceTest extends ServiceTest {
         @DisplayName("가입된 회원 정보를 받으면, 해당 회원의 Id와 회원가입 여부를 반환한다.")
         void success_find() {
             SlackUserInfo slackUserInfo = new SlackUserInfo("URookie", "T03LX3C5540",
-                "workspace_name", "루키",
+                "꼭꼭", "루키",
                 "rookie@gmail.com", "image");
 
             memberService.saveOrFind(slackUserInfo);
@@ -81,7 +81,7 @@ class MemberServiceTest extends ServiceTest {
         @DisplayName("저장된 회원의 Id를 받으면, 해당 회원의 정보를 반환한다.")
         void success() {
             SlackUserInfo slackUserInfo = new SlackUserInfo("URookie", "T03LX3C5540",
-                "workspace_name", "루키", "rookie@gmail.com", "image");
+                "꼭꼭", "루키", "rookie@gmail.com", "image");
             Long memberId = memberService.saveOrFind(slackUserInfo).getId();
             workspaceRepository.save(new Workspace(null, "T03LX3C5540", "꼭꼭", null));
 
@@ -110,9 +110,9 @@ class MemberServiceTest extends ServiceTest {
         @DisplayName("회원가입된 모든 회원들의 정보를 반환한다.")
         void success() {
             SlackUserInfo rookieUserInfo = new SlackUserInfo("URookie", "T03LX3C5540",
-                "workspace_name", "루키", "rookie@gmail.com", "image");
+                "꼭꼭", "루키", "rookie@gmail.com", "image");
             SlackUserInfo arthurUserInfo = new SlackUserInfo("UArthur", "T03LX3C5540",
-                "workspace_name", "아서", "arthur@gmail.com", "image");
+                "꼭꼭", "아서", "arthur@gmail.com", "image");
 
             memberService.saveOrFind(rookieUserInfo);
             memberService.saveOrFind(arthurUserInfo);
@@ -131,9 +131,9 @@ class MemberServiceTest extends ServiceTest {
         @DisplayName("로그인된 사용자의 history를 반환한다.")
         void success() {
             SlackUserInfo rookieUserInfo = new SlackUserInfo("URookie", "T03LX3C5540",
-                "workspace_name", "루키", "rookie@gmail.com", "image");
+                "꼭꼭", "루키", "rookie@gmail.com", "image");
             SlackUserInfo arthurUserInfo = new SlackUserInfo("UArthur", "T03LX3C5540", "아서",
-                "arthur@gmail.com", "image", "workspace_name");
+                "arthur@gmail.com", "image", "꼭꼭");
             MemberCreateResponse rookieCreateResponse = memberService.saveOrFind(rookieUserInfo);
             MemberCreateResponse arthurCreateResponse = memberService.saveOrFind(arthurUserInfo);
 
@@ -156,9 +156,9 @@ class MemberServiceTest extends ServiceTest {
         @DisplayName("요청받을 경우 true 로 변경된다.")
         void success() {
             SlackUserInfo rookieUserInfo = new SlackUserInfo("URookie", "T03LX3C5540",
-                "workspace_name", "루키", "rookie@gmail.com", "image");
+                "꼭꼭", "루키", "rookie@gmail.com", "image");
             SlackUserInfo arthurUserInfo = new SlackUserInfo("UArthur", "T03LX3C5540", "아서",
-                "arthur@gmail.com", "image", "workspace_name");
+                "arthur@gmail.com", "image", "꼭꼭");
             MemberCreateResponse rookieCreateResponse = memberService.saveOrFind(rookieUserInfo);
             MemberCreateResponse arthurCreateResponse = memberService.saveOrFind(arthurUserInfo);
             CouponSaveRequest couponSaveRequest = new CouponSaveRequest(
@@ -178,7 +178,7 @@ class MemberServiceTest extends ServiceTest {
         @DisplayName("사용자의 닉네임을 수정한다.")
         void success() {
             SlackUserInfo rookieUserInfo = new SlackUserInfo("URookie", "T03LX3C5540",
-                "workspace_name", "루키", "rookie@gmail.com", "image");
+                "꼭꼭", "루키", "rookie@gmail.com", "image");
             Long memberId = memberService.saveOrFind(rookieUserInfo).getId();
             workspaceRepository.save(new Workspace(null, "T03LX3C5540", "꼭꼭", null));
 

--- a/backend/src/test/java/com/woowacourse/kkogkkog/documentation/MemberControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/documentation/MemberControllerTest.java
@@ -74,7 +74,7 @@ public class MemberControllerTest extends Documentation {
     void 나의_회원정보를_요청할_수_있다() throws Exception {
         // given
         MyProfileResponse memberResponse = new MyProfileResponse(1L, "User1", "TWorkspace1",
-            "user_nickname1", "email1@gmail.com", "image", 10L);
+            "workspace_name", "user_nickname1", "email1@gmail.com", "image", 10L);
 
         given(jwtTokenProvider.getValidatedPayload(any())).willReturn("1");
         given(memberService.findById(any())).willReturn(memberResponse);
@@ -88,6 +88,7 @@ public class MemberControllerTest extends Documentation {
             .andExpect(jsonPath("$.id").value("1"))
             .andExpect(jsonPath("$.userId").value("User1"))
             .andExpect(jsonPath("$.workspaceId").value("TWorkspace1"))
+            .andExpect(jsonPath("$.workspaceName").value("workspace_name"))
             .andExpect(jsonPath("$.nickname").value("user_nickname1"))
             .andExpect(jsonPath("$.email").value("email1@gmail.com"))
             .andExpect(jsonPath("$.imageUrl").value("image"));
@@ -106,6 +107,8 @@ public class MemberControllerTest extends Documentation {
                     fieldWithPath("userId").type(JsonFieldType.STRING).description("유저 Id"),
                     fieldWithPath("workspaceId").type(JsonFieldType.STRING)
                         .description("워크스페이스 ID"),
+                    fieldWithPath("workspaceName").type(JsonFieldType.STRING)
+                        .description("워크스페이스 이름"),
                     fieldWithPath("nickname").type(JsonFieldType.STRING).description("닉네임"),
                     fieldWithPath("email").type(JsonFieldType.STRING).description("이메일"),
                     fieldWithPath("imageUrl").type(JsonFieldType.STRING).description("이미지 주소"),


### PR DESCRIPTION
## 작업 내용

- 로그인 시 워크스페이스의 이름을 저장하는 기능 구현
- 나의 정보 조회 시 Response body에 워크스페이스의 이름, 사진을 추가

## 공유사항
Member의 필드가 변경되지 않은 부분입니다.
[refactor: Member Workspace 엔티티 다대일 매핑 백업](https://github.com/woowacourse-teams/2022-kkogkkog/pull/196/commits/d9856d6b531c16743da47c077c9efebae35190a4) 바로 이전 커밋까지 + 앱 설치 때에 워크스페이스가 없으면 예외를 발생하는 것에서 워크스페이스가 생성되는 부분만 변경하여 pr 올립니다.
로그인시 토큰이 삭제되는 버그는 피드백 이후 커밋인 [feat: 로그인과 앱 설치 모두 워크스페이스를 생성 또는 업데이트하게 변경](https://github.com/woowacourse-teams/2022-kkogkkog/pull/196/commits/1d6fefaba5dad31f5c9fddd50030274efdc6e0e3) 에서 생겨서 지금은 정상적으로 동작합니다.
Resolves #195
