### PR TITLE
feat: Coupon UI 변경

### DIFF
--- a/frontend/src/@components/@shared/ListFilter/style.tsx
+++ b/frontend/src/@components/@shared/ListFilter/style.tsx
@@ -8,22 +8,16 @@ export const Root = styled.div`
 
   width: 100%;
 
-  & > button {
-    margin: 5px;
-  }
-  & > button:first-of-type {
-    margin-left: 0;
-  }
-  & > button:last-of-type {
-    margin-right: 0;
-  }
+  gap: 10px;
 `;
 
 export const FilterButton = styled.button<{ isFocus?: boolean; horizontalScroll?: boolean }>`
-  max-width: 100px;
+  max-width: 120px;
+
   aspect-ratio: 1/1;
 
-  padding: 10px;
+  padding: 5px;
+
   flex: 1;
 
   border-radius: 20px;
@@ -36,6 +30,14 @@ export const FilterButton = styled.button<{ isFocus?: boolean; horizontalScroll?
     background-color: ${isFocus ? theme.colors.primary_400 : theme.colors.white_100};
     color: ${isFocus ? theme.colors.white_100 : theme.colors.grey_100};
   `}
+
+  @media (max-width: 400px) {
+    font-size: 16px;
+  }
+
+  @media (max-width: 360px) {
+    font-size: 14px;
+  }
 `;
 
 export const ExtendedPlaceholder = css`

--- a/frontend/src/@components/@shared/Placeholder/index.tsx
+++ b/frontend/src/@components/@shared/Placeholder/index.tsx
@@ -5,7 +5,7 @@ import { CSSProperties } from 'react';
 type PlaceholderProps = Pick<CSSProperties, 'width' | 'height' | 'aspectRatio'>;
 
 const Placeholder = styled.div<PlaceholderProps>`
-  border-radius: 4px;
+  border-radius: 20px;
   background-image: linear-gradient(90deg, #e0e0e0 0px, #ededed 30px, #e0e0e0 60px);
   animation: refresh 2s infinite ease-out;
 

--- a/frontend/src/@components/coupon/AcceptedCouponList/index.tsx
+++ b/frontend/src/@components/coupon/AcceptedCouponList/index.tsx
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import Icon from '@/@components/@shared/Icon';
-import Position from '@/@components/@shared/Position';
+import Placeholder from '@/@components/@shared/Placeholder';
 import BigCouponItem from '@/@components/coupon/CouponItem/big';
 import VerticalCouponList from '@/@components/coupon/CouponList/vertical';
 import theme from '@/styles/theme';
@@ -32,61 +32,73 @@ const AcceptedCouponList = (props: AcceptedCouponListProps) => {
     navigate(`/coupon-list/${coupon.couponId}`);
   };
 
-  // const scrollContainer = useRef<HTMLDivElement>(null);
-
-  // const onClickRightArrow = () => {
-  //   const { current: element } = scrollContainer;
-
-  //   if (element) {
-  //     const { clientWidth, scrollWidth, offsetWidth, scrollLeft, clientLeft } = element;
-
-  //     element?.scroll({
-  //       left: scrollLeft + offsetWidth,
-  //       behavior: 'smooth',
-  //     });
-  //   }
-  // };
-
-  // const onClickLeftArrow = () => {
-  //   const { current: element } = scrollContainer;
-
-  //   if (element) {
-  //     const { clientWidth, scrollWidth, offsetWidth, scrollLeft } = element;
-
-  //     element?.scroll({ left: scrollLeft - offsetWidth, behavior: 'smooth' });
-  //   }
-  // };
+  if (Object.keys(acceptedCouponList).length === 0) {
+    return (
+      <Styled.NoneContentsContainer>
+        <Icon iconName='hand' size='36' color={theme.colors.primary_400} />
+        <h3>아직 승인된 약속이 존재하지 않아요!</h3>
+        <h4>약속을 기다리는 사람에게 신청해볼까요 ?</h4>
+      </Styled.NoneContentsContainer>
+    );
+  }
 
   return (
-    <Position>
-      <Styled.Root>
-        {Object.keys(acceptedCouponList).length === 0 ? (
-          <Styled.NoneContentsContainer>
-            <Icon iconName='hand' size='36' color={theme.colors.primary_400} />
-            <h3>아직 승인된 약속이 존재하지 않아요!</h3>
-            <h4>약속을 기다리는 사람에게 신청해볼까요 ?</h4>
-          </Styled.NoneContentsContainer>
-        ) : (
-          sortedKey.map(date => (
-            <Styled.DateContainer key={date}>
-              <Styled.DateTitle>{generateDateText(date)}</Styled.DateTitle>
-              <VerticalCouponList
-                CouponItem={BigCouponItem}
-                couponList={acceptedCouponList[date]}
-                onClickCouponItem={onClickCouponItem}
-              />
-            </Styled.DateContainer>
-          ))
-        )}
-        {/* <Styled.LeftArrow onClick={onClickLeftArrow}>
-          <Icon iconName='arrow' color={theme.colors.primary_400} size='36' />
-        </Styled.LeftArrow>
-        <Styled.RightArrow onClick={onClickRightArrow}>
-          <Icon iconName='arrow' color={theme.colors.primary_400} size='36' />
-        </Styled.RightArrow> */}
-      </Styled.Root>
-    </Position>
+    <Styled.Root>
+      {sortedKey.map(date => (
+        <Styled.DateContainer key={date}>
+          <Styled.DateTitle>{generateDateText(date)}</Styled.DateTitle>
+          <VerticalCouponList
+            CouponItem={BigCouponItem}
+            couponList={acceptedCouponList[date]}
+            onClickCouponItem={onClickCouponItem}
+          />
+        </Styled.DateContainer>
+      ))}
+    </Styled.Root>
   );
 };
 
 export default AcceptedCouponList;
+
+AcceptedCouponList.Skeleton = function Skeleton() {
+  return (
+    <Styled.Root>
+      <Placeholder width='320px' height='320px'>
+        <BigCouponItem.Skeleton />
+        <BigCouponItem.Skeleton />
+        <BigCouponItem.Skeleton />
+      </Placeholder>
+    </Styled.Root>
+  );
+};
+
+// const scrollContainer = useRef<HTMLDivElement>(null);
+
+// const onClickRightArrow = () => {
+//   const { current: element } = scrollContainer;
+
+//   if (element) {
+//     const { clientWidth, scrollWidth, offsetWidth, scrollLeft, clientLeft } = element;
+
+//     element?.scroll({
+//       left: scrollLeft + offsetWidth,
+//       behavior: 'smooth',
+//     });
+//   }
+// };
+
+// const onClickLeftArrow = () => {
+//   const { current: element } = scrollContainer;
+
+//   if (element) {
+//     const { clientWidth, scrollWidth, offsetWidth, scrollLeft } = element;
+
+//     element?.scroll({ left: scrollLeft - offsetWidth, behavior: 'smooth' });
+//   }
+// };
+/* <Styled.LeftArrow onClick={onClickLeftArrow}>
+          <Icon iconName='arrow' color={theme.colors.primary_400} size='36' />
+        </Styled.LeftArrow>
+        <Styled.RightArrow onClick={onClickRightArrow}>
+          <Icon iconName='arrow' color={theme.colors.primary_400} size='36' />
+        </Styled.RightArrow> */

--- a/frontend/src/@components/coupon/AcceptedCouponList/style.tsx
+++ b/frontend/src/@components/coupon/AcceptedCouponList/style.tsx
@@ -6,6 +6,8 @@ export const Root = styled.div`
 
   overflow-x: scroll;
   overflow-y: hidden;
+
+  gap: 15px;
 `;
 
 export const NoneContentsContainer = styled.div`
@@ -41,7 +43,7 @@ export const NoneContentsContainer = styled.div`
 `;
 
 export const DateContainer = styled.div`
-  width: 320px;
+  width: 350px;
   height: 320px;
 
   display: flex;
@@ -62,7 +64,7 @@ export const DateContainer = styled.div`
 `;
 
 export const DateTitle = styled.div`
-  font-size: 16px;
+  font-size: 18px;
   font-weight: 600;
 
   ${({ theme }) => css`

--- a/frontend/src/@components/coupon/AcceptedCouponList/style.tsx
+++ b/frontend/src/@components/coupon/AcceptedCouponList/style.tsx
@@ -17,7 +17,7 @@ export const NoneContentsContainer = styled.div`
   justify-content: center;
   align-items: center;
 
-  gap: 10px;
+  gap: 20px;
 
   & > h2 {
     font-size: 50px;
@@ -41,7 +41,7 @@ export const NoneContentsContainer = styled.div`
 `;
 
 export const DateContainer = styled.div`
-  width: 90%;
+  width: 320px;
   height: 320px;
 
   display: flex;
@@ -50,11 +50,11 @@ export const DateContainer = styled.div`
   gap: 10px;
 
   padding: 20px;
-  margin: 0 10px;
 
   border-radius: 20px;
 
   overflow-y: scroll;
+  overflow-x: hidden;
 
   ${({ theme }) => css`
     background-color: ${theme.colors.primary_100};

--- a/frontend/src/@components/coupon/CouponItem/big.style.tsx
+++ b/frontend/src/@components/coupon/CouponItem/big.style.tsx
@@ -5,8 +5,12 @@ import { COUPON_STATUS } from '@/types/client/coupon';
 
 export const Root = styled.div<{ hasCursor?: boolean }>`
   width: 100%;
-  max-width: 380px;
-  min-width: 125px;
+
+  max-width: 320px;
+  min-width: 280px;
+
+  max-height: 170px;
+  min-height: 120px;
 
   display: flex;
   justify-content: space-between;
@@ -14,8 +18,6 @@ export const Root = styled.div<{ hasCursor?: boolean }>`
   gap: 20px;
 
   border-radius: 20px;
-
-  aspect-ratio: 3/1;
 
   box-shadow: 0 0 20px rgba(0, 0, 0, 0.12);
 
@@ -71,11 +73,9 @@ export const Member = styled.p`
 `;
 
 export const TextContainer = styled.div`
-  overflow-x: scroll;
-
   flex: 1;
-  height: 100%;
 
+  height: 100%;
   white-space: nowrap;
 
   display: flex;
@@ -89,14 +89,6 @@ export const TextContainer = styled.div`
   ${({ theme }) => css`
     color: ${theme.colors.drak_grey_200};
   `}
-
-  @media (max-width: 400px) {
-    font-size: 16px;
-  }
-
-  @media (max-width: 360px) {
-    font-size: 14px;
-  }
 `;
 
 export const English = styled.span`
@@ -113,6 +105,7 @@ export const TypeText = styled.span`
 export const CouponPropertyContainer = styled.div`
   width: 30%;
   height: 100%;
+
   display: flex;
   flex-direction: column;
   justify-content: space-between;
@@ -132,7 +125,6 @@ export const ImageContainer = styled(CouponPropertyContainer)`
 export const ImageInner = styled.div`
   height: 58px;
   width: 58px;
-
   display: flex;
   justify-content: center;
   align-items: center;

--- a/frontend/src/@components/coupon/CouponItem/big.style.tsx
+++ b/frontend/src/@components/coupon/CouponItem/big.style.tsx
@@ -6,11 +6,10 @@ import { COUPON_STATUS } from '@/types/client/coupon';
 export const Root = styled.div<{ hasCursor?: boolean }>`
   width: 100%;
 
-  max-width: 320px;
+  max-width: 340px;
   min-width: 280px;
 
-  max-height: 170px;
-  min-height: 120px;
+  height: 120px;
 
   display: flex;
   justify-content: space-between;

--- a/frontend/src/@components/coupon/CouponItem/big.tsx
+++ b/frontend/src/@components/coupon/CouponItem/big.tsx
@@ -33,7 +33,7 @@ const BigCouponItem = (props: BigCouponItemProps) => {
   return (
     <Styled.Root className={className} hasCursor={!!onClick} onClick={onClick}>
       <Styled.CouponPropertyContainer>
-        <CouponStatus status={couponStatus} isSent={isSent} />
+        <CouponStatus status={couponStatus} meetingDate={meetingDate} isSent={isSent} />
 
         <Styled.ImageInner>
           <img src={thumbnail} alt='쿠폰' />

--- a/frontend/src/@components/coupon/CouponItem/big.tsx
+++ b/frontend/src/@components/coupon/CouponItem/big.tsx
@@ -26,8 +26,6 @@ const BigCouponItem = (props: BigCouponItemProps) => {
 
   const { me } = useFetchMe();
 
-  const meetingDateText = generateDateText(meetingDate);
-
   const isSent = me?.id === memberId;
 
   return (
@@ -44,11 +42,6 @@ const BigCouponItem = (props: BigCouponItemProps) => {
           <Styled.Member>
             <Styled.English>{isSent ? 'To.' : 'From.'}</Styled.English> {nickname}
           </Styled.Member>
-          {meetingDate && (
-            <Styled.MeetingDate couponStatus={couponStatus}>
-              {meetingDateText} 약속 {couponStatus === 'REQUESTED' && '신청됨'}
-            </Styled.MeetingDate>
-          )}
         </Styled.Top>
         <Styled.Message>{message}</Styled.Message>
         <Styled.Hashtag>#{hashtag}</Styled.Hashtag>

--- a/frontend/src/@components/coupon/CouponItem/small.style.tsx
+++ b/frontend/src/@components/coupon/CouponItem/small.style.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 
 export const Root = styled.div<{ hasCursor?: boolean }>`
-  width: 120px;
+  width: 140px;
 
   display: flex;
   justify-content: center;
@@ -25,6 +25,8 @@ export const Root = styled.div<{ hasCursor?: boolean }>`
 
 export const TextContainer = styled.div`
   font-weight: 600;
+
+  font-size: 14px;
 `;
 
 export const Preposition = styled.span`

--- a/frontend/src/@components/coupon/CouponItem/small.tsx
+++ b/frontend/src/@components/coupon/CouponItem/small.tsx
@@ -16,7 +16,7 @@ export interface SmallCouponItemProps extends CouponResponse {
 const SmallCouponItem = (props: SmallCouponItemProps) => {
   const { className, onClick, ...coupon } = props;
 
-  const { memberId, nickname, thumbnail, couponStatus } = {
+  const { memberId, nickname, thumbnail, couponStatus, meetingDate } = {
     ...coupon,
     thumbnail: THUMBNAIL[coupon.couponType],
   };

--- a/frontend/src/@components/coupon/CouponItem/small.tsx
+++ b/frontend/src/@components/coupon/CouponItem/small.tsx
@@ -27,7 +27,7 @@ const SmallCouponItem = (props: SmallCouponItemProps) => {
 
   return (
     <Styled.Root hasCursor={!!onClick} onClick={onClick}>
-      <CouponStatus status={couponStatus} isSent={isSent} />
+      <CouponStatus status={couponStatus} meetingDate={meetingDate} isSent={isSent} />
 
       <img src={thumbnail} alt='쿠폰' width='50px' />
 

--- a/frontend/src/@components/coupon/CouponStatus/index.tsx
+++ b/frontend/src/@components/coupon/CouponStatus/index.tsx
@@ -1,40 +1,44 @@
 import theme from '@/styles/theme';
 import { COUPON_STATUS } from '@/types/client/coupon';
+import { generateDateText } from '@/utils';
 
 import * as Styled from './style';
 
 const couponStatusMapper = (
   isSent: boolean
-): Record<COUPON_STATUS, { backgroundColor: string; text: string }> => ({
+): Record<COUPON_STATUS, { backgroundColor: string }> => ({
   REQUESTED: {
     backgroundColor: theme.colors.primary_500,
-    text: isSent ? '요청옴' : '요청중',
   },
   READY: {
     backgroundColor: theme.colors.primary_300,
-    text: '대기중',
   },
   ACCEPTED: {
     backgroundColor: theme.colors.green_500,
-    text: isSent ? '승인함' : '승인됨',
   },
   FINISHED: {
     backgroundColor: theme.colors.light_grey_100,
-    text: '사용완료',
   },
 });
 
 interface CouponStatusProps {
   status: 'REQUESTED' | 'READY' | 'ACCEPTED' | 'FINISHED';
+  meetingDate?: string;
   isSent: boolean;
 }
 
 const CouponStatus = (props: CouponStatusProps) => {
-  const { status, isSent } = props;
+  const { status, isSent, meetingDate } = props;
 
-  const { text, backgroundColor } = couponStatusMapper(isSent)[status];
+  const meetingDateText = generateDateText(meetingDate);
 
-  return <Styled.Root backgroundColor={backgroundColor}>{text}</Styled.Root>;
+  const { backgroundColor } = couponStatusMapper(isSent)[status];
+
+  if (status === 'READY') {
+    return <Styled.Root backgroundColor={backgroundColor}>대기중</Styled.Root>;
+  }
+
+  return <Styled.Root backgroundColor={backgroundColor}>{meetingDateText}</Styled.Root>;
 };
 
 export default CouponStatus;

--- a/frontend/src/@components/coupon/CouponStatus/index.tsx
+++ b/frontend/src/@components/coupon/CouponStatus/index.tsx
@@ -35,7 +35,7 @@ const CouponStatus = (props: CouponStatusProps) => {
   const { backgroundColor } = couponStatusMapper(isSent)[status];
 
   if (status === 'READY') {
-    return <Styled.Root backgroundColor={backgroundColor}>대기중</Styled.Root>;
+    return <Styled.HiddenRoot backgroundColor={backgroundColor}>대기중</Styled.HiddenRoot>;
   }
 
   return <Styled.Root backgroundColor={backgroundColor}>{meetingDateText}</Styled.Root>;

--- a/frontend/src/@components/coupon/CouponStatus/style.tsx
+++ b/frontend/src/@components/coupon/CouponStatus/style.tsx
@@ -12,3 +12,17 @@ export const Root = styled.div<{ backgroundColor: string }>`
     background-color: ${backgroundColor};
   `}
 `;
+
+export const HiddenRoot = styled.div<{ backgroundColor: string }>`
+  padding: 3px 5px;
+  border-radius: 20px;
+
+  font-size: 12px;
+
+  ${({ theme, backgroundColor }) => css`
+    color: ${theme.colors.white_100};
+    background-color: ${backgroundColor};
+  `}
+
+  visibility: hidden;
+`;

--- a/frontend/src/@components/reservation/ReservationItem/index.tsx
+++ b/frontend/src/@components/reservation/ReservationItem/index.tsx
@@ -11,14 +11,9 @@ interface ReservationItemProps {
 }
 
 const ReservationItem = (props: ReservationItemProps) => {
-  const {
-    coupon: { receiver, sender },
-    onClick,
-  } = props;
-
   const { me } = useFetchMe();
 
-  return <Styled.Root onClick={onClick}>ReservationItem</Styled.Root>;
+  return <Styled.Root>ReservationItem</Styled.Root>;
 };
 
 export default ReservationItem;

--- a/frontend/src/@components/reservation/ReservationItem/index.tsx
+++ b/frontend/src/@components/reservation/ReservationItem/index.tsx
@@ -1,0 +1,24 @@
+import { MouseEventHandler } from 'react';
+
+import { useFetchMe } from '@/@hooks/@queries/user';
+import { CouponResponse } from '@/types/remote/response';
+
+import * as Styled from './style';
+
+interface ReservationItemProps {
+  coupon: CouponResponse;
+  onClick?: MouseEventHandler;
+}
+
+const ReservationItem = (props: ReservationItemProps) => {
+  const {
+    coupon: { receiver, sender },
+    onClick,
+  } = props;
+
+  const { me } = useFetchMe();
+
+  return <Styled.Root onClick={onClick}>ReservationItem</Styled.Root>;
+};
+
+export default ReservationItem;

--- a/frontend/src/@components/reservation/ReservationItem/style.tsx
+++ b/frontend/src/@components/reservation/ReservationItem/style.tsx
@@ -1,0 +1,3 @@
+import styled from '@emotion/styled';
+
+export const Root = styled.div``;

--- a/frontend/src/@components/reservation/ReservationList/index.tsx
+++ b/frontend/src/@components/reservation/ReservationList/index.tsx
@@ -1,0 +1,25 @@
+import ReservationItem from '@/@components/reservation/ReservationItem';
+import { CouponResponse } from '@/types/remote/response';
+
+interface ReservationListProps {
+  couponList: CouponResponse[];
+  onClickReservationItem?: (coupon: CouponResponse) => void;
+}
+
+const ReservationList = (props: ReservationListProps) => {
+  const { couponList, onClickReservationItem } = props;
+
+  return (
+    <div>
+      {couponList.map(coupon => (
+        <ReservationItem
+          key={coupon.id}
+          coupon={coupon}
+          onClick={() => onClickReservationItem?.(coupon)}
+        />
+      ))}
+    </div>
+  );
+};
+
+export default ReservationList;

--- a/frontend/src/@components/reservation/ReservationList/style.tsx
+++ b/frontend/src/@components/reservation/ReservationList/style.tsx
@@ -1,0 +1,3 @@
+import styled from '@emotion/styled';
+
+export const Root = styled.div``;

--- a/frontend/src/@hooks/@queries/coupon.ts
+++ b/frontend/src/@hooks/@queries/coupon.ts
@@ -24,6 +24,7 @@ const QUERY_KEY = {
 export const useFetchCouponList = () => {
   const { displayMessage } = useToast();
 
+  /** suspense false만 isLoading을 사용할 수 있다. */
   const { data, ...rest } = useQuery([QUERY_KEY.couponList], getCouponList, {
     suspense: true,
     onError(error) {
@@ -37,8 +38,7 @@ export const useFetchCouponList = () => {
 
   const parsedSentCouponList = useMemo(
     () =>
-      couponList &&
-      couponList?.sent?.reduceRight<Record<COUPON_STATUS, CouponResponse[]>>(
+      (couponList?.sent ?? [])?.reduceRight<Record<COUPON_STATUS, CouponResponse[]>>(
         (prev, coupon) => {
           const key = coupon.couponStatus;
 
@@ -56,8 +56,7 @@ export const useFetchCouponList = () => {
 
   const parsedReceivedCouponList = useMemo(
     () =>
-      couponList &&
-      couponList?.received?.reduceRight<Record<COUPON_STATUS, CouponResponse[]>>(
+      (couponList?.received ?? [])?.reduceRight<Record<COUPON_STATUS, CouponResponse[]>>(
         (prev, coupon) => {
           const key = coupon.couponStatus;
 
@@ -87,11 +86,23 @@ export const useFetchCouponList = () => {
     }, {});
   }, [couponList]);
 
+  const receivedOpenCouponList = useMemo(
+    () => [...parsedReceivedCouponList.REQUESTED, ...parsedReceivedCouponList.READY],
+    [parsedReceivedCouponList.REQUESTED, parsedReceivedCouponList.READY]
+  );
+
+  const sentOpenCouponList = useMemo(
+    () => [...parsedSentCouponList.REQUESTED, ...parsedSentCouponList.READY],
+    [parsedSentCouponList.REQUESTED, parsedSentCouponList.READY]
+  );
+
   return {
     couponList,
     parsedSentCouponList,
     parsedReceivedCouponList,
     acceptedCouponList,
+    receivedOpenCouponList,
+    sentOpenCouponList,
     ...rest,
   };
 };

--- a/frontend/src/@pages/coupon-list/create/index.tsx
+++ b/frontend/src/@pages/coupon-list/create/index.tsx
@@ -77,7 +77,7 @@ export const Styled = {
     display: flex;
     padding: 25px;
 
-    height: 180px;
+    height: 170px;
 
     overflow-x: scroll;
 

--- a/frontend/src/@pages/coupon-list/index.tsx
+++ b/frontend/src/@pages/coupon-list/index.tsx
@@ -16,7 +16,7 @@ import theme from '@/styles/theme';
 import { COUPON_LIST_TYPE } from '@/types/client/coupon';
 import { CouponResponse } from '@/types/remote/response';
 
-const filterOption = ['전체', '열린 약속', '잡은 약속', '지난 약속'] as const;
+const filterOption = ['전체', '대기', '예약', '만료'] as const;
 
 export type FilterOption = typeof filterOption[number];
 
@@ -52,74 +52,76 @@ const CouponListPage = () => {
             onClickFilterButton={onClickFilterButton}
           />
         </Styled.ListFilterContainer>
-        {currentParsedCouponList && (
-          <>
-            {status === '전체' && (
-              <Styled.Container>
-                <section>
-                  <h2>열린 약속</h2>
-                  <HorizontalCouponList
+        <Styled.Container>
+          {
+            <>
+              {status === '전체' && (
+                <Styled.HorizonListContainer>
+                  <section>
+                    <h2>열린 약속</h2>
+                    <HorizontalCouponList
+                      couponList={[
+                        ...currentParsedCouponList['REQUESTED'],
+                        ...currentParsedCouponList['READY'],
+                      ]}
+                      CouponItem={SmallCouponItem}
+                      onClickCouponItem={onClickCouponItem}
+                    />
+                  </section>
+                  <section>
+                    <h2>잡은 약속</h2>
+                    <HorizontalCouponList
+                      couponList={currentParsedCouponList['ACCEPTED']}
+                      CouponItem={SmallCouponItem}
+                      onClickCouponItem={onClickCouponItem}
+                    />
+                  </section>
+                  <section>
+                    <h2>지난 약속</h2>
+                    <HorizontalCouponList
+                      couponList={currentParsedCouponList['FINISHED']}
+                      CouponItem={SmallCouponItem}
+                      onClickCouponItem={onClickCouponItem}
+                    />
+                  </section>
+                </Styled.HorizonListContainer>
+              )}
+
+              {status === '대기' && (
+                <Styled.VerticalListContainer>
+                  <VerticalCouponList
                     couponList={[
                       ...currentParsedCouponList['REQUESTED'],
                       ...currentParsedCouponList['READY'],
                     ]}
-                    CouponItem={SmallCouponItem}
+                    CouponItem={BigCouponItem}
                     onClickCouponItem={onClickCouponItem}
                   />
-                </section>
-                <section>
-                  <h2>잡은 약속</h2>
-                  <HorizontalCouponList
+                </Styled.VerticalListContainer>
+              )}
+
+              {status === '예약' && (
+                <Styled.VerticalListContainer>
+                  <VerticalCouponList
                     couponList={currentParsedCouponList['ACCEPTED']}
-                    CouponItem={SmallCouponItem}
+                    CouponItem={BigCouponItem}
                     onClickCouponItem={onClickCouponItem}
                   />
-                </section>
-                <section>
-                  <h2>지난 약속</h2>
-                  <HorizontalCouponList
+                </Styled.VerticalListContainer>
+              )}
+
+              {status === '만료' && (
+                <Styled.VerticalListContainer>
+                  <VerticalCouponList
                     couponList={currentParsedCouponList['FINISHED']}
-                    CouponItem={SmallCouponItem}
+                    CouponItem={BigCouponItem}
                     onClickCouponItem={onClickCouponItem}
                   />
-                </section>
-              </Styled.Container>
-            )}
-
-            {status === '열린 약속' && (
-              <Styled.Container>
-                <VerticalCouponList
-                  couponList={[
-                    ...currentParsedCouponList['REQUESTED'],
-                    ...currentParsedCouponList['READY'],
-                  ]}
-                  CouponItem={BigCouponItem}
-                  onClickCouponItem={onClickCouponItem}
-                />
-              </Styled.Container>
-            )}
-
-            {status === '잡은 약속' && (
-              <Styled.Container>
-                <VerticalCouponList
-                  couponList={currentParsedCouponList['ACCEPTED']}
-                  CouponItem={BigCouponItem}
-                  onClickCouponItem={onClickCouponItem}
-                />
-              </Styled.Container>
-            )}
-
-            {status === '지난 약속' && (
-              <Styled.Container>
-                <VerticalCouponList
-                  couponList={currentParsedCouponList['FINISHED']}
-                  CouponItem={BigCouponItem}
-                  onClickCouponItem={onClickCouponItem}
-                />
-              </Styled.Container>
-            )}
-          </>
-        )}
+                </Styled.VerticalListContainer>
+              )}
+            </>
+          }
+        </Styled.Container>
 
         <Styled.LinkInner>
           <Link to={PATH.COUPON_CREATE}>
@@ -155,24 +157,7 @@ export const Styled = {
     padding: 0 20px;
   `,
   Container: styled.div`
-    padding-bottom: 20px;
     margin-bottom: 10px;
-
-    & > section {
-      padding: 20px;
-    }
-
-    & > section:nth-of-type(2n) {
-      background-color: #ffbb9415;
-    }
-
-    ${({ theme }) => css`
-      & > section > h2 {
-        color: ${theme.colors.grey_400};
-        font-size: 18px;
-        font-weight: 600;
-      }
-    `}
   `,
   LinkInner: styled.div`
     position: sticky;
@@ -187,5 +172,25 @@ export const Styled = {
       right: 16px;
       bottom: 16px;
     }
+  `,
+  VerticalListContainer: styled.div`
+    padding: 0 10px 20px 10px;
+  `,
+  HorizonListContainer: styled.div`
+    & > section {
+      padding: 10px 20px;
+    }
+
+    & > section:nth-of-type(2n) {
+      background-color: #ffbb9415;
+    }
+
+    ${({ theme }) => css`
+      & > section > h2 {
+        color: ${theme.colors.grey_400};
+        font-size: 18px;
+        font-weight: 600;
+      }
+    `}
   `,
 };

--- a/frontend/src/@pages/landing/index.tsx
+++ b/frontend/src/@pages/landing/index.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/react';
+import { useMemo } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 
 import Button from '@/@components/@shared/Button';
@@ -67,7 +68,8 @@ const UnAuthorizedLanding = () => {
 
 const AuthorizedLanding = () => {
   const navigate = useNavigate();
-  const { couponList, acceptedCouponList, isLoading } = useFetchCouponList();
+  const { acceptedCouponList, receivedOpenCouponList, sentOpenCouponList, isLoading } =
+    useFetchCouponList();
 
   const onClickCouponItem = (coupon: CouponResponse) => {
     navigate(`/coupon-list/${coupon.couponId}`);
@@ -116,7 +118,7 @@ const AuthorizedLanding = () => {
             <span>승인된 꼭꼭</span>
           </Styled.FullListTitle>
 
-          <CustomSuspense fallback={<div>hi</div>} isLoading={isLoading}>
+          <CustomSuspense fallback={<AcceptedCouponList.Skeleton />} isLoading={isLoading}>
             <AcceptedCouponList acceptedCouponList={acceptedCouponList} />
           </CustomSuspense>
         </Styled.FullListContainer>
@@ -136,7 +138,7 @@ const AuthorizedLanding = () => {
               isLoading={isLoading}
             >
               <HorizontalCouponList
-                couponList={couponList && [...couponList.received].reverse()}
+                couponList={receivedOpenCouponList}
                 CouponItem={SmallCouponItem}
                 onClickCouponItem={onClickCouponItem}
               />
@@ -157,7 +159,7 @@ const AuthorizedLanding = () => {
               isLoading={isLoading}
             >
               <HorizontalCouponList
-                couponList={couponList && [...couponList.sent].reverse()}
+                couponList={sentOpenCouponList}
                 CouponItem={SmallCouponItem}
                 onClickCouponItem={onClickCouponItem}
               />

--- a/frontend/src/styles/globalStyle.ts
+++ b/frontend/src/styles/globalStyle.ts
@@ -100,6 +100,14 @@ const globalStyle = css`
       font-size: 16px !important;
     }
   }
+  div {
+    -ms-overflow-style: none; /* IE and Edge */
+    scrollbar-width: none; /* Firefox */
+  }
+
+  div::-webkit-scrollbar {
+    display: none; /* Chrome, Safari, Opera*/
+  }
 `;
 
 export default globalStyle;


### PR DESCRIPTION
## 작업 내용

- 쿠폰 UI를 강화

  - 쿠폰 리스트 페이지의 카테고리에서 쿠폰 상태를 표현한다.
  - 쿠폰에는 상태 워딩 대신 날짜가 표현된다.
  - 대기 중인 쿠폰에는 아무런 표식이 없다.
  - 쿠폰 UI의 비율이 사라진다. 고정 높이만이 존재하고 좌우 너비는 280~340로 자유롭게 가질 수 있다.

- 승인된 섹션

  - 승인된 쿠폰들이 날짜 별로 보인다. 
  - 쿠폰 UI -> 예약 UI로 대체한다.

## 공유사항

해당 작업 내용에 관한 부연 설명 및 및 향후 작업해야 할 내용 등에 대한 설명

Resolves #185
