### PR TITLE
feat: date input 크로스 브라우징 대응

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,6 +6,7 @@
     "start": "cross-env NODE_ENV=local webpack serve --mode=development",
     "start:dev": "cross-env NODE_ENV=development webpack serve  --mode=development",
     "build": " cross-env NODE_ENV=production webpack --progress --mode=production",
+    "build:local": " cross-env NODE_ENV=local webpack --progress --mode=development",
     "build:dev": "cross-env NODE_ENV=development webpack --progress --mode=development",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook"

--- a/frontend/src/@hooks/@common/useInput.ts
+++ b/frontend/src/@hooks/@common/useInput.ts
@@ -17,6 +17,7 @@ const useInput = (
       target: { value },
     } = e;
 
+    // @TODO: validation에 에러 메시지 추가
     if (validations?.some(validation => validation(value))) {
       return;
     }

--- a/frontend/src/@pages/coupon-list/coupon-detail/index.tsx
+++ b/frontend/src/@pages/coupon-list/coupon-detail/index.tsx
@@ -115,7 +115,10 @@ const CouponDetailPage = () => {
           </Position>
           <Styled.ProfileImage src={isSent ? receiver.imageUrl : sender.imageUrl} alt='' />
           <Styled.SummaryMessage>
-            {isSent ? `${receiver.nickname}님에게 ` : `${sender.nickname}님이 `}보낸&nbsp;
+            <strong>
+              {isSent ? `${receiver.nickname}님에게 ` : `${sender.nickname}님이 `}보낸
+            </strong>
+            &nbsp;
             {couponTypeTextMapper[couponType]} 쿠폰
           </Styled.SummaryMessage>
         </Styled.Top>

--- a/frontend/src/@pages/coupon-list/coupon-detail/index.tsx
+++ b/frontend/src/@pages/coupon-list/coupon-detail/index.tsx
@@ -1,4 +1,3 @@
-import { css } from '@emotion/react';
 import { Fragment } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 

--- a/frontend/src/@pages/coupon-list/coupon-detail/requesst/index.tsx
+++ b/frontend/src/@pages/coupon-list/coupon-detail/requesst/index.tsx
@@ -13,7 +13,7 @@ import NotFoundPage from '@/@pages/404';
 import { couponTypeTextMapper } from '@/constants/coupon';
 import { PATH } from '@/Router';
 import theme from '@/styles/theme';
-import { getToday } from '@/utils';
+import { getToday, isBeforeToday } from '@/utils';
 import { isOverMaxLength } from '@/utils/validations';
 
 import * as Styled from './style';
@@ -22,7 +22,7 @@ const CouponRequestPage = () => {
   const navigate = useNavigate();
   const { couponId } = useParams();
 
-  const [meetingDate, onChangeMeetingDate] = useInput('');
+  const [meetingDate, onChangeMeetingDate] = useInput('', [isBeforeToday]);
   const [message, onChangeMessage] = useInput('', [(value: string) => isOverMaxLength(value, 200)]);
 
   const { me } = useFetchMe();

--- a/frontend/src/@pages/coupon-list/coupon-detail/requesst/index.tsx
+++ b/frontend/src/@pages/coupon-list/coupon-detail/requesst/index.tsx
@@ -73,7 +73,10 @@ const CouponRequestPage = () => {
           </Position>
           <Styled.ProfileImage src={isSent ? receiver.imageUrl : sender.imageUrl} alt='' />
           <Styled.SummaryMessage>
-            {isSent ? `${receiver.nickname}님에게 ` : `${sender.nickname}님이 `}보낸&nbsp;
+            <strong>
+              {isSent ? `${receiver.nickname}님에게 ` : `${sender.nickname}님이 `}보낸
+            </strong>
+            &nbsp;
             {couponTypeTextMapper[couponType]} 쿠폰
           </Styled.SummaryMessage>
         </Styled.Top>

--- a/frontend/src/@pages/coupon-list/coupon-detail/requesst/index.tsx
+++ b/frontend/src/@pages/coupon-list/coupon-detail/requesst/index.tsx
@@ -1,4 +1,3 @@
-import { css } from '@emotion/react';
 import { useNavigate, useParams } from 'react-router-dom';
 
 import Button from '@/@components/@shared/Button';
@@ -85,6 +84,7 @@ const CouponRequestPage = () => {
             type='date'
             value={meetingDate}
             min={getToday()}
+            data-placeholder='날짜 선택'
             onChange={onChangeMeetingDate}
             required
           />

--- a/frontend/src/@pages/coupon-list/coupon-detail/requesst/style.tsx
+++ b/frontend/src/@pages/coupon-list/coupon-detail/requesst/style.tsx
@@ -67,6 +67,24 @@ export const DateInput = styled.input`
   padding: 10px;
   margin-bottom: 20px;
 
+  position: relative;
+
+  &[type='date']::-webkit-calendar-picker-indicator {
+    width: auto;
+    height: auto;
+
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 0;
+    bottom: 0;
+
+    background: transparent;
+    color: transparent;
+
+    cursor: pointer;
+  }
+
   ${({ theme }) => css`
     border: 1px solid ${theme.colors.grey_100};
   `}

--- a/frontend/src/@pages/coupon-list/coupon-detail/requesst/style.tsx
+++ b/frontend/src/@pages/coupon-list/coupon-detail/requesst/style.tsx
@@ -63,11 +63,27 @@ export const Description = styled.div`
 
 export const DateInput = styled.input`
   width: 100%;
+  background-color: transparent;
   border-radius: 10px;
   padding: 10px;
   margin-bottom: 20px;
 
+  text-align: left;
+
   position: relative;
+
+  &[type='date']::before {
+    content: attr(data-placeholder);
+    width: 100%;
+    ${({ theme }) => css`
+      color: ${theme.colors.grey_100};
+    `}
+  }
+
+  &[type='date']:focus::before,
+  &[type='date']:valid::before {
+    display: none;
+  }
 
   &[type='date']::-webkit-calendar-picker-indicator {
     width: auto;

--- a/frontend/src/@pages/coupon-list/coupon-detail/requesst/style.tsx
+++ b/frontend/src/@pages/coupon-list/coupon-detail/requesst/style.tsx
@@ -68,10 +68,6 @@ export const DateInput = styled.input`
   padding: 10px;
   margin-bottom: 20px;
 
-  text-align: left;
-
-  position: relative;
-
   &[type='date']::before {
     content: attr(data-placeholder);
     width: 100%;

--- a/frontend/src/@pages/coupon-list/coupon-detail/requesst/style.tsx
+++ b/frontend/src/@pages/coupon-list/coupon-detail/requesst/style.tsx
@@ -16,7 +16,7 @@ export const Top = styled.div`
   align-items: center;
 
   ${({ theme }) => css`
-    background-color: ${theme.colors.primary_200};
+    background-color: ${theme.colors.primary_100};
   `}
 `;
 
@@ -27,8 +27,11 @@ export const ProfileImage = styled.img`
 `;
 
 export const SummaryMessage = styled.span`
-  font-size: 14px;
-  font-weight: 600;
+  font-size: 16px;
+
+  strong {
+    font-weight: 600;
+  }
 `;
 
 export const Main = styled.main`
@@ -45,7 +48,6 @@ export const Main = styled.main`
 `;
 
 export const SectionTitle = styled.div`
-  font-weight: 600;
   margin-bottom: 30px;
   ${({ theme }) => css`
     color: ${theme.colors.drak_grey_200};
@@ -54,7 +56,6 @@ export const SectionTitle = styled.div`
 
 export const Description = styled.div`
   font-size: 14px;
-  font-weight: 600;
   margin-bottom: 16px;
   ${({ theme }) => css`
     color: ${theme.colors.drak_grey_200};

--- a/frontend/src/@pages/coupon-list/coupon-detail/style.tsx
+++ b/frontend/src/@pages/coupon-list/coupon-detail/style.tsx
@@ -27,8 +27,11 @@ export const ProfileImage = styled.img`
 `;
 
 export const SummaryMessage = styled.span`
-  font-size: 14px;
-  font-weight: 600;
+  font-size: 16px;
+
+  strong {
+    font-weight: 600;
+  }
 `;
 
 export const Main = styled.main`

--- a/frontend/src/styles/globalStyle.ts
+++ b/frontend/src/styles/globalStyle.ts
@@ -94,6 +94,12 @@ const globalStyle = css`
       transform: scaleY(1);
     }
   }
+
+  @media (max-width: 410px) {
+    input {
+      font-size: 16px !important;
+    }
+  }
 `;
 
 export default globalStyle;

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -25,3 +25,22 @@ export const generateDateText = (date: string | undefined, includeYear = false) 
 
   return dateText;
 };
+
+// 2022-08-15 형식의 텍스트가 들어옴.
+// @TODO: string 타입 구체적으로 좁히기
+export const isBeforeToday = (date: string) => {
+  const today = getToday();
+
+  const [todayYear, todayMonth, todayDay] = today.split('-');
+  const [year, month, day] = date.split('-');
+
+  if (todayYear > year) {
+    return true;
+  } else if (todayMonth > month) {
+    return true;
+  } else if (todayDay > day) {
+    return true;
+  }
+
+  return false;
+};


### PR DESCRIPTION
## 작업 내용

- input date를 클릭하면 무조건 calandar 가 뜨도록
- 모든 input 글자 16 px로 맞추어서 zoom 안되도록 하는 것
- input date 오늘 이전 날짜 선택하지 못 하도록 validation 추가 (사파리에서 min 을 지원하지 않기 때문)

## 공유사항

- build:local script 명령어 추가

Resolves #183
