### PR TITLE
feat: 알림함 기능 보완

### DIFF
--- a/frontend/src/@components/@shared/Header/index.tsx
+++ b/frontend/src/@components/@shared/Header/index.tsx
@@ -46,7 +46,7 @@ const Header = (props: HeaderProps) => {
             align-items: center;
           `}
         >
-          <Link to={PATH.USER_HISTORY}>
+          <Link to={PATH.USER_HISTORY} state={{ shouldRefetch: true }}>
             <Icon iconName='notification' size='26' color={'transparent'} />
           </Link>
           {me?.unReadCount !== 0 && (

--- a/frontend/src/@hooks/@queries/user.ts
+++ b/frontend/src/@hooks/@queries/user.ts
@@ -10,6 +10,7 @@ import {
   join,
   login,
   OAuthLogin,
+  readAllHistory,
   readHistory,
 } from '@/apis/user';
 import { ReadHistoryRequest } from '@/types/remote/request';
@@ -136,6 +137,16 @@ export const useLoginMutation = () => {
       if (error instanceof AxiosError) {
         displayMessage(error?.response?.data?.message, true);
       }
+    },
+  });
+};
+
+export const useReadAllHistoryMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation(readAllHistory, {
+    onSuccess() {
+      queryClient.invalidateQueries([QUERY_KEY.me]);
     },
   });
 };

--- a/frontend/src/@hooks/@queries/user.ts
+++ b/frontend/src/@hooks/@queries/user.ts
@@ -12,7 +12,6 @@ import {
   OAuthLogin,
   readAllHistory,
 } from '@/apis/user';
-import { ReadHistoryRequest } from '@/types/remote/request';
 import { UserHistoryResponse } from '@/types/remote/response';
 
 import { useToast } from '../@common/useToast';
@@ -153,7 +152,7 @@ export const useReadAllHistoryMutation = () => {
 export const useReadHistory = () => {
   const queryClient = useQueryClient();
 
-  const readHistory = async ({ id }: ReadHistoryRequest) => {
+  const readHistory = (id: number) => {
     queryClient.setQueryData<UserHistoryResponse | undefined>(
       [QUERY_KEY.getUserHistoryList],
       oldData => {

--- a/frontend/src/@hooks/@queries/user.ts
+++ b/frontend/src/@hooks/@queries/user.ts
@@ -11,7 +11,6 @@ import {
   login,
   OAuthLogin,
   readAllHistory,
-  readHistory,
 } from '@/apis/user';
 import { ReadHistoryRequest } from '@/types/remote/request';
 import { UserHistoryResponse } from '@/types/remote/response';
@@ -151,16 +150,10 @@ export const useReadAllHistoryMutation = () => {
   });
 };
 
-export const useReadHistoryMutation = () => {
+export const useReadHistory = () => {
   const queryClient = useQueryClient();
 
-  const onMutate = async ({ id }: ReadHistoryRequest) => {
-    await queryClient.cancelQueries([QUERY_KEY.getUserHistoryList]);
-
-    const previousQueryData = queryClient.getQueryData<UserHistoryResponse>([
-      QUERY_KEY.getUserHistoryList,
-    ]);
-
+  const readHistory = async ({ id }: ReadHistoryRequest) => {
     queryClient.setQueryData<UserHistoryResponse | undefined>(
       [QUERY_KEY.getUserHistoryList],
       oldData => {
@@ -178,25 +171,7 @@ export const useReadHistoryMutation = () => {
         return newData;
       }
     );
-
-    return previousQueryData;
   };
 
-  const onSuccess = () => {
-    queryClient.invalidateQueries([QUERY_KEY.me]);
-  };
-
-  const onError = (
-    error: unknown,
-    variables: ReadHistoryRequest,
-    context: UserHistoryResponse | undefined
-  ) => {
-    queryClient.setQueryData([QUERY_KEY.getUserHistoryList], context);
-  };
-
-  return useMutation(readHistory, {
-    onMutate,
-    onSuccess,
-    onError,
-  });
+  return readHistory;
 };

--- a/frontend/src/@pages/history/index.tsx
+++ b/frontend/src/@pages/history/index.tsx
@@ -15,7 +15,6 @@ const UserHistoryPage = () => {
   const state = useLocation().state as { shouldRefetch: boolean } | null;
 
   const { historyList, refetch } = useFetchUserHistoryList();
-
   const { mutate: readAllHistory } = useReadAllHistoryMutation();
   const readHistory = useReadHistory();
 
@@ -29,7 +28,7 @@ const UserHistoryPage = () => {
 
   const onClickHistoryItem = ({ id, couponId, isRead }: UserHistory) => {
     if (!isRead) {
-      readHistory({ id });
+      readHistory(id);
     }
     navigate(`/coupon-list/${couponId}`);
   };

--- a/frontend/src/@pages/history/index.tsx
+++ b/frontend/src/@pages/history/index.tsx
@@ -1,17 +1,28 @@
-import { useNavigate } from 'react-router-dom';
+import { useEffect } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 import PageTemplate from '@/@components/@shared/PageTemplate';
 import UserHistoryList from '@/@components/user/UserHistoryList';
-import { useFetchUserHistoryList } from '@/@hooks/@queries/user';
+import { useFetchUserHistoryList, useReadAllHistoryMutation } from '@/@hooks/@queries/user';
 import { useUserHistory } from '@/@hooks/user/useUserHistory';
 import { UserHistory } from '@/types/client/user';
 
 const UserHistoryPage = () => {
   const navigate = useNavigate();
+  const state = useLocation().state as { shouldRefetch: boolean } | null;
 
-  const { historyList } = useFetchUserHistoryList();
+  const { historyList, refetch } = useFetchUserHistoryList();
 
   const { readHistory } = useUserHistory();
+  const { mutate: readAllHistory } = useReadAllHistoryMutation();
+
+  useEffect(() => {
+    if (state?.shouldRefetch) {
+      refetch();
+      readAllHistory();
+      window.history.replaceState({}, document.title);
+    }
+  }, [state, refetch, readAllHistory]);
 
   const onClickHistoryItem = ({ id, couponId, isRead }: UserHistory) => {
     if (!isRead) {

--- a/frontend/src/@pages/history/index.tsx
+++ b/frontend/src/@pages/history/index.tsx
@@ -3,8 +3,11 @@ import { useLocation, useNavigate } from 'react-router-dom';
 
 import PageTemplate from '@/@components/@shared/PageTemplate';
 import UserHistoryList from '@/@components/user/UserHistoryList';
-import { useFetchUserHistoryList, useReadAllHistoryMutation } from '@/@hooks/@queries/user';
-import { useUserHistory } from '@/@hooks/user/useUserHistory';
+import {
+  useFetchUserHistoryList,
+  useReadAllHistoryMutation,
+  useReadHistory,
+} from '@/@hooks/@queries/user';
 import { UserHistory } from '@/types/client/user';
 
 const UserHistoryPage = () => {
@@ -13,8 +16,8 @@ const UserHistoryPage = () => {
 
   const { historyList, refetch } = useFetchUserHistoryList();
 
-  const { readHistory } = useUserHistory();
   const { mutate: readAllHistory } = useReadAllHistoryMutation();
+  const readHistory = useReadHistory();
 
   useEffect(() => {
     if (state?.shouldRefetch) {
@@ -26,7 +29,7 @@ const UserHistoryPage = () => {
 
   const onClickHistoryItem = ({ id, couponId, isRead }: UserHistory) => {
     if (!isRead) {
-      readHistory(id);
+      readHistory({ id });
     }
     navigate(`/coupon-list/${couponId}`);
   };

--- a/frontend/src/apis/user.ts
+++ b/frontend/src/apis/user.ts
@@ -32,5 +32,7 @@ export const getUserHistoryList = async () => {
   return data;
 };
 
+export const readAllHistory = () => client.put('members/me/histories');
+
 export const readHistory = ({ id }: ReadHistoryRequest) =>
   client.patch(`/members/me/histories/${id}`);

--- a/frontend/src/apis/user.ts
+++ b/frontend/src/apis/user.ts
@@ -35,4 +35,4 @@ export const getUserHistoryList = async () => {
 export const readAllHistory = () => client.put('members/me/histories');
 
 export const readHistory = ({ id }: ReadHistoryRequest) =>
-  client.patch(`/members/me/histories/${id}`);
+  client.put(`/members/me/histories/${id}`);

--- a/frontend/src/mocks/handlers/user.ts
+++ b/frontend/src/mocks/handlers/user.ts
@@ -67,6 +67,25 @@ export const userHandler = [
     }
   }),
 
+  rest.put(`${BASE_URL}/members/me/histories`, (req, res, ctx) => {
+    const { headers } = req;
+
+    try {
+      const user = users.findLoggedUser(headers.get('authorization'));
+
+      user.histories = user.histories.map(history => ({
+        ...history,
+        isRead: true,
+      }));
+
+      user.unReadCount = 0;
+
+      return res(ctx.status(200, 'authorized'));
+    } catch ({ message }) {
+      return res(ctx.status(400, 'unauthorized'), ctx.json({ message }));
+    }
+  }),
+
   rest.patch<any>(`${BASE_URL}/members/me/histories/:historyId`, (req, res, ctx) => {
     const {
       headers,
@@ -87,7 +106,9 @@ export const userHandler = [
         return history;
       });
 
-      user.unReadCount = user.unReadCount - 1;
+      if (user.unReadCount > 0) {
+        user.unReadCount = user.unReadCount - 1;
+      }
 
       return res(ctx.status(200, 'authorized'));
     } catch ({ message }) {

--- a/frontend/src/mocks/handlers/user.ts
+++ b/frontend/src/mocks/handlers/user.ts
@@ -86,7 +86,7 @@ export const userHandler = [
     }
   }),
 
-  rest.patch<any>(`${BASE_URL}/members/me/histories/:historyId`, (req, res, ctx) => {
+  rest.put<any>(`${BASE_URL}/members/me/histories/:historyId`, (req, res, ctx) => {
     const {
       headers,
       params: { historyId },


### PR DESCRIPTION
## 작업 내용

[당근마켓 레퍼런스]

- 페이지에 들어오면 모든 isRead를 true로 만든다.
- 상세 페이지에 갔다가, 돌아오는 뒤로가기 액션에는 반응하지 않는다.
- 알림 하나를 누르면, 하나의 클라이언트 isRead 상태만 변경된다.

이렇게 만드려고 노력했습니다.

/history에 들어오는 방법은 3가지입니다.
1. 헤더의 종을 눌러서 들어온다.
2. 알림함 내에서 하나의 알림을 눌러서 상세 페이지로 갔다가 뒤로 가기로 돌아온다.
3. /history url을 직접 치고 들어온다.

제가 택한 방법이 1,2번 케이스를 커버하지만, 3번은 커버하지 못 합니다. (3번의 경우, isRead 처리가 안 됩니다.)
모든 경우를 커버할 방법이 잘 떠오르지 않네요.

일단 마이너한 이슈라고 생각해서 일단락하고 PR 올립니다.

Resolves #241
