### PR TITLE
feat: 닉네임에 대해 정규표현식 적용 및 회원가입시 임의의 닉네임 생성 

### DIFF
--- a/backend/src/main/java/com/woowacourse/kkogkkog/application/AuthService.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/application/AuthService.java
@@ -31,7 +31,7 @@ public class AuthService {
     public TokenResponse login(String code) {
         SlackUserInfo userInfo = slackClient.getUserInfoByCode(code);
         Workspace workspace = getWorkspace(userInfo);
-        MemberCreateResponse memberCreateResponse = memberService.saveOrFind(userInfo, workspace);
+        MemberCreateResponse memberCreateResponse = memberService.saveOrUpdate(userInfo, workspace);
 
         return new TokenResponse(
             jwtTokenProvider.createToken(memberCreateResponse.getId().toString()),

--- a/backend/src/main/java/com/woowacourse/kkogkkog/application/MemberService.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/application/MemberService.java
@@ -47,7 +47,7 @@ public class MemberService {
             return new MemberCreateResponse(existingMember.getId(), false);
         }
         Member newMember = memberRepository.save(
-            new Member(null, userId, workspace, nickname, email, imageUrl));
+            Member.ofRandomNickname(userId, workspace, email, imageUrl));
         return new MemberCreateResponse(newMember.getId(), true);
     }
 

--- a/backend/src/main/java/com/woowacourse/kkogkkog/domain/Member.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/domain/Member.java
@@ -1,6 +1,7 @@
 package com.woowacourse.kkogkkog.domain;
 
 import com.woowacourse.kkogkkog.exception.InvalidRequestException;
+import java.security.SecureRandom;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.persistence.Column;
@@ -21,6 +22,7 @@ import lombok.NoArgsConstructor;
 public class Member {
 
     private static final Pattern NICKNAME_PATTERN = Pattern.compile("^[가-힣a-zA-Z0-9]{2,6}$");
+    private static final SecureRandom RANDOM_GENERATOR = new SecureRandom();
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -54,7 +56,7 @@ public class Member {
 
     public static Member ofRandomNickname(String userId, Workspace workspace, String email,
                                           String imageUrl) {
-        String randomNum = String.valueOf(Math.random());
+        String randomNum = String.valueOf(RANDOM_GENERATOR.nextDouble());
         String anonymousNickname = String.format("익명%s", randomNum.substring(2, 6));
         return new Member(null, userId, workspace, anonymousNickname, email, imageUrl);
     }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/domain/Member.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/domain/Member.java
@@ -1,5 +1,8 @@
 package com.woowacourse.kkogkkog.domain;
 
+import com.woowacourse.kkogkkog.exception.InvalidRequestException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -16,6 +19,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class Member {
+
+    private static final Pattern NICKNAME_PATTERN = Pattern.compile("^[가-힣a-zA-Z0-9]{2,6}$");
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -55,6 +60,10 @@ public class Member {
     }
 
     public void updateNickname(String nickname) {
+        Matcher matcher = NICKNAME_PATTERN.matcher(nickname);
+        if (!matcher.matches()) {
+            throw new InvalidRequestException("잘못된 닉네임 형식입니다. (한글, 숫자, 영문자로 구성된 2~6글자)");
+        }
         this.nickname = nickname;
     }
 

--- a/backend/src/main/java/com/woowacourse/kkogkkog/domain/Member.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/domain/Member.java
@@ -47,6 +47,13 @@ public class Member {
         this.imageUrl = imageUrl;
     }
 
+    public static Member ofRandomNickname(String userId, Workspace workspace, String email,
+                                          String imageUrl) {
+        String randomNum = String.valueOf(Math.random());
+        String anonymousNickname = String.format("익명%s", randomNum.substring(2, 6));
+        return new Member(null, userId, workspace, anonymousNickname, email, imageUrl);
+    }
+
     public void updateNickname(String nickname) {
         this.nickname = nickname;
     }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/presentation/MemberController.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/presentation/MemberController.java
@@ -7,6 +7,7 @@ import com.woowacourse.kkogkkog.presentation.dto.MemberUpdateMeRequest;
 import com.woowacourse.kkogkkog.presentation.dto.SuccessResponse;
 import com.woowacourse.kkogkkog.presentation.dto.MemberHistoriesResponse;
 import java.util.List;
+import javax.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -40,7 +41,7 @@ public class MemberController {
 
     @PutMapping("/me")
     public ResponseEntity<Void> updateMe(@LoginMember Long id,
-                                         @RequestBody MemberUpdateMeRequest memberUpdateMeRequest) {
+                                         @Valid @RequestBody MemberUpdateMeRequest memberUpdateMeRequest) {
         memberService.update(memberUpdateMeRequest.toMemberUpdateRequest(id));
 
         return ResponseEntity.ok().build();

--- a/backend/src/main/java/com/woowacourse/kkogkkog/presentation/dto/MemberUpdateMeRequest.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/presentation/dto/MemberUpdateMeRequest.java
@@ -1,6 +1,7 @@
 package com.woowacourse.kkogkkog.presentation.dto;
 
 import com.woowacourse.kkogkkog.application.dto.MemberUpdateRequest;
+import javax.validation.constraints.NotBlank;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -9,6 +10,7 @@ import lombok.NoArgsConstructor;
 @Getter
 public class MemberUpdateMeRequest {
 
+    @NotBlank(message = "닉네임을 입력해주세요")
     private String nickname;
 
     public MemberUpdateMeRequest(String nickname) {

--- a/backend/src/main/java/com/woowacourse/kkogkkog/presentation/dto/MemberUpdateMeRequest.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/presentation/dto/MemberUpdateMeRequest.java
@@ -16,6 +16,6 @@ public class MemberUpdateMeRequest {
     }
 
     public MemberUpdateRequest toMemberUpdateRequest(Long memberId) {
-        return new MemberUpdateRequest(memberId, nickname);
+        return new MemberUpdateRequest(memberId, nickname.trim());
     }
 }

--- a/backend/src/test/java/com/woowacourse/kkogkkog/acceptance/CouponAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/acceptance/CouponAcceptanceTest.java
@@ -53,8 +53,10 @@ public class CouponAcceptanceTest extends AcceptanceTest {
 
         @Test
         void 로그인된_사용자는_받은_쿠폰과_보낸_쿠폰을_전부_조회할_수_있다() {
-            String jeongAccessToken = 회원가입_또는_로그인에_성공한다(MemberResponse.of(JEONG), WorkspaceResponse.of(WORKSPACE)).getAccessToken();
-            String leoAccessToken = 회원가입_또는_로그인에_성공한다(MemberResponse.of(LEO), WorkspaceResponse.of(WORKSPACE)).getAccessToken();
+            String jeongAccessToken = 회원가입_또는_로그인에_성공한다(MemberResponse.of(JEONG),
+                WorkspaceResponse.of(WORKSPACE)).getAccessToken();
+            String leoAccessToken = 회원가입_또는_로그인에_성공한다(MemberResponse.of(LEO),
+                WorkspaceResponse.of(WORKSPACE)).getAccessToken();
             회원가입_또는_로그인에_성공한다(MemberResponse.of(ARTHUR), WorkspaceResponse.of(WORKSPACE));
             List<CouponResponse> sentCoupons = 쿠폰_발급에_성공한다(jeongAccessToken,
                 List.of(LEO, ARTHUR)).getData();
@@ -64,8 +66,7 @@ public class CouponAcceptanceTest extends AcceptanceTest {
             MyCouponsResponse actual = 쿠폰_전체_조회에_성공한다(jeongAccessToken);
             MyCouponsResponse expected = new MyCouponsResponse(receivedCoupons, sentCoupons);
 
-            assertThat(actual).usingRecursiveComparison()
-                .isEqualTo(expected);
+            assertThat(actual).usingRecursiveComparison().isEqualTo(expected);
         }
 
         @Test
@@ -97,7 +98,8 @@ public class CouponAcceptanceTest extends AcceptanceTest {
 
         @Test
         void 로그인된_사용자는_복수의_사용자에게_쿠폰을_발급할_수_있다() {
-            String jeongAccessToken = 회원가입_또는_로그인에_성공한다(MemberResponse.of(JEONG), WorkspaceResponse.of(WORKSPACE)).getAccessToken();
+            String jeongAccessToken = 회원가입_또는_로그인에_성공한다(MemberResponse.of(JEONG),
+                WorkspaceResponse.of(WORKSPACE)).getAccessToken();
             회원가입_또는_로그인에_성공한다(MemberResponse.of(LEO), WorkspaceResponse.of(WORKSPACE));
             회원가입_또는_로그인에_성공한다(MemberResponse.of(ARTHUR), WorkspaceResponse.of(WORKSPACE));
             회원가입_또는_로그인에_성공한다(MemberResponse.of(ROOKIE), WorkspaceResponse.of(WORKSPACE));
@@ -109,7 +111,9 @@ public class CouponAcceptanceTest extends AcceptanceTest {
                 toCouponResponse(2L, JEONG, ARTHUR),
                 toCouponResponse(3L, JEONG, ROOKIE)));
 
-            assertThat(actual).usingRecursiveComparison().isEqualTo(expected);
+            assertThat(actual).usingRecursiveComparison()
+                .ignoringFields("data.receiver.nickname", "data.sender.nickname")
+                .isEqualTo(expected);
         }
 
         @Test
@@ -125,7 +129,8 @@ public class CouponAcceptanceTest extends AcceptanceTest {
         @Test
         void 자신에게_쿠폰을_발급할_수_없다() {
             회원가입_또는_로그인에_성공한다(MemberResponse.of(JEONG), WorkspaceResponse.of(WORKSPACE));
-            String accessToken = 회원가입_또는_로그인에_성공한다(MemberResponse.of(JEONG), WorkspaceResponse.of(WORKSPACE)).getAccessToken();
+            String accessToken = 회원가입_또는_로그인에_성공한다(MemberResponse.of(JEONG),
+                WorkspaceResponse.of(WORKSPACE)).getAccessToken();
 
             ExtractableResponse<Response> response = 쿠폰_발급을_요청한다(accessToken, List.of(JEONG));
 
@@ -134,7 +139,8 @@ public class CouponAcceptanceTest extends AcceptanceTest {
 
         @Test
         void 받는_사람이_존재하지_않는_경우_쿠폰을_발급할_수_없다() {
-            String accessToken = 회원가입_또는_로그인에_성공한다(MemberResponse.of(LEO), WorkspaceResponse.of(WORKSPACE)).getAccessToken();
+            String accessToken = 회원가입_또는_로그인에_성공한다(MemberResponse.of(LEO),
+                WorkspaceResponse.of(WORKSPACE)).getAccessToken();
 
             ExtractableResponse<Response> response = 쿠폰_발급을_요청한다(accessToken,
                 List.of(MemberFixture.NON_EXISTING_MEMBER));
@@ -151,7 +157,8 @@ public class CouponAcceptanceTest extends AcceptanceTest {
         void 생성된_쿠폰을_조회할_수_있다() {
             회원가입_또는_로그인에_성공한다(MemberResponse.of(JEONG), WorkspaceResponse.of(WORKSPACE));
             회원가입_또는_로그인에_성공한다(MemberResponse.of(LEO), WorkspaceResponse.of(WORKSPACE));
-            String accessToken = 회원가입_또는_로그인에_성공한다(MemberResponse.of(JEONG), WorkspaceResponse.of(WORKSPACE)).getAccessToken();
+            String accessToken = 회원가입_또는_로그인에_성공한다(MemberResponse.of(JEONG),
+                WorkspaceResponse.of(WORKSPACE)).getAccessToken();
 
             CouponResponse expected = 쿠폰_발급에_성공한다(accessToken, List.of(LEO)).getData().get(0);
             CouponResponse actual = 쿠폰_조회에_성공한다(expected.getId());
@@ -190,8 +197,10 @@ public class CouponAcceptanceTest extends AcceptanceTest {
         void 로그인된_사용자는_받은_쿠폰에_대해_사용_요청을_보낼_수_있다() {
             회원가입_또는_로그인에_성공한다(MemberResponse.of(JEONG), WorkspaceResponse.of(WORKSPACE));
             회원가입_또는_로그인에_성공한다(MemberResponse.of(LEO), WorkspaceResponse.of(WORKSPACE));
-            String jeongAccessToken = 회원가입_또는_로그인에_성공한다(MemberResponse.of(JEONG), WorkspaceResponse.of(WORKSPACE)).getAccessToken();
-            String leoAccessToken = 회원가입_또는_로그인에_성공한다(MemberResponse.of(LEO), WorkspaceResponse.of(WORKSPACE)).getAccessToken();
+            String jeongAccessToken = 회원가입_또는_로그인에_성공한다(MemberResponse.of(JEONG),
+                WorkspaceResponse.of(WORKSPACE)).getAccessToken();
+            String leoAccessToken = 회원가입_또는_로그인에_성공한다(MemberResponse.of(LEO),
+                WorkspaceResponse.of(WORKSPACE)).getAccessToken();
             쿠폰_발급에_성공한다(jeongAccessToken, List.of(LEO));
 
             ExtractableResponse<Response> response = 쿠폰_사용을_요청한다(leoAccessToken, 1L,
@@ -204,8 +213,10 @@ public class CouponAcceptanceTest extends AcceptanceTest {
         void 존재하지_않는_이벤트를_보낼_수_없다() {
             회원가입_또는_로그인에_성공한다(MemberResponse.of(JEONG), WorkspaceResponse.of(WORKSPACE));
             회원가입_또는_로그인에_성공한다(MemberResponse.of(LEO), WorkspaceResponse.of(WORKSPACE));
-            String jeongAccessToken = 회원가입_또는_로그인에_성공한다(MemberResponse.of(JEONG), WorkspaceResponse.of(WORKSPACE)).getAccessToken();
-            String leoAccessToken = 회원가입_또는_로그인에_성공한다(MemberResponse.of(LEO), WorkspaceResponse.of(WORKSPACE)).getAccessToken();
+            String jeongAccessToken = 회원가입_또는_로그인에_성공한다(MemberResponse.of(JEONG),
+                WorkspaceResponse.of(WORKSPACE)).getAccessToken();
+            String leoAccessToken = 회원가입_또는_로그인에_성공한다(MemberResponse.of(LEO),
+                WorkspaceResponse.of(WORKSPACE)).getAccessToken();
             쿠폰_발급에_성공한다(jeongAccessToken, List.of(LEO));
 
             ExtractableResponse<Response> response = 쿠폰_상태_변경을_요청한다(leoAccessToken, 1L,
@@ -218,8 +229,10 @@ public class CouponAcceptanceTest extends AcceptanceTest {
         void 쿠폰을_보낸_사람은_사용_요청을_취소_할_수_있다() {
             회원가입_또는_로그인에_성공한다(MemberResponse.of(JEONG), WorkspaceResponse.of(WORKSPACE));
             회원가입_또는_로그인에_성공한다(MemberResponse.of(LEO), WorkspaceResponse.of(WORKSPACE));
-            String jeongAccessToken = 회원가입_또는_로그인에_성공한다(MemberResponse.of(JEONG), WorkspaceResponse.of(WORKSPACE)).getAccessToken();
-            String leoAccessToken = 회원가입_또는_로그인에_성공한다(MemberResponse.of(LEO), WorkspaceResponse.of(WORKSPACE)).getAccessToken();
+            String jeongAccessToken = 회원가입_또는_로그인에_성공한다(MemberResponse.of(JEONG),
+                WorkspaceResponse.of(WORKSPACE)).getAccessToken();
+            String leoAccessToken = 회원가입_또는_로그인에_성공한다(MemberResponse.of(LEO),
+                WorkspaceResponse.of(WORKSPACE)).getAccessToken();
             쿠폰_발급에_성공한다(jeongAccessToken, List.of(LEO));
 
             쿠폰_사용을_요청한다(leoAccessToken, 1L, CouponEvent.REQUEST.name(), "2022-07-27");
@@ -233,8 +246,10 @@ public class CouponAcceptanceTest extends AcceptanceTest {
         void 사용_요청_상태가_아닌_쿠폰은_요청을_취소할_수_없다() {
             회원가입_또는_로그인에_성공한다(MemberResponse.of(JEONG), WorkspaceResponse.of(WORKSPACE));
             회원가입_또는_로그인에_성공한다(MemberResponse.of(LEO), WorkspaceResponse.of(WORKSPACE));
-            String jeongAccessToken = 회원가입_또는_로그인에_성공한다(MemberResponse.of(JEONG), WorkspaceResponse.of(WORKSPACE)).getAccessToken();
-            String leoAccessToken = 회원가입_또는_로그인에_성공한다(MemberResponse.of(LEO), WorkspaceResponse.of(WORKSPACE)).getAccessToken();
+            String jeongAccessToken = 회원가입_또는_로그인에_성공한다(MemberResponse.of(JEONG),
+                WorkspaceResponse.of(WORKSPACE)).getAccessToken();
+            String leoAccessToken = 회원가입_또는_로그인에_성공한다(MemberResponse.of(LEO),
+                WorkspaceResponse.of(WORKSPACE)).getAccessToken();
             쿠폰_발급에_성공한다(jeongAccessToken, List.of(LEO));
 
             ExtractableResponse<Response> response = 쿠폰_상태_변경을_요청한다(leoAccessToken, 1L,
@@ -247,8 +262,10 @@ public class CouponAcceptanceTest extends AcceptanceTest {
         void 로그인된_사용자가_보낸_쿠폰에_대해_사용_요청을_받으면_요청을_거절할_수_있다() {
             회원가입_또는_로그인에_성공한다(MemberResponse.of(JEONG), WorkspaceResponse.of(WORKSPACE));
             회원가입_또는_로그인에_성공한다(MemberResponse.of(LEO), WorkspaceResponse.of(WORKSPACE));
-            String jeongAccessToken = 회원가입_또는_로그인에_성공한다(MemberResponse.of(JEONG), WorkspaceResponse.of(WORKSPACE)).getAccessToken();
-            String leoAccessToken = 회원가입_또는_로그인에_성공한다(MemberResponse.of(LEO), WorkspaceResponse.of(WORKSPACE)).getAccessToken();
+            String jeongAccessToken = 회원가입_또는_로그인에_성공한다(MemberResponse.of(JEONG),
+                WorkspaceResponse.of(WORKSPACE)).getAccessToken();
+            String leoAccessToken = 회원가입_또는_로그인에_성공한다(MemberResponse.of(LEO),
+                WorkspaceResponse.of(WORKSPACE)).getAccessToken();
             쿠폰_발급에_성공한다(jeongAccessToken, List.of(LEO));
 
             쿠폰_사용을_요청한다(leoAccessToken, 1L, CouponEvent.REQUEST.name(), "2022-07-27");
@@ -262,7 +279,8 @@ public class CouponAcceptanceTest extends AcceptanceTest {
         void 쿠폰이_사용_준비_상태이면_사용_요청을_거절할_수_없다() {
             회원가입_또는_로그인에_성공한다(MemberResponse.of(JEONG), WorkspaceResponse.of(WORKSPACE));
             회원가입_또는_로그인에_성공한다(MemberResponse.of(LEO), WorkspaceResponse.of(WORKSPACE));
-            String jeongAccessToken = 회원가입_또는_로그인에_성공한다(MemberResponse.of(JEONG), WorkspaceResponse.of(WORKSPACE)).getAccessToken();
+            String jeongAccessToken = 회원가입_또는_로그인에_성공한다(MemberResponse.of(JEONG),
+                WorkspaceResponse.of(WORKSPACE)).getAccessToken();
             쿠폰_발급에_성공한다(jeongAccessToken, List.of(LEO));
 
             ExtractableResponse<Response> response = 쿠폰_상태_변경을_요청한다(jeongAccessToken, 1L,
@@ -275,8 +293,10 @@ public class CouponAcceptanceTest extends AcceptanceTest {
         void 로그인된_사용자가_보낸_쿠폰에_대해_사용_요청을_받으면_요청을_수락할_수_있다() {
             회원가입_또는_로그인에_성공한다(MemberResponse.of(JEONG), WorkspaceResponse.of(WORKSPACE));
             회원가입_또는_로그인에_성공한다(MemberResponse.of(LEO), WorkspaceResponse.of(WORKSPACE));
-            String jeongAccessToken = 회원가입_또는_로그인에_성공한다(MemberResponse.of(JEONG), WorkspaceResponse.of(WORKSPACE)).getAccessToken();
-            String leoAccessToken = 회원가입_또는_로그인에_성공한다(MemberResponse.of(LEO), WorkspaceResponse.of(WORKSPACE)).getAccessToken();
+            String jeongAccessToken = 회원가입_또는_로그인에_성공한다(MemberResponse.of(JEONG),
+                WorkspaceResponse.of(WORKSPACE)).getAccessToken();
+            String leoAccessToken = 회원가입_또는_로그인에_성공한다(MemberResponse.of(LEO),
+                WorkspaceResponse.of(WORKSPACE)).getAccessToken();
             쿠폰_발급에_성공한다(jeongAccessToken, List.of(LEO));
 
             쿠폰_사용을_요청한다(leoAccessToken, 1L, CouponEvent.REQUEST.name(), "2022-07-27");
@@ -290,7 +310,8 @@ public class CouponAcceptanceTest extends AcceptanceTest {
         void 쿠폰이_사용_준비_상태이면_사용_요청을_수락할_수_없다() {
             회원가입_또는_로그인에_성공한다(MemberResponse.of(JEONG), WorkspaceResponse.of(WORKSPACE));
             회원가입_또는_로그인에_성공한다(MemberResponse.of(LEO), WorkspaceResponse.of(WORKSPACE));
-            String jeongAccessToken = 회원가입_또는_로그인에_성공한다(MemberResponse.of(JEONG), WorkspaceResponse.of(WORKSPACE)).getAccessToken();
+            String jeongAccessToken = 회원가입_또는_로그인에_성공한다(MemberResponse.of(JEONG),
+                WorkspaceResponse.of(WORKSPACE)).getAccessToken();
             쿠폰_발급에_성공한다(jeongAccessToken, List.of(LEO));
 
             ExtractableResponse<Response> response = 쿠폰_상태_변경을_요청한다(jeongAccessToken, 1L,
@@ -303,8 +324,10 @@ public class CouponAcceptanceTest extends AcceptanceTest {
         void 로그인된_사용자는_받은_쿠폰에_대해_사용_대기_상태이면_사용_완료를_할_수_있다() {
             회원가입_또는_로그인에_성공한다(MemberResponse.of(JEONG), WorkspaceResponse.of(WORKSPACE));
             회원가입_또는_로그인에_성공한다(MemberResponse.of(LEO), WorkspaceResponse.of(WORKSPACE));
-            String jeongAccessToken = 회원가입_또는_로그인에_성공한다(MemberResponse.of(JEONG), WorkspaceResponse.of(WORKSPACE)).getAccessToken();
-            String leoAccessToken = 회원가입_또는_로그인에_성공한다(MemberResponse.of(LEO), WorkspaceResponse.of(WORKSPACE)).getAccessToken();
+            String jeongAccessToken = 회원가입_또는_로그인에_성공한다(MemberResponse.of(JEONG),
+                WorkspaceResponse.of(WORKSPACE)).getAccessToken();
+            String leoAccessToken = 회원가입_또는_로그인에_성공한다(MemberResponse.of(LEO),
+                WorkspaceResponse.of(WORKSPACE)).getAccessToken();
             쿠폰_발급에_성공한다(jeongAccessToken, List.of(LEO));
 
             ExtractableResponse<Response> response = 쿠폰_상태_변경을_요청한다(leoAccessToken, 1L,
@@ -317,8 +340,10 @@ public class CouponAcceptanceTest extends AcceptanceTest {
         void 로그인된_사용자는_받은_쿠폰에_대해_사용_요청_상태이면_사용_완료를_할_수_있다() {
             회원가입_또는_로그인에_성공한다(MemberResponse.of(JEONG), WorkspaceResponse.of(WORKSPACE));
             회원가입_또는_로그인에_성공한다(MemberResponse.of(LEO), WorkspaceResponse.of(WORKSPACE));
-            String jeongAccessToken = 회원가입_또는_로그인에_성공한다(MemberResponse.of(JEONG), WorkspaceResponse.of(WORKSPACE)).getAccessToken();
-            String leoAccessToken = 회원가입_또는_로그인에_성공한다(MemberResponse.of(LEO), WorkspaceResponse.of(WORKSPACE)).getAccessToken();
+            String jeongAccessToken = 회원가입_또는_로그인에_성공한다(MemberResponse.of(JEONG),
+                WorkspaceResponse.of(WORKSPACE)).getAccessToken();
+            String leoAccessToken = 회원가입_또는_로그인에_성공한다(MemberResponse.of(LEO),
+                WorkspaceResponse.of(WORKSPACE)).getAccessToken();
             쿠폰_발급에_성공한다(jeongAccessToken, List.of(LEO));
 
             쿠폰_사용을_요청한다(leoAccessToken, 1L, CouponEvent.REQUEST.name(), "2022-07-27");
@@ -332,8 +357,10 @@ public class CouponAcceptanceTest extends AcceptanceTest {
         void 로그인된_사용자는_받은_쿠폰에_대해_사용_수락_상태이면_사용_완료를_할_수_있다() {
             회원가입_또는_로그인에_성공한다(MemberResponse.of(JEONG), WorkspaceResponse.of(WORKSPACE));
             회원가입_또는_로그인에_성공한다(MemberResponse.of(LEO), WorkspaceResponse.of(WORKSPACE));
-            String jeongAccessToken = 회원가입_또는_로그인에_성공한다(MemberResponse.of(JEONG), WorkspaceResponse.of(WORKSPACE)).getAccessToken();
-            String leoAccessToken = 회원가입_또는_로그인에_성공한다(MemberResponse.of(LEO), WorkspaceResponse.of(WORKSPACE)).getAccessToken();
+            String jeongAccessToken = 회원가입_또는_로그인에_성공한다(MemberResponse.of(JEONG),
+                WorkspaceResponse.of(WORKSPACE)).getAccessToken();
+            String leoAccessToken = 회원가입_또는_로그인에_성공한다(MemberResponse.of(LEO),
+                WorkspaceResponse.of(WORKSPACE)).getAccessToken();
             쿠폰_발급에_성공한다(jeongAccessToken, List.of(LEO));
 
             쿠폰_사용을_요청한다(leoAccessToken, 1L, CouponEvent.REQUEST.name(), "2022-07-27");
@@ -348,8 +375,10 @@ public class CouponAcceptanceTest extends AcceptanceTest {
         void 받은_쿠폰에_대해_사용_완료_상태이면_사용_완료를_할_수_없다() {
             회원가입_또는_로그인에_성공한다(MemberResponse.of(JEONG), WorkspaceResponse.of(WORKSPACE));
             회원가입_또는_로그인에_성공한다(MemberResponse.of(LEO), WorkspaceResponse.of(WORKSPACE));
-            String jeongAccessToken = 회원가입_또는_로그인에_성공한다(MemberResponse.of(JEONG), WorkspaceResponse.of(WORKSPACE)).getAccessToken();
-            String leoAccessToken = 회원가입_또는_로그인에_성공한다(MemberResponse.of(LEO), WorkspaceResponse.of(WORKSPACE)).getAccessToken();
+            String jeongAccessToken = 회원가입_또는_로그인에_성공한다(MemberResponse.of(JEONG),
+                WorkspaceResponse.of(WORKSPACE)).getAccessToken();
+            String leoAccessToken = 회원가입_또는_로그인에_성공한다(MemberResponse.of(LEO),
+                WorkspaceResponse.of(WORKSPACE)).getAccessToken();
             쿠폰_발급에_성공한다(jeongAccessToken, List.of(LEO));
 
             쿠폰_사용을_요청한다(leoAccessToken, 1L, CouponEvent.REQUEST.name(), "2022-07-27");
@@ -365,7 +394,8 @@ public class CouponAcceptanceTest extends AcceptanceTest {
         void 로그인된_사용자는_보낸_쿠폰에_대해_사용_대기_상태이면_사용_완료를_할_수_있다() {
             회원가입_또는_로그인에_성공한다(MemberResponse.of(JEONG), WorkspaceResponse.of(WORKSPACE));
             회원가입_또는_로그인에_성공한다(MemberResponse.of(LEO), WorkspaceResponse.of(WORKSPACE));
-            String jeongAccessToken = 회원가입_또는_로그인에_성공한다(MemberResponse.of(JEONG), WorkspaceResponse.of(WORKSPACE)).getAccessToken();
+            String jeongAccessToken = 회원가입_또는_로그인에_성공한다(MemberResponse.of(JEONG),
+                WorkspaceResponse.of(WORKSPACE)).getAccessToken();
             쿠폰_발급에_성공한다(jeongAccessToken, List.of(LEO));
 
             ExtractableResponse<Response> response = 쿠폰_상태_변경을_요청한다(jeongAccessToken, 1L,
@@ -378,8 +408,10 @@ public class CouponAcceptanceTest extends AcceptanceTest {
         void 로그인된_사용자는_보낸_쿠폰에_대해_사용_요청_상태이면_사용_완료를_할_수_있다() {
             회원가입_또는_로그인에_성공한다(MemberResponse.of(JEONG), WorkspaceResponse.of(WORKSPACE));
             회원가입_또는_로그인에_성공한다(MemberResponse.of(LEO), WorkspaceResponse.of(WORKSPACE));
-            String jeongAccessToken = 회원가입_또는_로그인에_성공한다(MemberResponse.of(JEONG), WorkspaceResponse.of(WORKSPACE)).getAccessToken();
-            String leoAccessToken = 회원가입_또는_로그인에_성공한다(MemberResponse.of(LEO), WorkspaceResponse.of(WORKSPACE)).getAccessToken();
+            String jeongAccessToken = 회원가입_또는_로그인에_성공한다(MemberResponse.of(JEONG),
+                WorkspaceResponse.of(WORKSPACE)).getAccessToken();
+            String leoAccessToken = 회원가입_또는_로그인에_성공한다(MemberResponse.of(LEO),
+                WorkspaceResponse.of(WORKSPACE)).getAccessToken();
             쿠폰_발급에_성공한다(jeongAccessToken, List.of(LEO));
 
             쿠폰_사용을_요청한다(leoAccessToken, 1L, CouponEvent.REQUEST.name(), "2022-07-27");
@@ -393,8 +425,10 @@ public class CouponAcceptanceTest extends AcceptanceTest {
         void 로그인된_사용자는_보낸_쿠폰에_대해_사용_수락_상태이면_사용_완료를_할_수_있다() {
             회원가입_또는_로그인에_성공한다(MemberResponse.of(JEONG), WorkspaceResponse.of(WORKSPACE));
             회원가입_또는_로그인에_성공한다(MemberResponse.of(LEO), WorkspaceResponse.of(WORKSPACE));
-            String jeongAccessToken = 회원가입_또는_로그인에_성공한다(MemberResponse.of(JEONG), WorkspaceResponse.of(WORKSPACE)).getAccessToken();
-            String leoAccessToken = 회원가입_또는_로그인에_성공한다(MemberResponse.of(LEO), WorkspaceResponse.of(WORKSPACE)).getAccessToken();
+            String jeongAccessToken = 회원가입_또는_로그인에_성공한다(MemberResponse.of(JEONG),
+                WorkspaceResponse.of(WORKSPACE)).getAccessToken();
+            String leoAccessToken = 회원가입_또는_로그인에_성공한다(MemberResponse.of(LEO),
+                WorkspaceResponse.of(WORKSPACE)).getAccessToken();
             쿠폰_발급에_성공한다(jeongAccessToken, List.of(LEO));
 
             쿠폰_사용을_요청한다(leoAccessToken, 1L, CouponEvent.REQUEST.name(), "2022-07-27");
@@ -409,8 +443,10 @@ public class CouponAcceptanceTest extends AcceptanceTest {
         void 보낸_쿠폰에_대해_사용_완료_상태이면_사용_완료를_할_수_없다() {
             회원가입_또는_로그인에_성공한다(MemberResponse.of(JEONG), WorkspaceResponse.of(WORKSPACE));
             회원가입_또는_로그인에_성공한다(MemberResponse.of(LEO), WorkspaceResponse.of(WORKSPACE));
-            String jeongAccessToken = 회원가입_또는_로그인에_성공한다(MemberResponse.of(JEONG), WorkspaceResponse.of(WORKSPACE)).getAccessToken();
-            String leoAccessToken = 회원가입_또는_로그인에_성공한다(MemberResponse.of(LEO), WorkspaceResponse.of(WORKSPACE)).getAccessToken();
+            String jeongAccessToken = 회원가입_또는_로그인에_성공한다(MemberResponse.of(JEONG),
+                WorkspaceResponse.of(WORKSPACE)).getAccessToken();
+            String leoAccessToken = 회원가입_또는_로그인에_성공한다(MemberResponse.of(LEO),
+                WorkspaceResponse.of(WORKSPACE)).getAccessToken();
             쿠폰_발급에_성공한다(jeongAccessToken, List.of(LEO));
 
             쿠폰_사용을_요청한다(leoAccessToken, 1L, CouponEvent.REQUEST.name(), "2022-07-27");

--- a/backend/src/test/java/com/woowacourse/kkogkkog/acceptance/MemberAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/acceptance/MemberAcceptanceTest.java
@@ -115,7 +115,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
 
     @Test
     void 본인의_닉네임을_수정할_수_있다() {
-        String newNickname = "새로운_닉네임";
+        String newNickname = "새로운닉네임";
         String rookieAccessToken = 회원가입_또는_로그인에_성공한다(MemberResponse.of(ROOKIE),
             WorkspaceResponse.of(WORKSPACE)).getAccessToken();
 

--- a/backend/src/test/java/com/woowacourse/kkogkkog/acceptance/MemberAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/acceptance/MemberAcceptanceTest.java
@@ -40,16 +40,16 @@ public class MemberAcceptanceTest extends AcceptanceTest {
         assertAll(
             () -> assertThat(extract.statusCode()).isEqualTo(HttpStatus.OK.value()),
             () -> assertThat(membersResponse.getData()).hasSize(2),
-            () -> assertThat(membersResponse.getData()).usingRecursiveComparison().isEqualTo(
-                List.of(
-                    MemberResponse.of(new Member(1L, "URookie",
-                        new Workspace(1L, "T03LX3C5540", "workspace_name", "ACCESS_TOKEN"),
-                        "루키", "rookie@gmail.com", "image")),
-                    MemberResponse.of(new Member(2L, "UArthur",
-                        new Workspace(1L, "T03LX3C5540", "workspace_name", "ACCESS_TOKEN"),
-                        "아서", "arthur@gmail.com", "image"))
-                )
-            ));
+            () -> assertThat(membersResponse.getData()).usingRecursiveComparison()
+                .ignoringFields("nickname").isEqualTo(List.of(
+                        MemberResponse.of(new Member(1L, "URookie",
+                            new Workspace(1L, "T03LX3C5540", "workspace_name", "ACCESS_TOKEN"),
+                            "익명1234", "rookie@gmail.com", "image")),
+                        MemberResponse.of(new Member(2L, "UArthur",
+                            new Workspace(1L, "T03LX3C5540", "workspace_name", "ACCESS_TOKEN"),
+                            "익명4321", "arthur@gmail.com", "image"))
+                    )
+                ));
     }
 
     @Test
@@ -63,9 +63,9 @@ public class MemberAcceptanceTest extends AcceptanceTest {
 
         assertAll(
             () -> assertThat(extract.statusCode()).isEqualTo(HttpStatus.OK.value()),
-            () -> assertThat(memberResponse).usingRecursiveComparison().isEqualTo(
-                new MyProfileResponse(1L, "URookie", "T03LX3C5540", "workspace_name",
-                    "루키", "rookie@gmail.com", "image", 0L))
+            () -> assertThat(memberResponse).usingRecursiveComparison().ignoringFields("nickname")
+                .isEqualTo(new MyProfileResponse(1L, "URookie", "T03LX3C5540", "workspace_name",
+                        "익명1234", "rookie@gmail.com", "image", 0L))
         );
     }
 

--- a/backend/src/test/java/com/woowacourse/kkogkkog/application/MemberServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/application/MemberServiceTest.java
@@ -55,7 +55,7 @@ class MemberServiceTest extends ServiceTest {
         void success_save() {
             SlackUserInfo slackUserInfo = new SlackUserInfo("URookie", null, null, "루키",
                 "rookie@gmail.com", "image");
-            MemberCreateResponse memberCreateResponse = memberService.saveOrFind(slackUserInfo,
+            MemberCreateResponse memberCreateResponse = memberService.saveOrUpdate(slackUserInfo,
                 WORKSPACE);
 
             assertAll(
@@ -70,8 +70,8 @@ class MemberServiceTest extends ServiceTest {
             SlackUserInfo slackUserInfo = new SlackUserInfo("URookie", null, null, "루키",
                 "rookie@gmail.com", "image");
 
-            memberService.saveOrFind(slackUserInfo, WORKSPACE);
-            MemberCreateResponse memberCreateResponse = memberService.saveOrFind(slackUserInfo,
+            memberService.saveOrUpdate(slackUserInfo, WORKSPACE);
+            MemberCreateResponse memberCreateResponse = memberService.saveOrUpdate(slackUserInfo,
                 WORKSPACE);
 
             assertAll(
@@ -90,7 +90,7 @@ class MemberServiceTest extends ServiceTest {
         void success() {
             SlackUserInfo slackUserInfo = new SlackUserInfo("URookie", null, null, "루키",
                 "rookie@gmail.com", "image");
-            Long memberId = memberService.saveOrFind(slackUserInfo, WORKSPACE).getId();
+            Long memberId = memberService.saveOrUpdate(slackUserInfo, WORKSPACE).getId();
 
             MyProfileResponse memberResponse = memberService.findById(memberId);
 
@@ -120,8 +120,8 @@ class MemberServiceTest extends ServiceTest {
                 "rookie@gmail.com", "image");
             SlackUserInfo arthurUserInfo = new SlackUserInfo("UArthur", null, null, "아서",
                 "arthur@gmail.com", "image");
-            memberService.saveOrFind(rookieUserInfo, WORKSPACE);
-            memberService.saveOrFind(arthurUserInfo, WORKSPACE);
+            memberService.saveOrUpdate(rookieUserInfo, WORKSPACE);
+            memberService.saveOrUpdate(arthurUserInfo, WORKSPACE);
 
             List<MemberResponse> membersResponse = memberService.findAll();
 
@@ -140,9 +140,9 @@ class MemberServiceTest extends ServiceTest {
                 "rookie@gmail.com", "image");
             SlackUserInfo arthurUserInfo = new SlackUserInfo("UArthur", null, null, "아서",
                 "arthur@gmail.com", "image");
-            MemberCreateResponse rookieCreateResponse = memberService.saveOrFind(rookieUserInfo,
+            MemberCreateResponse rookieCreateResponse = memberService.saveOrUpdate(rookieUserInfo,
                 WORKSPACE);
-            MemberCreateResponse arthurCreateResponse = memberService.saveOrFind(arthurUserInfo,
+            MemberCreateResponse arthurCreateResponse = memberService.saveOrUpdate(arthurUserInfo,
                 WORKSPACE);
 
             CouponSaveRequest couponSaveRequest = new CouponSaveRequest(
@@ -167,9 +167,9 @@ class MemberServiceTest extends ServiceTest {
                 "rookie@gmail.com", "image");
             SlackUserInfo arthurUserInfo = new SlackUserInfo("UArthur", null, null, "아서",
                 "arthur@gmail.com", "image");
-            MemberCreateResponse rookieCreateResponse = memberService.saveOrFind(rookieUserInfo,
+            MemberCreateResponse rookieCreateResponse = memberService.saveOrUpdate(rookieUserInfo,
                 WORKSPACE);
-            MemberCreateResponse arthurCreateResponse = memberService.saveOrFind(arthurUserInfo,
+            MemberCreateResponse arthurCreateResponse = memberService.saveOrUpdate(arthurUserInfo,
                 WORKSPACE);
             CouponSaveRequest couponSaveRequest = new CouponSaveRequest(
                 rookieCreateResponse.getId(), List.of(arthurCreateResponse.getId()), "한턱쏘는",
@@ -189,7 +189,7 @@ class MemberServiceTest extends ServiceTest {
         void success() {
             SlackUserInfo rookieUserInfo = new SlackUserInfo("URookie", null, null, "루키",
                 "rookie@gmail.com", "image");
-            Long memberId = memberService.saveOrFind(rookieUserInfo, WORKSPACE).getId();
+            Long memberId = memberService.saveOrUpdate(rookieUserInfo, WORKSPACE).getId();
 
             String expected = "새로운_닉네임";
             memberService.update(new MemberUpdateRequest(memberId, expected));

--- a/backend/src/test/java/com/woowacourse/kkogkkog/application/MemberServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/application/MemberServiceTest.java
@@ -94,8 +94,8 @@ class MemberServiceTest extends ServiceTest {
 
             MyProfileResponse memberResponse = memberService.findById(memberId);
 
-            assertThat(memberResponse).usingRecursiveComparison().ignoringFields("id").isEqualTo(
-                new MyProfileResponse(null, "URookie", "T03LX3C5540", "workspace_name", "루키",
+            assertThat(memberResponse).usingRecursiveComparison().ignoringFields("id", "nickname").isEqualTo(
+                new MyProfileResponse(null, "URookie", "T03LX3C5540", "workspace_name", "익명1234",
                     "rookie@gmail.com", "image", 0L));
         }
 
@@ -191,7 +191,7 @@ class MemberServiceTest extends ServiceTest {
                 "rookie@gmail.com", "image");
             Long memberId = memberService.saveOrUpdate(rookieUserInfo, WORKSPACE).getId();
 
-            String expected = "새로운_닉네임";
+            String expected = "새로운닉네임";
             memberService.update(new MemberUpdateRequest(memberId, expected));
             String actual = memberService.findById(memberId).getNickname();
 

--- a/backend/src/test/java/com/woowacourse/kkogkkog/domain/MemberTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/domain/MemberTest.java
@@ -24,7 +24,7 @@ public class MemberTest {
                 "jeong@gmail.com", "image");
 
             String actual = member.getNickname();
-            assertThat(actual.matches("^[가-힣a-zA-Z0-9]{2,6}$")).isTrue();
+            assertThat(actual).matches("^[가-힣a-zA-Z0-9]{2,6}$");
         }
     }
 
@@ -43,7 +43,7 @@ public class MemberTest {
 
         @Test
         @DisplayName("6글자를 초과한 닉네임으로 수정하려는 경우 예외를 발생시킨다.")
-        void fail_longerThatSix() {
+        void fail_longerThanSix() {
             assertThatThrownBy(() -> member.updateNickname("일곱글자닉네임"))
                 .isInstanceOf(InvalidRequestException.class);
         }

--- a/backend/src/test/java/com/woowacourse/kkogkkog/domain/MemberTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/domain/MemberTest.java
@@ -1,0 +1,27 @@
+package com.woowacourse.kkogkkog.domain;
+
+import static com.woowacourse.kkogkkog.fixture.WorkspaceFixture.WORKSPACE;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Coupon 클래스의")
+public class MemberTest {
+
+    @Nested
+    @DisplayName("ofRandomNickname 정적 팩토리 메서드는")
+    class OfRandomNickname {
+
+        @Test
+        @DisplayName("익명1234라는 형식의 닉네임을 지닌 회원을 생성한다.")
+        void success() {
+            Member member = Member.ofRandomNickname("UJeong", WORKSPACE,
+                "jeong@gmail.com", "image");
+
+            String actual = member.getNickname();
+            assertThat(actual.matches("^(?=.*[a-z0-9가-힣])[a-z0-9가-힣]{2,6}$")).isTrue();
+        }
+    }
+}

--- a/backend/src/test/java/com/woowacourse/kkogkkog/domain/MemberTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/domain/MemberTest.java
@@ -2,7 +2,10 @@ package com.woowacourse.kkogkkog.domain;
 
 import static com.woowacourse.kkogkkog.fixture.WorkspaceFixture.WORKSPACE;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.woowacourse.kkogkkog.exception.InvalidRequestException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -21,7 +24,35 @@ public class MemberTest {
                 "jeong@gmail.com", "image");
 
             String actual = member.getNickname();
-            assertThat(actual.matches("^(?=.*[a-z0-9가-힣])[a-z0-9가-힣]{2,6}$")).isTrue();
+            assertThat(actual.matches("^[가-힣a-zA-Z0-9]{2,6}$")).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("updateNickname 메서드는")
+    class UpdateNickname {
+
+        private final Member member = Member.ofRandomNickname("UJeong", WORKSPACE,
+            "jeong@gmail.com", "image");
+
+        @Test
+        @DisplayName("2~6글자 사이의 한글, 숫자, 영문자로 구성된 닉네임으로 수정할 수 있다.")
+        void success() {
+            assertThatNoException().isThrownBy(() -> member.updateNickname("가aB12"));
+        }
+
+        @Test
+        @DisplayName("6글자를 초과한 닉네임으로 수정하려는 경우 예외를 발생시킨다.")
+        void fail_longerThatSix() {
+            assertThatThrownBy(() -> member.updateNickname("일곱글자닉네임"))
+                .isInstanceOf(InvalidRequestException.class);
+        }
+
+        @Test
+        @DisplayName("공백이 포함된 닉네임으로 수정하려는 경우 예외를 발생시킨다.")
+        void fail_hasBlank() {
+            assertThatThrownBy(() -> member.updateNickname("정 진우"))
+                .isInstanceOf(InvalidRequestException.class);
         }
     }
 }


### PR DESCRIPTION
## 작업 내용

- 회원가입시 "익명1234"와 같은 형식의 닉네임을 임의로 생성하여 DB에 데이터를 저장하도록 수정.
  - FE에서는 신규 회원이 생성되었다는 정보를 통해 닉네임 수정 페이지로 즉시 리다이렉트시키므로, 일반적인 flow상 회원은 자신의 닉네임을 모름.

- 향후 닉네임 수정시, `^[가-힣a-zA-Z0-9]{2,6}$`라는 정규표현식에 부합하는지를 검증.
- 닉네임 수정 API에 빈 값이 들어오거나 null이 들어오면 예외 발생하도록 Bean Validation 추가.
- 닉네임 수정 API에 들어온 입력 값이 "   정    "와 같이 앞뒤에 공백이 포함된 경우, 공백 제거하여 저장하도록 DTO에서 trim

## 공유사항

Member 자체에 방어로직을 추가하는 경우, 테스트가 너무 깨져서 일단은 닉네임 수정에 대해서만 로직을 추가하였습니다.

Resolves #201
