### PR TITLE
feat: 쿠폰 대상을 Sender와 Receiver로 보내주는 기능 추가

### DIFF
--- a/backend/src/docs/asciidoc/auth.adoc
+++ b/backend/src/docs/asciidoc/auth.adoc
@@ -7,4 +7,4 @@
 
 == Auth
 === 로그인
-operation::auth-login[snippets='http-request,http-response,response-fields']
+operation::auth-login[snippets='http-request,http-response']

--- a/backend/src/docs/asciidoc/coupon.adoc
+++ b/backend/src/docs/asciidoc/coupon.adoc
@@ -7,10 +7,10 @@
 
 == Coupon
 === 쿠폰 생성
-operation::coupon-create[snippets='http-request,http-response,request-fields']
+operation::coupon-create[snippets='http-request,http-response']
 
 === 쿠폰 전체 조회
-operation::coupon-showAll-me[snippets='http-request,http-response,response-fields']
+operation::coupon-showAll-me[snippets='http-request,http-response']
 
 === 단일 쿠폰 상세 조회
-operation::coupon-show[snippets='http-request,http-response,response-fields']
+operation::coupon-show[snippets='http-request,http-response']

--- a/backend/src/docs/asciidoc/member.adoc
+++ b/backend/src/docs/asciidoc/member.adoc
@@ -8,10 +8,10 @@
 == Member
 
 === 본인 정보 조회
-operation::member-showMe[snippets='http-request,http-response,response-fields']
+operation::member-showMe[snippets='http-request,http-response']
 
 === 본인 이벤트 기록 조회
-operation::member-showMeHistory[snippets='http-request,http-response,response-fields']
+operation::member-showMeHistory[snippets='http-request,http-response']
 
 == 본인 모든 이벤트 방문 수정
 operation::member-updateAllMeHistories[snippets='http-request,http-response']
@@ -20,7 +20,7 @@ operation::member-updateAllMeHistories[snippets='http-request,http-response']
 operation::member-updateMeHistory[snippets='http-request,http-response']
 
 === 전체 조회
-operation::member-showAll[snippets='http-request,http-response,response-fields']
+operation::member-showAll[snippets='http-request,http-response']
 
 == 본인 정보 수정
 operation::member-update[snippets='http-request,http-response']

--- a/backend/src/main/java/com/woowacourse/kkogkkog/coupon/application/CouponService.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/coupon/application/CouponService.java
@@ -48,7 +48,7 @@ public class CouponService {
     public List<CouponReservationResponse> findAllBySender(Long memberId) {
         Member member = findMember(memberId);
         return couponQueryRepository.findAllBySender(member).stream()
-            .map(CouponReservationResponse::of)
+            .map(it -> CouponReservationResponse.of(it, "SENT"))
             .collect(Collectors.toList());
     }
 
@@ -56,7 +56,7 @@ public class CouponService {
     public List<CouponReservationResponse> findAllByReceiver(Long memberId) {
         Member member = findMember(memberId);
         return couponQueryRepository.findAllByReceiver(member).stream()
-            .map(CouponReservationResponse::of)
+            .map(it -> CouponReservationResponse.of(it, "RECEIVED"))
             .collect(Collectors.toList());
     }
 

--- a/backend/src/main/java/com/woowacourse/kkogkkog/coupon/application/dto/CouponReservationResponse.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/coupon/application/dto/CouponReservationResponse.java
@@ -26,6 +26,7 @@ public class CouponReservationResponse {
     private String message;
     @JsonFormat(shape = Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime meetingDate;
+    private String memberType;
 
     public CouponReservationResponse(Long couponId,
                                      Long reservationId,
@@ -37,7 +38,8 @@ public class CouponReservationResponse {
                                      CouponType couponType,
                                      CouponStatus couponStatus,
                                      String message,
-                                     LocalDateTime meetingDate) {
+                                     LocalDateTime meetingDate,
+                                     String memberType) {
         this.couponId = couponId;
         this.reservationId = reservationId;
         this.memberId = memberId;
@@ -49,13 +51,14 @@ public class CouponReservationResponse {
         this.couponStatus = couponStatus.name();
         this.message = message;
         this.meetingDate = meetingDate;
+        this.memberType = memberType;
     }
 
-    public static CouponReservationResponse of(CouponReservationData data) {
+    public static CouponReservationResponse of(CouponReservationData data, String memberType) {
         return new CouponReservationResponse(
             data.getCouponId(), data.getReservationId(), data.getMemberId(), data.getNickname(),
             data.getImageUrl(), data.getHashtag(), data.getDescription(),
             data.getCouponType(), data.getCouponStatus(),
-            data.getMessage(), data.getMeetingDate());
+            data.getMessage(), data.getMeetingDate(), memberType);
     }
 }

--- a/backend/src/test/java/com/woowacourse/kkogkkog/common/fixture/dto/CouponDtoFixture.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/common/fixture/dto/CouponDtoFixture.java
@@ -59,7 +59,8 @@ public class CouponDtoFixture {
             CouponType.COFFEE,
             CouponStatus.REQUESTED,
             "예약 요청 메시지를 입력할 수 있어요",
-            LocalDateTime.of(2022, 1, 1, 0, 0, 0)
+            LocalDateTime.of(2022, 1, 1, 0, 0, 0),
+            null
         );
     }
     public static CouponDetailResponse 쿠폰_생성_상세조회_응답(Long couponId, Long senderId, Long receiverId) {

--- a/backend/src/test/java/com/woowacourse/kkogkkog/core/coupon/documentation/CouponDocumentTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/core/coupon/documentation/CouponDocumentTest.java
@@ -60,41 +60,7 @@ class CouponDocumentTest extends Documentation {
             .andDo(print())
             .andDo(document("coupon-create",
                 getDocumentRequest(),
-                getDocumentResponse(),
-                requestHeaders(
-                    headerWithName(HttpHeaders.AUTHORIZATION).description("Access Token")
-                ),
-                requestFields(
-                    fieldWithPath("receiverIds").type(JsonFieldType.ARRAY)
-                        .description("쿠폰 받을 사람들의 ID 리스트"),
-                    fieldWithPath("hashtag").type(JsonFieldType.STRING)
-                        .description("쿠폰 해시태그"),
-                    fieldWithPath("description").type(JsonFieldType.STRING)
-                        .description("쿠폰 추가 설명"),
-                    fieldWithPath("couponType").type(JsonFieldType.STRING)
-                        .description("쿠폰 타입")
-                ),
-                responseFields(
-                    fieldWithPath("data.[].id").type(JsonFieldType.NUMBER)
-                        .description("쿠폰 ID"),
-                    fieldWithPath("data.[].senderId").type(JsonFieldType.NUMBER)
-                        .description("쿠폰을 보낸 사람의 ID"),
-                    fieldWithPath("data.[].senderNickname").type(JsonFieldType.STRING)
-                        .description("쿠폰을 보낸 사람의 닉네임"),
-                    fieldWithPath("data.[].receiverId").type(JsonFieldType.NUMBER)
-                        .description("쿠폰을 받을 사람의 ID"),
-                    fieldWithPath("data.[].receiverNickname").type(JsonFieldType.STRING)
-                        .description("쿠폰을 받을 사람의 닉네임"),
-                    fieldWithPath("data.[].hashtag").type(JsonFieldType.STRING)
-                        .description("쿠폰 해시태그"),
-                    fieldWithPath("data.[].description").type(JsonFieldType.STRING)
-                        .description("쿠폰 추가 설명"),
-                    fieldWithPath("data.[].couponType").type(JsonFieldType.STRING)
-                        .description("쿠폰 타입"),
-                    fieldWithPath("data.[].couponStatus").type(JsonFieldType.STRING)
-                        .description("쿠폰 상태")
-                )
-            ));
+                getDocumentResponse()));
     }
 
     @Test
@@ -121,57 +87,7 @@ class CouponDocumentTest extends Documentation {
             .andDo(print())
             .andDo(document("coupon-showAll-me",
                 getDocumentRequest(),
-                getDocumentResponse(),
-                requestHeaders(
-                    headerWithName(HttpHeaders.AUTHORIZATION).description("Access Token")
-                ),
-                responseFields(
-                    fieldWithPath("data.received.[].couponId").type(JsonFieldType.NUMBER)
-                        .description("받은 쿠폰 ID"),
-                    fieldWithPath("data.received.[].reservationId").type(JsonFieldType.NUMBER)
-                        .description("예약 ID"),
-                    fieldWithPath("data.received.[].memberId").type(JsonFieldType.NUMBER)
-                        .description("받은 사람 ID"),
-                    fieldWithPath("data.received.[].nickname").type(JsonFieldType.STRING)
-                        .description("받은 사람 닉네임"),
-                    fieldWithPath("data.received.[].imageUrl").type(JsonFieldType.STRING)
-                        .description("받은 사람 이미지"),
-                    fieldWithPath("data.received.[].hashtag").type(JsonFieldType.STRING)
-                        .description("받은 쿠폰 해시태그"),
-                    fieldWithPath("data.received.[].description").type(JsonFieldType.STRING)
-                        .description("받은 쿠폰 설명"),
-                    fieldWithPath("data.received.[].couponType").type(JsonFieldType.STRING)
-                        .description("받은 쿠폰 타입"),
-                    fieldWithPath("data.received.[].couponStatus").type(JsonFieldType.STRING)
-                        .description("받은 쿠폰 상태"),
-                    fieldWithPath("data.received.[].message").type(JsonFieldType.STRING)
-                        .description("예약 메시지"),
-                    fieldWithPath("data.received.[].meetingDate").type(JsonFieldType.STRING)
-                        .description("예약 시간"),
-
-                    fieldWithPath("data.sent.[].couponId").type(JsonFieldType.NUMBER)
-                        .description("보낸 쿠폰 ID"),
-                    fieldWithPath("data.sent.[].reservationId").type(JsonFieldType.NUMBER)
-                        .description("예약 ID"),
-                    fieldWithPath("data.sent.[].memberId").type(JsonFieldType.NUMBER)
-                        .description("보낸 사람 ID"),
-                    fieldWithPath("data.sent.[].nickname").type(JsonFieldType.STRING)
-                        .description("보낸 사람 닉네임"),
-                    fieldWithPath("data.sent.[].imageUrl").type(JsonFieldType.STRING)
-                        .description("받은 사람 이미지"),
-                    fieldWithPath("data.sent.[].hashtag").type(JsonFieldType.STRING)
-                        .description("보낸 쿠폰 해시태그"),
-                    fieldWithPath("data.sent.[].description").type(JsonFieldType.STRING)
-                        .description("보낸 쿠폰 설명"),
-                    fieldWithPath("data.sent.[].couponType").type(JsonFieldType.STRING)
-                        .description("보낸 쿠폰 타입"),
-                    fieldWithPath("data.sent.[].couponStatus").type(JsonFieldType.STRING)
-                        .description("보낸 쿠폰 상태"),
-                    fieldWithPath("data.sent.[].message").type(JsonFieldType.STRING)
-                        .description("예약 메시지"),
-                    fieldWithPath("data.sent.[].meetingDate").type(JsonFieldType.STRING)
-                        .description("예약 시간")
-                ))
+                getDocumentResponse())
             );
     }
 
@@ -190,6 +106,9 @@ class CouponDocumentTest extends Documentation {
 
         perform
             .andDo(print())
-            .andDo(document("coupon-show"));
+            .andDo(document("coupon-show",
+                getDocumentRequest(),
+                getDocumentResponse())
+            );
     }
 }


### PR DESCRIPTION
## 작업 내용

- Coupon 목록을 보여주는 API에 SENDER와 RECEIVER를 추가

## 공유사항

- 현재 PR은 추후 API를 분리하면서 제거될 내용입니다.

Resolves #253
