### PR TITLE
hotfix: 깨지는 RepositoryTest 수정

### DIFF
--- a/backend/src/main/java/com/woowacourse/kkogkkog/KkogKkogApplication.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/KkogKkogApplication.java
@@ -2,10 +2,8 @@ package com.woowacourse.kkogkkog;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
-@EnableJpaAuditing
 public class KkogKkogApplication {
 
     public static void main(String[] args) {

--- a/backend/src/main/java/com/woowacourse/kkogkkog/config/DatabaseConfig.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/config/DatabaseConfig.java
@@ -1,0 +1,9 @@
+package com.woowacourse.kkogkkog.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class DatabaseConfig {
+}

--- a/backend/src/test/java/com/woowacourse/kkogkkog/common/annotaion/RepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/common/annotaion/RepositoryTest.java
@@ -1,15 +1,18 @@
 package com.woowacourse.kkogkkog.common.annotaion;
 
+import com.woowacourse.kkogkkog.config.DatabaseConfig;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
 
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import(DatabaseConfig.class)
 public @interface RepositoryTest {
 }

--- a/backend/src/test/java/com/woowacourse/kkogkkog/common/annotaion/RepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/common/annotaion/RepositoryTest.java
@@ -1,10 +1,13 @@
 package com.woowacourse.kkogkkog.common.annotaion;
 
 import com.woowacourse.kkogkkog.config.DatabaseConfig;
+import com.woowacourse.kkogkkog.support.DataClearExtension;
+import com.woowacourse.kkogkkog.support.DatabaseCleaner;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
@@ -13,6 +16,7 @@ import org.springframework.context.annotation.Import;
 @Retention(RetentionPolicy.RUNTIME)
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@Import(DatabaseConfig.class)
+@Import({DatabaseConfig.class, DatabaseCleaner.class})
+@ExtendWith(DataClearExtension.class)
 public @interface RepositoryTest {
 }

--- a/backend/src/test/java/com/woowacourse/kkogkkog/core/coupon/acceptance/CouponAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/core/coupon/acceptance/CouponAcceptanceTest.java
@@ -20,8 +20,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 
 @SuppressWarnings("NonAsciiCharacters")
-public
-class CouponAcceptanceTest extends AcceptanceTest {
+public class CouponAcceptanceTest extends AcceptanceTest {
 
     @Test
     void 쿠폰_생성을_할_수_있다() {

--- a/backend/src/test/java/com/woowacourse/kkogkkog/core/coupon/domain/query/CouponQueryRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/core/coupon/domain/query/CouponQueryRepositoryTest.java
@@ -4,6 +4,7 @@ import static com.woowacourse.kkogkkog.common.fixture.domain.CouponFixture.COFFE
 import static com.woowacourse.kkogkkog.common.fixture.domain.MemberFixture.RECEIVER;
 import static com.woowacourse.kkogkkog.common.fixture.domain.MemberFixture.SENDER;
 import static com.woowacourse.kkogkkog.common.fixture.domain.ReservationFixture.RESERVE_SAVE;
+import static com.woowacourse.kkogkkog.fixture.WorkspaceFixture.KKOGKKOG;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.woowacourse.kkogkkog.common.annotaion.RepositoryTest;
@@ -13,7 +14,9 @@ import com.woowacourse.kkogkkog.coupon.domain.query.CouponQueryRepository;
 import com.woowacourse.kkogkkog.coupon.domain.query.CouponReservationData;
 import com.woowacourse.kkogkkog.coupon.domain.repository.CouponRepository;
 import com.woowacourse.kkogkkog.domain.Member;
+import com.woowacourse.kkogkkog.domain.Workspace;
 import com.woowacourse.kkogkkog.domain.repository.MemberRepository;
+import com.woowacourse.kkogkkog.domain.repository.WorkspaceRepository;
 import com.woowacourse.kkogkkog.reservation.domain.Reservation;
 import com.woowacourse.kkogkkog.reservation.domain.repository.ReservationRepository;
 import java.time.LocalDateTime;
@@ -30,6 +33,8 @@ class CouponQueryRepositoryTest {
     @Autowired
     private MemberRepository memberRepository;
     @Autowired
+    private WorkspaceRepository workspaceRepository;
+    @Autowired
     private CouponRepository couponRepository;
     @Autowired
     private ReservationRepository reservationRepository;
@@ -44,12 +49,11 @@ class CouponQueryRepositoryTest {
         private Member receiver;
         private Coupon coupon1;
 
-        private Reservation reservation;
-
         @BeforeEach
         void setUp() {
-            sender = memberRepository.save(SENDER.getMember());
-            receiver = memberRepository.save(RECEIVER.getMember());
+            Workspace workspace = workspaceRepository.save(KKOGKKOG.getWorkspace());
+            sender = memberRepository.save(SENDER.getMember(workspace));
+            receiver = memberRepository.save(RECEIVER.getMember(workspace));
             coupon1 = couponRepository.save(COFFEE.getCoupon(sender, receiver));
             couponRepository.save(COFFEE.getCoupon(sender, receiver));
             couponRepository.save(COFFEE.getCoupon(sender, receiver));

--- a/backend/src/test/java/com/woowacourse/kkogkkog/support/DataClearExtension.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/support/DataClearExtension.java
@@ -7,13 +7,13 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 public class DataClearExtension implements BeforeEachCallback {
 
     @Override
-    public void beforeEach(ExtensionContext context) throws Exception {
+    public void beforeEach(ExtensionContext context) {
         DatabaseCleaner databaseCleaner = getDatabaseCleaner(context);
         databaseCleaner.execute();
     }
 
     private DatabaseCleaner getDatabaseCleaner(final ExtensionContext extensionContext) {
-        return (DatabaseCleaner) SpringExtension.getApplicationContext(extensionContext)
-            .getBean("databaseCleaner");
+        return SpringExtension.getApplicationContext(extensionContext)
+            .getBean(DatabaseCleaner.class);
     }
 }


### PR DESCRIPTION
## 작업 내용

- @RepositoryTest에서 DB 초기화하도록 설정
- @RepsitoryTest에서 DatabaseCleaner 빈을 직접 주입했을 때 접근할 수 있도록 DataClearExtension의 빈 가져오는 로직 수정
- @RepsitoryTest에서 SpringApplication 전체를 실행하지 않아도 @EnableJpaAuditing 설정되도록 별도의 DatabaseConfig 구현하여 주입하도록 수정. (prod에서는 @Configuration 설정하여 알아서 ComponentScan 대상 되도록 설정)
- 영속성 컨텍스트에 Workspace를 저장하고 Member에 연관관계로 설정해야 하는 부분 수정

## 공유사항

현재 develop 브랜치 깨지고 있는 상황이기는 한데 수정한 부분이 많은 것 같아서 별도의 PR로 만들었습니다.

Resolves #219
