### PR TITLE
hotfix: created_time으로 필드명 통일

### DIFF
--- a/backend/src/main/java/com/woowacourse/kkogkkog/application/MemberService.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/application/MemberService.java
@@ -80,7 +80,7 @@ public class MemberService {
         Member findMember = memberRepository.findById(memberId)
             .orElseThrow(MemberNotFoundException::new);
 
-        return memberHistoryRepository.findAllByHostMemberOrderByCreatedAtDesc(findMember).stream()
+        return memberHistoryRepository.findAllByHostMemberOrderByCreatedTimeDesc(findMember).stream()
             .map(MemberHistoryResponse::of)
             .collect(toList());
     }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/application/dto/MemberHistoryResponse.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/application/dto/MemberHistoryResponse.java
@@ -54,7 +54,7 @@ public class MemberHistoryResponse {
             memberHistory.getCouponEvent().name(),
             memberHistory.getMeetingDate(),
             memberHistory.getIsRead(),
-            memberHistory.getCreatedAt()
+            memberHistory.getCreatedTime()
         );
     }
 }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/coupon/application/CouponService.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/coupon/application/CouponService.java
@@ -102,7 +102,7 @@ public class CouponService {
     @Transactional(readOnly = true)
     public CouponDetailResponse find(Long couponId) {
         CouponDetailData couponDetail = couponQueryRepository.findCouponWithMeetingDate(couponId);
-        List<MemberHistory> memberHistories = memberHistoryRepository.findAllByCouponIdOrderByCreatedAtDesc(couponId);
+        List<MemberHistory> memberHistories = memberHistoryRepository.findAllByCouponIdOrderByCreatedTimeDesc(couponId);
         return CouponDetailResponse.of(couponDetail, memberHistories);
     }
 }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/coupon/application/dto/CouponHistoryResponse.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/coupon/application/dto/CouponHistoryResponse.java
@@ -43,7 +43,7 @@ public class CouponHistoryResponse {
             memberHistory.getCouponEvent(),
             memberHistory.getMeetingDate(),
             memberHistory.getMessage(),
-            memberHistory.getCreatedAt()
+            memberHistory.getCreatedTime()
         );
     }
 

--- a/backend/src/main/java/com/woowacourse/kkogkkog/coupon/domain/Coupon.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/coupon/domain/Coupon.java
@@ -1,11 +1,10 @@
 package com.woowacourse.kkogkkog.coupon.domain;
 
-import com.woowacourse.kkogkkog.domain.Member;
 import com.woowacourse.kkogkkog.coupon.exception.SameSenderReceiverException;
-import java.time.LocalDateTime;
+import com.woowacourse.kkogkkog.domain.BaseEntity;
+import com.woowacourse.kkogkkog.domain.Member;
 import javax.persistence.Column;
 import javax.persistence.Entity;
-import javax.persistence.EntityListeners;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.FetchType;
@@ -17,16 +16,12 @@ import javax.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 
-@EntityListeners(AuditingEntityListener.class)
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class Coupon {
+public class Coupon extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -53,12 +48,6 @@ public class Coupon {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private CouponStatus couponStatus;
-
-    @CreatedDate
-    private LocalDateTime createdTime;
-
-    @LastModifiedDate
-    private LocalDateTime updatedTime;
 
     public Coupon(Member sender, Member receiver, String hashtag, String description,
                   CouponType couponType, CouponStatus couponStatus) {

--- a/backend/src/main/java/com/woowacourse/kkogkkog/domain/BaseEntity.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/domain/BaseEntity.java
@@ -1,6 +1,7 @@
 package com.woowacourse.kkogkkog.domain;
 
 import java.time.LocalDateTime;
+import javax.persistence.Column;
 import javax.persistence.EntityListeners;
 import javax.persistence.MappedSuperclass;
 import lombok.Getter;
@@ -14,8 +15,10 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 public abstract class BaseEntity {
 
     @CreatedDate
+    @Column(nullable = false)
     private LocalDateTime createdTime;
 
     @LastModifiedDate
+    @Column(nullable = false)
     private LocalDateTime updatedTime;
 }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/domain/BaseEntity.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/domain/BaseEntity.java
@@ -5,6 +5,7 @@ import javax.persistence.EntityListeners;
 import javax.persistence.MappedSuperclass;
 import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @EntityListeners(AuditingEntityListener.class)
@@ -13,5 +14,8 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 public abstract class BaseEntity {
 
     @CreatedDate
-    protected LocalDateTime createdAt;
+    private LocalDateTime createdTime;
+
+    @LastModifiedDate
+    private LocalDateTime updatedTime;
 }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/domain/MemberHistory.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/domain/MemberHistory.java
@@ -4,6 +4,7 @@ import com.woowacourse.kkogkkog.coupon.domain.CouponEvent;
 import com.woowacourse.kkogkkog.coupon.domain.CouponType;
 import java.time.LocalDateTime;
 import javax.persistence.Entity;
+import javax.persistence.EntityListeners;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.FetchType;
@@ -15,11 +16,14 @@ import javax.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+@EntityListeners(AuditingEntityListener.class)
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class MemberHistory extends BaseEntity {
+public class MemberHistory {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -46,6 +50,9 @@ public class MemberHistory extends BaseEntity {
     private String message;
 
     private Boolean isRead = false;
+
+    @CreatedDate
+    private LocalDateTime createdTime;
 
     public MemberHistory(Long id, Member hostMember, Member targetMember, Long couponId,
                          CouponType couponType, CouponEvent couponEvent, LocalDateTime meetingDate,

--- a/backend/src/main/java/com/woowacourse/kkogkkog/domain/MemberHistory.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/domain/MemberHistory.java
@@ -3,6 +3,7 @@ package com.woowacourse.kkogkkog.domain;
 import com.woowacourse.kkogkkog.coupon.domain.CouponEvent;
 import com.woowacourse.kkogkkog.coupon.domain.CouponType;
 import java.time.LocalDateTime;
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EntityListeners;
 import javax.persistence.EnumType;
@@ -52,6 +53,7 @@ public class MemberHistory {
     private Boolean isRead = false;
 
     @CreatedDate
+    @Column(nullable = false)
     private LocalDateTime createdTime;
 
     public MemberHistory(Long id, Member hostMember, Member targetMember, Long couponId,

--- a/backend/src/main/java/com/woowacourse/kkogkkog/domain/repository/MemberHistoryRepository.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/domain/repository/MemberHistoryRepository.java
@@ -7,9 +7,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberHistoryRepository extends JpaRepository<MemberHistory, Long> {
 
-    List<MemberHistory> findAllByHostMemberOrderByCreatedAtDesc(Member member);
+    List<MemberHistory> findAllByHostMemberOrderByCreatedTimeDesc(Member member);
 
     long countByHostMemberAndIsReadFalse(Member member);
 
-    List<MemberHistory> findAllByCouponIdOrderByCreatedAtDesc(Long couponId);
+    List<MemberHistory> findAllByCouponIdOrderByCreatedTimeDesc(Long couponId);
 }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/reservation/domain/Reservation.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/reservation/domain/Reservation.java
@@ -2,11 +2,11 @@ package com.woowacourse.kkogkkog.reservation.domain;
 
 import com.woowacourse.kkogkkog.coupon.domain.Coupon;
 import com.woowacourse.kkogkkog.coupon.domain.CouponEvent;
+import com.woowacourse.kkogkkog.domain.BaseEntity;
 import com.woowacourse.kkogkkog.domain.Member;
 import java.time.LocalDateTime;
 import javax.persistence.Column;
 import javax.persistence.Entity;
-import javax.persistence.EntityListeners;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.FetchType;
@@ -18,15 +18,11 @@ import javax.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-@EntityListeners(AuditingEntityListener.class)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-public class Reservation {
+public class Reservation extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -43,12 +39,6 @@ public class Reservation {
 
     @Enumerated(EnumType.STRING)
     private ReservationStatus reservationStatus;
-
-    @CreatedDate
-    private LocalDateTime createdTime;
-
-    @LastModifiedDate
-    private LocalDateTime updatedTime;
 
     public Reservation(Long id,
                        Coupon coupon,

--- a/backend/src/test/java/com/woowacourse/kkogkkog/core/coupon/application/CouponServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/core/coupon/application/CouponServiceTest.java
@@ -88,7 +88,7 @@ class CouponServiceTest {
                 CouponDtoFixture.COFFEE_쿠폰_저장_요청(sender.getId(), List.of(receiver1.getId())));
 
             Long couponId = response.get(0).getId();
-            List<MemberHistory> memberHistories = memberHistoryRepository.findAllByCouponIdOrderByCreatedAtDesc(
+            List<MemberHistory> memberHistories = memberHistoryRepository.findAllByCouponIdOrderByCreatedTimeDesc(
                 couponId);
             assertThat(memberHistories).hasSize(1);
         }

--- a/backend/src/test/java/com/woowacourse/kkogkkog/core/reservation/application/ReservationServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/core/reservation/application/ReservationServiceTest.java
@@ -90,7 +90,7 @@ class ReservationServiceTest {
 
             reservationService.save(reservationSaveRequest);
 
-            List<MemberHistory> memberHistories = memberHistoryRepository.findAllByCouponIdOrderByCreatedAtDesc(
+            List<MemberHistory> memberHistories = memberHistoryRepository.findAllByCouponIdOrderByCreatedTimeDesc(
                 coupon.getId());
             assertThat(memberHistories).hasSize(1);
         }
@@ -135,7 +135,7 @@ class ReservationServiceTest {
 
             reservationService.update(reservationUpdateRequest);
 
-            List<MemberHistory> memberHistories = memberHistoryRepository.findAllByCouponIdOrderByCreatedAtDesc(
+            List<MemberHistory> memberHistories = memberHistoryRepository.findAllByCouponIdOrderByCreatedTimeDesc(
                 coupon.getId());
             assertThat(memberHistories).hasSize(1);
         }


### PR DESCRIPTION
## 작업 내용

- MemberHistory의 createdAt을 created_time으로 통일
- createdTime과 updatedTime을 사용하는 도메인들의 경우 실수 예방을 위해 BaseEntity 상속받도록 수정

## 공유사항

- MemberHistory는 update될 일이 없어서 BaseEntity 상속받도록 설정하지 않았는데, 실수가 발생할 수 있는 구조가 아닌가 싶네요.