### PR TITLE
fix: 예약 생성 요청 시 LocalDateTime을 LocalDate로 받도록 수정

### DIFF
--- a/backend/src/main/java/com/woowacourse/kkogkkog/reservation/application/dto/ReservationSaveRequest.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/reservation/application/dto/ReservationSaveRequest.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonFormat.Shape;
 import com.woowacourse.kkogkkog.coupon.domain.Coupon;
 import com.woowacourse.kkogkkog.reservation.domain.Reservation;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -21,11 +22,11 @@ public class ReservationSaveRequest {
     private LocalDateTime meetingDate;
     private String message;
 
-    public ReservationSaveRequest(Long memberId, Long couponId, LocalDateTime meetingDate,
+    public ReservationSaveRequest(Long memberId, Long couponId, LocalDate meetingDate,
                                   String message) {
         this.memberId = memberId;
         this.couponId = couponId;
-        this.meetingDate = meetingDate;
+        this.meetingDate = meetingDate.atStartOfDay();
         this.message = message;
     }
 

--- a/backend/src/main/java/com/woowacourse/kkogkkog/reservation/presentation/dto/ReservationCreateRequest.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/reservation/presentation/dto/ReservationCreateRequest.java
@@ -1,23 +1,22 @@
 package com.woowacourse.kkogkkog.reservation.presentation.dto;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
-import com.fasterxml.jackson.annotation.JsonFormat.Shape;
 import com.woowacourse.kkogkkog.reservation.application.dto.ReservationSaveRequest;
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class ReservationCreateRequest {
 
     private Long couponId;
-    @JsonFormat(shape = Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
-    private LocalDateTime meetingDate;
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    private LocalDate meetingDate;
     private String message;
 
-    public ReservationCreateRequest(Long couponId, LocalDateTime meetingDate,
+    public ReservationCreateRequest(Long couponId, LocalDate meetingDate,
                                     String message) {
         this.couponId = couponId;
         this.meetingDate = meetingDate;

--- a/backend/src/test/java/com/woowacourse/kkogkkog/application/PushAlarmListenerTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/application/PushAlarmListenerTest.java
@@ -5,7 +5,6 @@ import static com.woowacourse.kkogkkog.common.fixture.domain.ReservationFixture.
 import static com.woowacourse.kkogkkog.common.fixture.dto.ReservationDtoFixture.예약_수정_요청;
 import static com.woowacourse.kkogkkog.common.fixture.dto.ReservationDtoFixture.예약_저장_요청;
 import static java.time.LocalDateTime.now;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import com.woowacourse.kkogkkog.common.annotaion.ApplicationTest;
 import com.woowacourse.kkogkkog.common.fixture.domain.MemberFixture;
@@ -24,7 +23,7 @@ import com.woowacourse.kkogkkog.reservation.application.dto.ReservationSaveReque
 import com.woowacourse.kkogkkog.reservation.application.dto.ReservationUpdateRequest;
 import com.woowacourse.kkogkkog.reservation.domain.Reservation;
 import com.woowacourse.kkogkkog.reservation.domain.repository.ReservationRepository;
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -88,7 +87,7 @@ public class PushAlarmListenerTest {
         void success_reservationSave() {
             coupon = couponRepository.save(COFFEE.getCoupon(sender, receiver));
             reservationSaveRequest = 예약_저장_요청(receiver.getId(), coupon.getId(),
-                LocalDateTime.now());
+                LocalDate.now());
 
             reservationService.save(reservationSaveRequest);
 

--- a/backend/src/test/java/com/woowacourse/kkogkkog/common/fixture/dto/ReservationDtoFixture.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/common/fixture/dto/ReservationDtoFixture.java
@@ -4,15 +4,16 @@ import com.woowacourse.kkogkkog.reservation.application.dto.ReservationSaveReque
 import com.woowacourse.kkogkkog.reservation.application.dto.ReservationUpdateRequest;
 import com.woowacourse.kkogkkog.reservation.presentation.dto.ReservationChangeRequest;
 import com.woowacourse.kkogkkog.reservation.presentation.dto.ReservationCreateRequest;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 public class ReservationDtoFixture {
 
-    public static ReservationCreateRequest 예약_생성_요청(Long couponId, LocalDateTime now) {
+    public static ReservationCreateRequest 예약_생성_요청(Long couponId, LocalDate now) {
         return new ReservationCreateRequest(couponId, now, "예약할 때 보내는 메시지");
     }
 
-    public static ReservationSaveRequest 예약_저장_요청(Long memberId, Long couponId, LocalDateTime now) {
+    public static ReservationSaveRequest 예약_저장_요청(Long memberId, Long couponId, LocalDate now) {
         return new ReservationSaveRequest(memberId, couponId, now, "예약할 때 보내는 메시지");
     }
 

--- a/backend/src/test/java/com/woowacourse/kkogkkog/core/reservation/acceptance/ReservationAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/core/reservation/acceptance/ReservationAcceptanceTest.java
@@ -16,6 +16,7 @@ import com.woowacourse.kkogkkog.acceptance.AcceptanceTest;
 import com.woowacourse.kkogkkog.reservation.presentation.dto.ReservationCreateRequest;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -30,7 +31,7 @@ public class ReservationAcceptanceTest extends AcceptanceTest {
         쿠폰_생성을_요청하고(rookieToken, COFFEE_쿠폰_생성_요청(List.of(2L)));
 
         ExtractableResponse<Response> extract = 예약을_신청한다(
-            leoToken, 예약_생성_요청(1L, LocalDateTime.now()));
+            leoToken, 예약_생성_요청(1L, LocalDate.now()));
 
         assertAll(
             () -> assertThat(extract.header("Location").split("/")[3]).isEqualTo("1"),
@@ -43,7 +44,7 @@ public class ReservationAcceptanceTest extends AcceptanceTest {
         String rookieToken = 회원가입을_하고(ROOKIE.getMember());
         String leoToken = 회원가입을_하고(LEO.getMember());
         쿠폰_생성을_요청하고(rookieToken, COFFEE_쿠폰_생성_요청(List.of(2L)));
-        예약을_신청하고(leoToken, 예약_생성_요청(1L, LocalDateTime.now()));
+        예약을_신청하고(leoToken, 예약_생성_요청(1L, LocalDate.now()));
 
         ExtractableResponse<Response> extract = 예약을_변경한다(
             1L, rookieToken, 예약_변경_요청("ACCEPT"));

--- a/backend/src/test/java/com/woowacourse/kkogkkog/core/reservation/application/ReservationServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/core/reservation/application/ReservationServiceTest.java
@@ -27,6 +27,7 @@ import com.woowacourse.kkogkkog.reservation.application.dto.ReservationSaveReque
 import com.woowacourse.kkogkkog.reservation.application.dto.ReservationUpdateRequest;
 import com.woowacourse.kkogkkog.reservation.domain.Reservation;
 import com.woowacourse.kkogkkog.reservation.domain.repository.ReservationRepository;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -72,7 +73,7 @@ class ReservationServiceTest {
         @Test
         @DisplayName("쿠폰을 통해서 예약을 생성하고, 예약 ID를 반환한다.")
         void success() {
-            reservationSaveRequest = 예약_저장_요청(receiver.getId(), coupon.getId(), LocalDateTime.now());
+            reservationSaveRequest = 예약_저장_요청(receiver.getId(), coupon.getId(), LocalDate.now());
 
             Long actual = reservationService.save(reservationSaveRequest);
 
@@ -86,7 +87,7 @@ class ReservationServiceTest {
         @Test
         @DisplayName("예약을 생성할 때, 쿠폰 사용 내역에 기록한다.")
         void success_reservationSave() {
-            reservationSaveRequest = 예약_저장_요청(receiver.getId(), coupon.getId(), LocalDateTime.now());
+            reservationSaveRequest = 예약_저장_요청(receiver.getId(), coupon.getId(), LocalDate.now());
 
             reservationService.save(reservationSaveRequest);
 

--- a/backend/src/test/java/com/woowacourse/kkogkkog/core/reservation/documentation/ReservationDocumentTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/core/reservation/documentation/ReservationDocumentTest.java
@@ -14,6 +14,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.woowacourse.kkogkkog.documentation.Documentation;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import org.apache.http.HttpHeaders;
 import org.junit.jupiter.api.Test;
@@ -33,7 +34,7 @@ public class ReservationDocumentTest extends Documentation {
         ResultActions perform = mockMvc.perform(
             post("/api/reservations")
                 .header(HttpHeaders.AUTHORIZATION, BEARER_TOKEN)
-                .content(objectMapper.writeValueAsString(예약_저장_요청(1L, 1L, LocalDateTime.now())))
+                .content(objectMapper.writeValueAsString(예약_저장_요청(1L, 1L, LocalDate.now())))
                 .contentType(MediaType.APPLICATION_JSON));
 
         perform.andExpect(status().isCreated());

--- a/backend/src/test/java/com/woowacourse/kkogkkog/core/reservation/documentation/ReservationDocumentTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/core/reservation/documentation/ReservationDocumentTest.java
@@ -23,7 +23,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
 
 @SuppressWarnings("NonAsciiCharacters")
-public class ReservationDocumentTest extends Documentation {
+class ReservationDocumentTest extends Documentation {
 
     private final String BEARER_TOKEN = "Bearer {Access Token}";
 

--- a/backend/src/test/java/com/woowacourse/kkogkkog/core/reservation/documentation/ReservationDocumentTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/core/reservation/documentation/ReservationDocumentTest.java
@@ -1,6 +1,7 @@
 package com.woowacourse.kkogkkog.core.reservation.documentation;
 
 import static com.woowacourse.kkogkkog.common.fixture.dto.ReservationDtoFixture.예약_변경_요청;
+import static com.woowacourse.kkogkkog.common.fixture.dto.ReservationDtoFixture.예약_생성_요청;
 import static com.woowacourse.kkogkkog.common.fixture.dto.ReservationDtoFixture.예약_저장_요청;
 import static com.woowacourse.kkogkkog.documentation.support.ApiDocumentUtils.getDocumentRequest;
 import static com.woowacourse.kkogkkog.documentation.support.ApiDocumentUtils.getDocumentResponse;
@@ -34,7 +35,7 @@ public class ReservationDocumentTest extends Documentation {
         ResultActions perform = mockMvc.perform(
             post("/api/reservations")
                 .header(HttpHeaders.AUTHORIZATION, BEARER_TOKEN)
-                .content(objectMapper.writeValueAsString(예약_저장_요청(1L, 1L, LocalDate.now())))
+                .content(objectMapper.writeValueAsString(예약_생성_요청(1L, LocalDate.now())))
                 .contentType(MediaType.APPLICATION_JSON));
 
         perform.andExpect(status().isCreated());


### PR DESCRIPTION
## 작업 내용

프론트에서 받아오는 날짜 객체를 LocalDateTime이 아닌 LocalDate로 받도록 수정하였습니다.

- Request Dto 날짜 타입 변환

  - LocalDateTime -> LocalDate

- @JsonFormat -> @DateTimeFormat으로 변환

  ![image](https://user-images.githubusercontent.com/48710213/184639573-26d0d633-4dab-4e72-a9c4-efd5e4e126fa.png)


## 공유사항

없음

Resolves #238
