### PR TITLE
refactor: 필요없는 SlackClient redirect uri 삭제

### DIFF
--- a/backend/src/main/java/com/woowacourse/kkogkkog/infrastructure/SlackClient.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/infrastructure/SlackClient.java
@@ -25,13 +25,9 @@ public class SlackClient {
     private static final String BOT_TOKEN_URI = "https://slack.com/api/oauth.v2.access";
     private static final String MESSAGE_URI = "https://slack.com/api/chat.postMessage";
 
-    private static final String LOGIN_REDIRECT_URL = "https://kkogkkog.com/login/redirect";
-    private static final String BOT_TOKEN_REDIRECT_URL = "https://kkogkkog.com/download/redirect";
-
     private static final String CODE_PARAMETER = "code";
     private static final String CLIENT_ID_PARAMETER = "client_id";
     private static final String SECRET_ID_PARAMETER = "client_secret";
-    private static final String REDIRECT_URI_PARAMETER = "redirect_uri";
     private static final String USER_ID_PARAMETER = "channel";
     private static final String MESSAGE_PARAMETER = "text";
     private static final ParameterizedTypeReference<Map<String, Object>> PARAMETERIZED_TYPE_REFERENCE = new ParameterizedTypeReference<>() {
@@ -74,7 +70,7 @@ public class SlackClient {
     private String requestAccessToken(String code) {
         Map<String, Object> responseBody = oAuthLoginClient
             .post()
-            .uri(uriBuilder -> toRequestTokenUri(uriBuilder, code, LOGIN_REDIRECT_URL))
+            .uri(uriBuilder -> toRequestTokenUri(uriBuilder, code))
             .headers(this::setHeaders)
             .retrieve()
             .bodyToMono(PARAMETERIZED_TYPE_REFERENCE)
@@ -105,7 +101,7 @@ public class SlackClient {
     public WorkspaceResponse requestBotAccessToken(String code) {
         BotTokenResponse botTokenResponse = botTokenClient
             .post()
-            .uri(uriBuilder -> toRequestTokenUri(uriBuilder, code, BOT_TOKEN_REDIRECT_URL))
+            .uri(uriBuilder -> toRequestTokenUri(uriBuilder, code))
             .headers(this::setHeaders)
             .retrieve()
             .bodyToMono(BotTokenResponse.class)
@@ -142,12 +138,11 @@ public class SlackClient {
             .build();
     }
 
-    private URI toRequestTokenUri(UriBuilder uriBuilder, String code, String redirectUri) {
+    private URI toRequestTokenUri(UriBuilder uriBuilder, String code) {
         return uriBuilder
             .queryParam(CODE_PARAMETER, code)
             .queryParam(CLIENT_ID_PARAMETER, clientId)
             .queryParam(SECRET_ID_PARAMETER, secretId)
-            .queryParam(REDIRECT_URI_PARAMETER, redirectUri)
             .build();
     }
 


### PR DESCRIPTION
## 작업 내용

- 엑세스 토큰 요청시 사용하는 SlackClient의 리다이렉트 uri를 삭제한다.

Resolves #227
