### PR TITLE
fix: receiver, sender 데이터를 로그인 대상으로 가져오는 문제 수정

### DIFF
--- a/backend/src/main/java/com/woowacourse/kkogkkog/coupon/application/CouponService.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/coupon/application/CouponService.java
@@ -45,17 +45,17 @@ public class CouponService {
     }
 
     @Transactional(readOnly = true)
-    public List<CouponReservationResponse> findAllBySender(Long senderId) {
-        Member sender = findMember(senderId);
-        return couponQueryRepository.findAllBySender(sender).stream()
+    public List<CouponReservationResponse> findAllBySender(Long memberId) {
+        Member member = findMember(memberId);
+        return couponQueryRepository.findAllBySender(member).stream()
             .map(CouponReservationResponse::of)
             .collect(Collectors.toList());
     }
 
     @Transactional(readOnly = true)
-    public List<CouponReservationResponse> findAllByReceiver(Long receiverId) {
-        Member sender = findMember(receiverId);
-        return couponQueryRepository.findAllByReceiver(sender).stream()
+    public List<CouponReservationResponse> findAllByReceiver(Long memberId) {
+        Member member = findMember(memberId);
+        return couponQueryRepository.findAllByReceiver(member).stream()
             .map(CouponReservationResponse::of)
             .collect(Collectors.toList());
     }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/coupon/application/dto/CouponReservationResponse.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/coupon/application/dto/CouponReservationResponse.java
@@ -18,6 +18,7 @@ public class CouponReservationResponse {
     private Long reservationId;
     private Long memberId;
     private String nickname;
+    private String imageUrl;
     private String hashtag;
     private String description;
     private String couponType;
@@ -31,6 +32,7 @@ public class CouponReservationResponse {
                                      Long reservationId,
                                      Long memberId,
                                      String nickname,
+                                     String imageUrl,
                                      String hashtag,
                                      String description,
                                      CouponType couponType,
@@ -41,6 +43,7 @@ public class CouponReservationResponse {
         this.reservationId = reservationId;
         this.memberId = memberId;
         this.nickname = nickname;
+        this.imageUrl = imageUrl;
         this.hashtag = hashtag;
         this.description = description;
         this.couponType = couponType.name();
@@ -52,7 +55,7 @@ public class CouponReservationResponse {
     public static CouponReservationResponse of(CouponReservationData data) {
         return new CouponReservationResponse(
             data.getCouponId(), data.getReservationId(), data.getMemberId(), data.getNickname(),
-            data.getHashtag(), data.getDescription(),
+            data.getImageUrl(), data.getHashtag(), data.getDescription(),
             data.getCouponType(), data.getCouponStatus(),
             data.getMessage(), data.getMeetingDate());
     }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/coupon/domain/query/CouponQueryRepository.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/coupon/domain/query/CouponQueryRepository.java
@@ -10,7 +10,7 @@ import org.springframework.data.repository.query.Param;
 public interface CouponQueryRepository extends JpaRepository<Coupon, Long> {
 
     @Query(
-        "SELECT new com.woowacourse.kkogkkog.coupon.domain.query.CouponReservationData(c.id, r.id, m.id, m.nickname.value, c.hashtag, c.description, c.couponType, c.couponStatus, r.message, r.meetingDate)"
+        "SELECT new com.woowacourse.kkogkkog.coupon.domain.query.CouponReservationData(c.id, r.id, c.receiver.id, c.receiver.nickname.value, m.imageUrl, c.hashtag, c.description, c.couponType, c.couponStatus, r.message, r.meetingDate)"
             + " FROM Coupon c"
             + " JOIN c.sender m"
             + " LEFT JOIN Reservation r ON r.coupon = c WHERE m = :member"
@@ -19,7 +19,7 @@ public interface CouponQueryRepository extends JpaRepository<Coupon, Long> {
     List<CouponReservationData> findAllBySender(@Param("member") Member member);
 
     @Query(
-        "SELECT new com.woowacourse.kkogkkog.coupon.domain.query.CouponReservationData(c.id, r.id, m.id, m.nickname.value, c.hashtag, c.description, c.couponType, c.couponStatus, r.message, r.meetingDate)"
+        "SELECT new com.woowacourse.kkogkkog.coupon.domain.query.CouponReservationData(c.id, r.id, c.sender.id, c.sender.nickname.value, c.sender.imageUrl, c.hashtag, c.description, c.couponType, c.couponStatus, r.message, r.meetingDate)"
             + " FROM Coupon c"
             + " JOIN c.receiver m"
             + " LEFT JOIN Reservation r ON r.coupon = c WHERE m = :member"

--- a/backend/src/main/java/com/woowacourse/kkogkkog/coupon/domain/query/CouponReservationData.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/coupon/domain/query/CouponReservationData.java
@@ -15,6 +15,7 @@ public class CouponReservationData {
     private Long reservationId;
     private Long memberId;
     private String nickname;
+    private String imageUrl;
     private String hashtag;
     private String description;
     private CouponType couponType;
@@ -26,6 +27,7 @@ public class CouponReservationData {
                                  Long reservationId,
                                  Long memberId,
                                  String nickname,
+                                 String imageUrl,
                                  String hashtag,
                                  String description,
                                  CouponType couponType,
@@ -36,6 +38,7 @@ public class CouponReservationData {
         this.reservationId = reservationId;
         this.memberId = memberId;
         this.nickname = nickname;
+        this.imageUrl = imageUrl;
         this.hashtag = hashtag;
         this.description = description;
         this.couponType = couponType;

--- a/backend/src/main/java/com/woowacourse/kkogkkog/coupon/presentation/dto/MyCouponsReservationResponse.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/coupon/presentation/dto/MyCouponsReservationResponse.java
@@ -15,9 +15,4 @@ public class MyCouponsReservationResponse {
     public MyCouponsReservationResponse(CouponsReservationResponse data) {
         this.data = data;
     }
-
-    public MyCouponsReservationResponse(List<CouponReservationResponse> received,
-                                        List<CouponReservationResponse> sent) {
-        this.data = new CouponsReservationResponse(received, sent);
-    }
 }

--- a/backend/src/test/java/com/woowacourse/kkogkkog/common/fixture/dto/CouponDtoFixture.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/common/fixture/dto/CouponDtoFixture.java
@@ -53,6 +53,7 @@ public class CouponDtoFixture {
             reservationId,
             memberId,
             "멤버 닉네임",
+            "https://",
             "고마워요",
             "쿠폰에 대한 설명을 작성했어요",
             CouponType.COFFEE,


### PR DESCRIPTION
## 작업 내용

- sender, receiver를 query상에서 잘못 가져오던 내용을 수정했습니다.

  - jpql에서 sender와 receiver를 가져오도록 수정

- memberCoupon에 ImageUrl 추가

## 공유사항

없음

Resolves #245
