### PR TITLE
feat : 쿠폰이 ACCEPTED 상태일 때 CANCEL이 가능하도록 기능 추가

### DIFF
--- a/backend/src/main/java/com/woowacourse/kkogkkog/coupon/domain/CouponEvent.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/coupon/domain/CouponEvent.java
@@ -45,8 +45,8 @@ public enum CouponEvent {
     }
 
     private static void canCancel(boolean isSender, boolean isReceiver) {
-        if (!isReceiver) {
-            throw new ForbiddenException("쿠폰을 받은 사람만 사용 요청을 취소할 수 있습니다.");
+        if (!isSender && !isReceiver) {
+            throw new ForbiddenException("쿠폰을 보낸 사람과 받은 사람만 쿠폰 사용을 취소할 수 있습니다.");
         }
     }
 

--- a/backend/src/main/java/com/woowacourse/kkogkkog/coupon/domain/CouponStatus.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/coupon/domain/CouponStatus.java
@@ -37,7 +37,7 @@ public enum CouponStatus {
     }
 
     private CouponStatus handleCancel() {
-        if (this != REQUESTED) {
+        if (this != REQUESTED && this != ACCEPTED) {
             throw new InvalidRequestException("사용 요청을 취소할 수 없는 상태의 쿠폰입니다.");
         }
         return READY;

--- a/backend/src/test/java/com/woowacourse/kkogkkog/core/coupon/domain/CouponEventTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/core/coupon/domain/CouponEventTest.java
@@ -61,13 +61,12 @@ class CouponEventTest {
         }
 
         @Test
-        @DisplayName("보낸 사람이 요청을 할 경우, 예외를 발생시킨다.")
+        @DisplayName("보낸 사람이 요청을 할 경우, 성공적으로 요청을 보낼 수 있다.")
         void fail_senderCancel() {
             boolean isSender = true;
             boolean isReceiver = false;
 
-            assertThatThrownBy(() -> CANCEL.checkExecutable(isSender, isReceiver))
-                .isInstanceOf(ForbiddenException.class);
+            assertDoesNotThrow(() -> CANCEL.checkExecutable(isSender, isReceiver));
         }
     }
 

--- a/backend/src/test/java/com/woowacourse/kkogkkog/core/coupon/domain/CouponStatusTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/core/coupon/domain/CouponStatusTest.java
@@ -132,6 +132,16 @@ class CouponStatusTest {
     class accepted {
 
         @Test
+        @DisplayName("CANCEL 이벤트를 받으면, READY를 반환한다.")
+        void success_cancel() {
+            CouponStatus status = ACCEPTED;
+
+            CouponStatus actual = status.handle(CANCEL);
+
+            assertThat(actual).isEqualTo(READY);
+        }
+
+        @Test
         @DisplayName("FINISH 이벤트를 받으면, FINISHED를 반환한다.")
         void success_finish() {
             CouponStatus status = ACCEPTED;
@@ -147,15 +157,6 @@ class CouponStatusTest {
             CouponStatus status = ACCEPTED;
 
             assertThatThrownBy(() -> status.handle(REQUEST))
-                .isInstanceOf(InvalidRequestException.class);
-        }
-
-        @Test
-        @DisplayName("CANCEL 이벤트를 받으면, 예외를 발생시킨다.")
-        void fail_cancel() {
-            CouponStatus status = ACCEPTED;
-
-            assertThatThrownBy(() -> status.handle(CANCEL))
                 .isInstanceOf(InvalidRequestException.class);
         }
 

--- a/backend/src/test/java/com/woowacourse/kkogkkog/core/reservation/domain/ReservationStatusTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/core/reservation/domain/ReservationStatusTest.java
@@ -18,7 +18,7 @@ class ReservationStatusTest {
     class progress {
 
         @Test
-        @DisplayName("CANCEL 이벤트를 받으면, CANCEL을 반환한다.")
+        @DisplayName("CANCEL 이벤트를 받으면, CANCELED을 반환한다.")
         void success_cancel() {
             ReservationStatus status = ReservationStatus.IN_PROGRESS;
 
@@ -28,7 +28,7 @@ class ReservationStatusTest {
         }
 
         @Test
-        @DisplayName("DECLINE 이벤트를 받으면, CANCEL을 반환한다.")
+        @DisplayName("DECLINE 이벤트를 받으면, CANCELED을 반환한다.")
         void success_decline() {
             ReservationStatus status = ReservationStatus.IN_PROGRESS;
 
@@ -38,7 +38,7 @@ class ReservationStatusTest {
         }
 
         @Test
-        @DisplayName("ACCEPT 이벤트를 받으면, PROGRESS을 반환한다.")
+        @DisplayName("ACCEPT 이벤트를 받으면, IN_PROGRESS을 반환한다.")
         void fail_approve() {
             ReservationStatus status = ReservationStatus.IN_PROGRESS;
 


### PR DESCRIPTION
## 작업 내용

Accepted 상태에서 Cancel이 가능하도록 변경했습니다.

- CouponStatus 변경 사항
  - 기존 : Requested 일 경우 Cancel 가능
  - 변경 후 : Requested 혹은 Accepted 일 경우 Cancel 가능
- CouponEvent 변경 사항
  - 기존 : Receiver만 Cancel 가능
  - 변경 후 : Receiver 혹은 Sender 일 경우 Cancel 가능

- ReservationStatus는 변경 사항이 없었습니다.
  - IN_PROGRESS는 쿠폰의 REQUESTED, ACCEPTED 를 품고 있어서 원래 CANCEL이 가능했습니다.

## 공유사항

- ReservationStatus 와 CouponStatus가 동일한 역할을 하고 있습니다.
  - 추후 CouponStatus를 삭제하고 ReservationStatus를 활용하면, 현재 저희가 그리는 쿠폰 로직을 동일하게 수행할 수 있을 것 같습니다. 
- CouponEvent를 보낼 수 있는 권한 확인이 필요한지 고민해볼 필요가 있을 것 같습니다.
- refactor라고 생각했는데, issue가 feat으로 되어있어서 feat으로 올립니다.

Resolves #222 
