### PR TITLE
docs: RestDocs 동기화

### DIFF
--- a/backend/src/docs/asciidoc/auth.adoc
+++ b/backend/src/docs/asciidoc/auth.adoc
@@ -8,3 +8,6 @@
 == Auth
 === 로그인
 operation::auth-login[snippets='http-request,http-response']
+
+=== 슬랙 앱 설치
+operation::slack-bot-install[snippets='http-request,http-response,request-fields']

--- a/backend/src/docs/asciidoc/member.adoc
+++ b/backend/src/docs/asciidoc/member.adoc
@@ -13,14 +13,14 @@ operation::member-showMe[snippets='http-request,http-response']
 === 본인 이벤트 기록 조회
 operation::member-showMeHistory[snippets='http-request,http-response']
 
-== 본인 모든 이벤트 방문 수정
+=== 모든 본인 히스토리 읽음 여부 수정
 operation::member-updateAllMeHistories[snippets='http-request,http-response']
 
-=== 본인 이벤트 방문 수정
+=== 단일 히스토리 읽음 여부 수정
 operation::member-updateMeHistory[snippets='http-request,http-response']
 
 === 전체 조회
 operation::member-showAll[snippets='http-request,http-response']
 
-== 본인 정보 수정
+=== 본인 정보 수정
 operation::member-update[snippets='http-request,http-response']

--- a/backend/src/test/java/com/woowacourse/kkogkkog/auth/documentation/AuthDocumentTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/auth/documentation/AuthDocumentTest.java
@@ -6,15 +6,19 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.woowacourse.kkogkkog.auth.application.dto.TokenResponse;
+import com.woowacourse.kkogkkog.auth.presentation.dto.InstallSlackAppRequest;
 import com.woowacourse.kkogkkog.support.documenation.DocumentTest;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.ResultActions;
 
@@ -46,6 +50,31 @@ class AuthDocumentTest extends DocumentTest {
                 responseFields(
                     fieldWithPath("accessToken").type(JsonFieldType.STRING).description("토큰"),
                     fieldWithPath("isNew").type(JsonFieldType.BOOLEAN).description("회원가입 여부")
+                )
+            ));
+    }
+
+    @Test
+    void 슬랙_앱을_설치한다() throws Exception {
+        //given
+        InstallSlackAppRequest installSlackAppRequest = new InstallSlackAppRequest("code");
+
+        // when
+        ResultActions perform = mockMvc.perform(post("/api/install/bot")
+            .content(objectMapper.writeValueAsString(installSlackAppRequest))
+            .contentType(MediaType.APPLICATION_JSON));
+
+        // then
+        perform
+            .andExpect(status().isOk());
+
+        // docs
+        perform
+            .andDo(print())
+            .andDo(document("slack-bot-install",
+                getDocumentRequest(),
+                requestFields(
+                    fieldWithPath("code").type(JsonFieldType.STRING).description("인가 코드")
                 )
             ));
     }


### PR DESCRIPTION
## 작업 내용

- 슬랙 앱 설치 RestDocs를 작성한다.
- 단일 쿠폰 상세 조회 RestDocs를 작성한다.
-  예약 요청과 상세 조회 Request, Response Fields를 작성한다.

## 공유사항
API 변경시 걸리적거리면 RestDocs를 삭제하고 시간 여유있을 때 작성하기를 권장한다.

Resolves #248
