### PR TITLE
hotfix: 동작하는 profile에 따라 SlackClient에 다른 redirect url들 설정

### DIFF
--- a/backend/src/main/java/com/woowacourse/kkogkkog/infrastructure/SlackClient.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/infrastructure/SlackClient.java
@@ -55,7 +55,7 @@ public class SlackClient {
                        @Value(MESSAGE_URI) String messageUri,
                        Environment env,
                        WebClient webClient) {
-        String activeProfile = env.getActiveProfiles()[0];
+        String activeProfile = getActiveProfile(env);
         this.clientId = clientId;
         this.secretId = secretId;
         this.oAuthLoginClient = toWebClient(webClient, oAuthLoginUri);
@@ -71,6 +71,14 @@ public class SlackClient {
             .baseUrl(baseUrl)
             .defaultHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
             .build();
+    }
+
+    private String getActiveProfile( Environment env) {
+        String[] activeProfiles = env.getActiveProfiles();
+        if (activeProfiles.length > 0) {
+            return activeProfiles[0];
+        }
+        return "default";
     }
 
     private String toPublicDomain(String activeProfile) {

--- a/backend/src/test/java/com/woowacourse/kkogkkog/infrastructure/SlackClientTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/infrastructure/SlackClientTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.mock.env.MockEnvironment;
 import org.springframework.web.reactive.function.client.WebClient;
 
 class SlackClientTest {
@@ -137,10 +138,12 @@ class SlackClientTest {
     }
 
     private SlackClient buildMockSlackClient(MockWebServer mockWebServer) {
+        MockEnvironment env = new MockEnvironment();
+        env.setActiveProfiles("dev");
         String mockWebClientURI = String.format("http://%s:%s",
             mockWebServer.getHostName(), mockWebServer.getPort());
         return new SlackClient("clientId", "secretId", mockWebClientURI, mockWebClientURI,
-            mockWebClientURI, mockWebClientURI, WebClient.create());
+            mockWebClientURI, mockWebClientURI, env, WebClient.create());
     }
 
     private void setUpResponse(MockWebServer mockWebServer, String responseBody) {


### PR DESCRIPTION
## 작업 내용

- submodule 수정 없이 일단 내부적으로 수정
- 정상 동작 확인 이후에 yml에서 받아오도록 리팩토링