### PR TITLE
feat: 회원가입시 형용사와 동물명을 활용한 닉네임을 자동 생성

### DIFF
--- a/backend/src/main/java/com/woowacourse/kkogkkog/member/domain/Nickname.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/member/domain/Nickname.java
@@ -2,6 +2,7 @@ package com.woowacourse.kkogkkog.member.domain;
 
 import com.woowacourse.kkogkkog.common.exception.InvalidRequestException;
 import java.security.SecureRandom;
+import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.persistence.Column;
@@ -17,6 +18,16 @@ public class Nickname {
 
     private static final Pattern NICKNAME_PATTERN = Pattern.compile("^[가-힣a-zA-Z0-9]{2,6}$");
     private static final SecureRandom RANDOM_GENERATOR = new SecureRandom();
+    private static final List<String> ADJECTIVES = List.of(
+        "귀여운", "작은", "졸린", "착한", "무서운", "작은", "예쁜", "상냥한", "해로운", "느린", "빠른", "커다란");
+    private static final List<String> ANIMALS = List.of(
+        "강아지", "다람쥐", "고라니", "고래", "고릴라", "고양이", "곰", "기린", "낙타", "너구리", "노루",
+        "늑대", "다람쥐", "당나귀", "돌고래", "돼지", "두더지", "라마", "망아지", "매머드", "멧돼지", "물개",
+        "미어캣", "박쥐", "반달곰", "범고래", "북극곰", "불여우", "비버", "보아뱀", "사슴", "산양", "사자",
+        "산토끼", "살쾡이", "삵", "생쥐", "송아지", "수달", "순록", "스컹크", "스피츠", "승냥이", "시궁쥐",
+        "알파카", "양", "얼룩말", "얼룩소", "여우", "염소", "영양", "오소리", "원숭이","이리", "자칼",
+        "재규어", "쥐", "진돗개", "청서", "청설모", "치와와", "치타", "친칠라", "침팬지", "캥거루", "코끼리",
+        "코뿔소", "코알라", "토끼", "판다", "표범", "푸들", "하마", "해달", "햄스터", "호랑이", "황소");
 
     @Column(name = "nickname", nullable = false)
     private String value;
@@ -30,7 +41,9 @@ public class Nickname {
     }
 
     public static Nickname ofRandom() {
-        String randomNum = String.valueOf(RANDOM_GENERATOR.nextDouble());
-        return new Nickname(String.format("익명%s", randomNum.substring(2, 6)));
+        double randomNum = RANDOM_GENERATOR.nextDouble();
+        String adjective = ADJECTIVES.get((int) (ADJECTIVES.size() * randomNum));
+        String animal = ANIMALS.get((int) (ANIMALS.size() * randomNum));
+        return new Nickname(String.format("%s%s", adjective, animal));
     }
 }

--- a/backend/src/test/java/com/woowacourse/kkogkkog/member/domain/NicknameTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/member/domain/NicknameTest.java
@@ -3,7 +3,6 @@ package com.woowacourse.kkogkkog.member.domain;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.woowacourse.kkogkkog.common.exception.InvalidRequestException;
 import org.junit.jupiter.api.DisplayName;
@@ -43,15 +42,12 @@ class NicknameTest {
     class OfRandom {
 
         @Test
-        @DisplayName("익명1234라는 형식의 닉네임을 생성한다.")
+        @DisplayName("'형용사동물명'이라는 형식의 닉네임을 생성한다.")
         void success() {
             Nickname nickname = Nickname.ofRandom();
             String actual = nickname.getValue();
 
-            assertAll(
-                () -> assertThat(actual).startsWith("익명"),
-                () -> assertThat(actual).matches("^[가-힣a-zA-Z0-9]{2,6}$")
-            );
+            assertThat(actual).matches("^[가-힣a-zA-Z0-9]{2,6}$");
         }
     }
 }


### PR DESCRIPTION
## 작업 내용

- 형용사+동물명을 활용하여 닉네임을 생성합니다.
  
## 공유사항

- 처음에는 동물명, 형용사 종류를 파일에서 읽어오는 방법을 생각했는데, 굉장히 마이너한 기능에 관한 정보를 `resources`에 추가하는 것에 거부감을 느껴서 Nickname 도메인 내부에 감췄습니다. 

- 커밋하지는 않았지만, 혹시 몰라서 100000번 돌려봤습니다.
<img width="496" alt="image" src="https://user-images.githubusercontent.com/73531614/185110701-7cf3cd37-1eeb-4f2a-934b-6af0d375750d.png">

Resolves #281
