### PR TITLE
fix: 로그인시 연관된 워크스페이스 정보도 자동 갱신

### DIFF
--- a/backend/src/main/java/com/woowacourse/kkogkkog/infrastructure/event/PushAlarmEvent.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/infrastructure/event/PushAlarmEvent.java
@@ -22,7 +22,6 @@ public class PushAlarmEvent {
         this.couponEvent = couponEvent;
     }
 
-
     public static PushAlarmEvent of(MemberHistory memberHistory) {
         Member hostMember = memberHistory.getHostMember();
         Workspace workspace = hostMember.getWorkspace();

--- a/backend/src/main/java/com/woowacourse/kkogkkog/member/application/MemberService.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/member/application/MemberService.java
@@ -43,7 +43,7 @@ public class MemberService {
         String userId = userInfo.getUserId();
         Optional<WorkspaceUser> workspaceUser = workspaceUserRepository.findByUserId(userId);
         if (workspaceUser.isPresent()) {
-            return updateExistingMember(userInfo, workspaceUser.get());
+            return updateExistingMember(userInfo, workspaceUser.get(), workspace);
         }
         Optional<Member> member = memberRepository.findByEmail(userInfo.getEmail());
         if (member.isPresent()) {
@@ -53,21 +53,24 @@ public class MemberService {
     }
 
     private MemberCreateResponse updateExistingMember(SlackUserInfo userInfo,
-                                                      WorkspaceUser workspaceUser) {
+                                                      WorkspaceUser workspaceUser,
+                                                      Workspace workspace) {
         workspaceUser.updateDisplayName(userInfo.getName());
         workspaceUser.updateImageURL(userInfo.getPicture());
 
         Member member = workspaceUser.getMasterMember();
         member.updateMainSlackUserId(userInfo.getUserId());
         member.updateImageURL(userInfo.getPicture());
+        member.updateWorkspace(workspace);
         return new MemberCreateResponse(member.getId(), false);
     }
 
     private MemberCreateResponse integrateNewWorkspaceUser(SlackUserInfo userInfo,
                                                            Member existingMember,
                                                            Workspace workspace) {
-        existingMember.updateImageURL(userInfo.getPicture());
         existingMember.updateMainSlackUserId(userInfo.getUserId());
+        existingMember.updateImageURL(userInfo.getPicture());
+        existingMember.updateWorkspace(workspace);
         workspaceUserRepository.save(
             new WorkspaceUser(null, existingMember, userInfo.getUserId(), workspace,
                 userInfo.getName(), userInfo.getEmail(), userInfo.getPicture()));

--- a/backend/src/main/java/com/woowacourse/kkogkkog/member/domain/Member.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/member/domain/Member.java
@@ -63,4 +63,8 @@ public class Member {
     public void updateImageURL(String imageUrl) {
         this.imageUrl = imageUrl;
     }
+
+    public void updateWorkspace(Workspace workspace) {
+        this.workspace = workspace;
+    }
 }


### PR DESCRIPTION
## 작업 내용

- 봇 토큰을 가져오는데 사용되는 워크스페이스도 자동갱신되도록 수정!
- 향후 Member에서 워크스페이스 정보는 제거하고, workspaceUser를 직접 활용하도록 수정할 수 있을 듯함.