### PR TITLE
feat: 소셜 로그인과 회원 가입을 분리

### DIFF
--- a/backend/src/docs/asciidoc/auth.adoc
+++ b/backend/src/docs/asciidoc/auth.adoc
@@ -9,5 +9,8 @@
 === 로그인
 operation::auth-login[snippets='http-request,http-response']
 
+=== 회원가입
+operation::auth-signUp[snippets='http-request,http-response']
+
 === 슬랙 앱 설치
 operation::slack-bot-install[snippets='http-request,http-response,request-fields']

--- a/backend/src/main/java/com/woowacourse/kkogkkog/auth/application/dto/MemberUpdateResponse.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/auth/application/dto/MemberUpdateResponse.java
@@ -6,12 +6,12 @@ import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class MemberCreateResponse {
+public class MemberUpdateResponse {
 
     private Long id;
     private Boolean isNew;
 
-    public MemberCreateResponse(Long id, Boolean isNew) {
+    public MemberUpdateResponse(Long id, Boolean isNew) {
         this.id = id;
         this.isNew = isNew;
     }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/auth/presentation/AuthController.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/auth/presentation/AuthController.java
@@ -3,6 +3,8 @@ package com.woowacourse.kkogkkog.auth.presentation;
 import com.woowacourse.kkogkkog.auth.application.AuthService;
 import com.woowacourse.kkogkkog.auth.application.dto.TokenResponse;
 import com.woowacourse.kkogkkog.auth.presentation.dto.InstallSlackAppRequest;
+import com.woowacourse.kkogkkog.member.application.dto.MemberCreateResponse;
+import com.woowacourse.kkogkkog.member.presentation.dto.MemberCreateRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -33,5 +35,13 @@ public class AuthController {
         authService.installSlackApp(installSlackAppRequest.getCode());
 
         return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/sign-up")
+    public ResponseEntity<MemberCreateResponse> save(@RequestBody MemberCreateRequest memberCreateRequest) {
+        Long id = authService.signUp(memberCreateRequest);
+        MemberCreateResponse memberCreateResponse = authService.loginByMemberId(id);
+
+        return ResponseEntity.created(null).body(memberCreateResponse);
     }
 }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/auth/presentation/AuthController.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/auth/presentation/AuthController.java
@@ -37,7 +37,7 @@ public class AuthController {
         return ResponseEntity.ok().build();
     }
 
-    @PostMapping("/sign-up")
+    @PostMapping("/signup/token")
     public ResponseEntity<MemberCreateResponse> save(@RequestBody MemberCreateRequest memberCreateRequest) {
         Long id = authService.signUp(memberCreateRequest);
         MemberCreateResponse memberCreateResponse = authService.loginByMemberId(id);

--- a/backend/src/main/java/com/woowacourse/kkogkkog/infrastructure/application/SlackClient.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/infrastructure/application/SlackClient.java
@@ -73,12 +73,7 @@ public class SlackClient {
             .build();
     }
 
-    public SlackUserInfo getUserInfoByCode(final String code) {
-        String token = requestAccessToken(code);
-        return requestUserInfo(token);
-    }
-
-    private String requestAccessToken(String code) {
+    public String requestAccessToken(String code) {
         Map<String, Object> responseBody = oAuthLoginClient
             .post()
             .uri(uriBuilder -> toRequestTokenUri(uriBuilder, code, loginRedirectUrl))
@@ -95,7 +90,7 @@ public class SlackClient {
         return responseBody.get("access_token").toString();
     }
 
-    private SlackUserInfo requestUserInfo(String token) {
+    public SlackUserInfo requestUserInfo(String token) {
         try {
             return userClient
                 .get()

--- a/backend/src/main/java/com/woowacourse/kkogkkog/member/application/MemberService.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/member/application/MemberService.java
@@ -5,7 +5,7 @@ import static java.util.stream.Collectors.toList;
 import com.woowacourse.kkogkkog.auth.application.dto.MemberUpdateResponse;
 import com.woowacourse.kkogkkog.member.application.dto.MemberHistoryResponse;
 import com.woowacourse.kkogkkog.member.application.dto.MemberResponse;
-import com.woowacourse.kkogkkog.member.application.dto.MemberUpdateRequest;
+import com.woowacourse.kkogkkog.member.application.dto.MemberNicknameUpdateRequest;
 import com.woowacourse.kkogkkog.member.application.dto.MyProfileResponse;
 import com.woowacourse.kkogkkog.member.domain.Member;
 import com.woowacourse.kkogkkog.member.domain.MemberHistory;
@@ -110,11 +110,11 @@ public class MemberService {
             .collect(toList());
     }
 
-    public void updateNickname(MemberUpdateRequest memberUpdateRequest) {
-        Member member = memberRepository.findById(memberUpdateRequest.getMemberId())
+    public void updateNickname(MemberNicknameUpdateRequest memberNicknameUpdateRequest) {
+        Member member = memberRepository.findById(memberNicknameUpdateRequest.getMemberId())
             .orElseThrow(MemberNotFoundException::new);
 
-        member.updateNickname(memberUpdateRequest.getNickname());
+        member.updateNickname(memberNicknameUpdateRequest.getNickname());
     }
 
     public List<MemberHistoryResponse> findHistoryById(Long memberId) {

--- a/backend/src/main/java/com/woowacourse/kkogkkog/member/application/MemberService.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/member/application/MemberService.java
@@ -50,10 +50,8 @@ public class MemberService {
         String email = userInfo.getEmail();
         String imageUrl = userInfo.getPicture();
 
-        Member newMember = memberRepository.save(
-            new Member(null, userId, workspace, new Nickname(nickname), email, imageUrl));
-        workspaceUserRepository.save(
-            new WorkspaceUser(null, newMember, userId, workspace, nickname, email, imageUrl));
+        Member newMember = memberRepository.save(new Member( userId, workspace, new Nickname(nickname), email, imageUrl));
+        workspaceUserRepository.save(new WorkspaceUser( newMember, userId, workspace, nickname, email, imageUrl));
         return newMember.getId();
     }
 

--- a/backend/src/main/java/com/woowacourse/kkogkkog/member/application/MemberService.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/member/application/MemberService.java
@@ -2,7 +2,7 @@ package com.woowacourse.kkogkkog.member.application;
 
 import static java.util.stream.Collectors.toList;
 
-import com.woowacourse.kkogkkog.auth.application.dto.MemberCreateResponse;
+import com.woowacourse.kkogkkog.auth.application.dto.MemberUpdateResponse;
 import com.woowacourse.kkogkkog.member.application.dto.MemberHistoryResponse;
 import com.woowacourse.kkogkkog.member.application.dto.MemberResponse;
 import com.woowacourse.kkogkkog.member.application.dto.MemberUpdateRequest;
@@ -39,20 +39,36 @@ public class MemberService {
         this.memberHistoryRepository = memberHistoryRepository;
     }
 
-    public MemberCreateResponse saveOrUpdate(SlackUserInfo userInfo, Workspace workspace) {
+    public boolean existsMember(SlackUserInfo userInfo) {
+        String email = userInfo.getEmail();
+        return memberRepository.findByEmail(email)
+            .isPresent();
+    }
+
+    public Long save(SlackUserInfo userInfo, Workspace workspace, String nickname) {
+        String userId = userInfo.getUserId();
+        String email = userInfo.getEmail();
+        String imageUrl = userInfo.getPicture();
+
+        Member newMember = memberRepository.save(
+            new Member(null, userId, workspace, new Nickname(nickname), email, imageUrl));
+        workspaceUserRepository.save(
+            new WorkspaceUser(null, newMember, userId, workspace, nickname, email, imageUrl));
+        return newMember.getId();
+    }
+
+    public MemberUpdateResponse update(SlackUserInfo userInfo, Workspace workspace) {
         String userId = userInfo.getUserId();
         Optional<WorkspaceUser> workspaceUser = workspaceUserRepository.findByUserId(userId);
         if (workspaceUser.isPresent()) {
             return updateExistingMember(userInfo, workspaceUser.get(), workspace);
         }
-        Optional<Member> member = memberRepository.findByEmail(userInfo.getEmail());
-        if (member.isPresent()) {
-            return integrateNewWorkspaceUser(userInfo, member.get(), workspace);
-        }
-        return saveNewMember(userInfo, workspace);
+        Member member = memberRepository.findByEmail(userInfo.getEmail())
+            .orElseThrow(MemberNotFoundException::new);
+        return integrateNewWorkspaceUser(userInfo, member, workspace);
     }
 
-    private MemberCreateResponse updateExistingMember(SlackUserInfo userInfo,
+    private MemberUpdateResponse updateExistingMember(SlackUserInfo userInfo,
                                                       WorkspaceUser workspaceUser,
                                                       Workspace workspace) {
         workspaceUser.updateDisplayName(userInfo.getName());
@@ -62,10 +78,10 @@ public class MemberService {
         member.updateMainSlackUserId(userInfo.getUserId());
         member.updateImageURL(userInfo.getPicture());
         member.updateWorkspace(workspace);
-        return new MemberCreateResponse(member.getId(), false);
+        return new MemberUpdateResponse(member.getId(), false);
     }
 
-    private MemberCreateResponse integrateNewWorkspaceUser(SlackUserInfo userInfo,
+    private MemberUpdateResponse integrateNewWorkspaceUser(SlackUserInfo userInfo,
                                                            Member existingMember,
                                                            Workspace workspace) {
         existingMember.updateMainSlackUserId(userInfo.getUserId());
@@ -74,20 +90,7 @@ public class MemberService {
         workspaceUserRepository.save(
             new WorkspaceUser(null, existingMember, userInfo.getUserId(), workspace,
                 userInfo.getName(), userInfo.getEmail(), userInfo.getPicture()));
-        return new MemberCreateResponse(existingMember.getId(), false);
-    }
-
-    private MemberCreateResponse saveNewMember(SlackUserInfo userInfo, Workspace workspace) {
-        String userId = userInfo.getUserId();
-        String nickname = userInfo.getName();
-        String email = userInfo.getEmail();
-        String imageUrl = userInfo.getPicture();
-
-        Member newMember = memberRepository.save(
-            new Member(null, userId, workspace, Nickname.ofRandom(), email, imageUrl));
-        workspaceUserRepository.save(
-            new WorkspaceUser(null, newMember, userId, workspace, nickname, email, imageUrl));
-        return new MemberCreateResponse(newMember.getId(), true);
+        return new MemberUpdateResponse(existingMember.getId(), false);
     }
 
     @Transactional(readOnly = true)
@@ -107,7 +110,7 @@ public class MemberService {
             .collect(toList());
     }
 
-    public void update(MemberUpdateRequest memberUpdateRequest) {
+    public void updateNickname(MemberUpdateRequest memberUpdateRequest) {
         Member member = memberRepository.findById(memberUpdateRequest.getMemberId())
             .orElseThrow(MemberNotFoundException::new);
 

--- a/backend/src/main/java/com/woowacourse/kkogkkog/member/application/dto/MemberCreateResponse.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/member/application/dto/MemberCreateResponse.java
@@ -1,0 +1,16 @@
+package com.woowacourse.kkogkkog.member.application.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class MemberCreateResponse {
+
+    private String accessToken;
+
+    public MemberCreateResponse(String accessToken) {
+        this.accessToken = accessToken;
+    }
+}

--- a/backend/src/main/java/com/woowacourse/kkogkkog/member/application/dto/MemberNicknameUpdateRequest.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/member/application/dto/MemberNicknameUpdateRequest.java
@@ -6,12 +6,12 @@ import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class MemberUpdateRequest {
+public class MemberNicknameUpdateRequest {
 
     private Long memberId;
     private String nickname;
 
-    public MemberUpdateRequest(Long memberId, String nickname) {
+    public MemberNicknameUpdateRequest(Long memberId, String nickname) {
         this.memberId = memberId;
         this.nickname = nickname;
     }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/member/domain/Member.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/member/domain/Member.java
@@ -22,9 +22,6 @@ public class Member {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, unique = true)
-    private String email;
-
     @Column(nullable = false)
     private String userId;
 
@@ -35,8 +32,16 @@ public class Member {
     @Embedded
     private Nickname nickname;
 
+    @Column(nullable = false, unique = true)
+    private String email;
+
     @Column(nullable = false)
     private String imageUrl;
+
+    public Member(String userId, Workspace workspace, Nickname nickname, String email,
+                  String imageUrl) {
+        this(null, userId, workspace, nickname, email, imageUrl);
+    }
 
     public Member(Long id, String userId, Workspace workspace, Nickname nickname, String email,
                   String imageUrl) {

--- a/backend/src/main/java/com/woowacourse/kkogkkog/member/domain/WorkspaceUser.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/member/domain/WorkspaceUser.java
@@ -21,12 +21,12 @@ public class WorkspaceUser {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, unique = true)
-    private String userId;
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "master_member_id", nullable = false)
     private Member masterMember;
+
+    @Column(nullable = false, unique = true)
+    private String userId;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "workspace_id", nullable = false)
@@ -40,6 +40,12 @@ public class WorkspaceUser {
 
     @Column(nullable = false)
     private String imageUrl;
+
+    public WorkspaceUser(Member masterMember, String userId, Workspace workspace,
+                         String displayName,
+                         String email, String imageUrl) {
+        this(null, masterMember, userId, workspace, displayName, email, imageUrl);
+    }
 
     public WorkspaceUser(Long id, Member masterMember, String userId, Workspace workspace,
                          String displayName, String email, String imageUrl) {

--- a/backend/src/main/java/com/woowacourse/kkogkkog/member/presentation/MemberController.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/member/presentation/MemberController.java
@@ -41,7 +41,7 @@ public class MemberController {
     @PutMapping("/me")
     public ResponseEntity<Void> updateMe(@LoginMemberId Long id,
                                          @Valid @RequestBody MemberUpdateMeRequest memberUpdateMeRequest) {
-        memberService.update(memberUpdateMeRequest.toMemberUpdateRequest(id));
+        memberService.updateNickname(memberUpdateMeRequest.toMemberUpdateRequest(id));
 
         return ResponseEntity.ok().build();
     }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/member/presentation/dto/MemberCreateRequest.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/member/presentation/dto/MemberCreateRequest.java
@@ -1,0 +1,18 @@
+package com.woowacourse.kkogkkog.member.presentation.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class MemberCreateRequest {
+
+    private String accessToken;
+    private String nickname;
+
+    public MemberCreateRequest(String accessToken, String nickname) {
+        this.accessToken = accessToken;
+        this.nickname = nickname;
+    }
+}

--- a/backend/src/main/java/com/woowacourse/kkogkkog/member/presentation/dto/MemberUpdateMeRequest.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/member/presentation/dto/MemberUpdateMeRequest.java
@@ -1,6 +1,6 @@
 package com.woowacourse.kkogkkog.member.presentation.dto;
 
-import com.woowacourse.kkogkkog.member.application.dto.MemberUpdateRequest;
+import com.woowacourse.kkogkkog.member.application.dto.MemberNicknameUpdateRequest;
 import javax.validation.constraints.NotBlank;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -17,7 +17,7 @@ public class MemberUpdateMeRequest {
         this.nickname = nickname;
     }
 
-    public MemberUpdateRequest toMemberUpdateRequest(Long memberId) {
-        return new MemberUpdateRequest(memberId, nickname.trim());
+    public MemberNicknameUpdateRequest toMemberUpdateRequest(Long memberId) {
+        return new MemberNicknameUpdateRequest(memberId, nickname.trim());
     }
 }

--- a/backend/src/test/java/com/woowacourse/kkogkkog/acceptance/AuthAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/acceptance/AuthAcceptanceTest.java
@@ -108,6 +108,6 @@ public class AuthAcceptanceTest extends AcceptanceTest {
     }
 
     static ExtractableResponse<Response> 회원가입을_요청한다(Object data) {
-        return invokePost("/api/sign-up", data);
+        return invokePost("/api/signup/token", data);
     }
 }

--- a/backend/src/test/java/com/woowacourse/kkogkkog/acceptance/MemberAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/acceptance/MemberAcceptanceTest.java
@@ -37,8 +37,8 @@ public class MemberAcceptanceTest extends AcceptanceTest {
         Workspace workspace = KKOGKKOG.getWorkspace(1L);
         Member rookie = ROOKIE.getMember(1L, workspace);
         Member author = AUTHOR.getMember(2L, workspace);
-        회원가입_및_닉네임을_수정하고(rookie);
-        회원가입_및_닉네임을_수정하고(author);
+        회원가입을_하고(rookie);
+        회원가입을_하고(author);
 
         ExtractableResponse<Response> extract = 전체_사용자_조회를_요청한다();
         List<MemberResponse> members = extract.body().jsonPath()
@@ -56,7 +56,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
     void 로그인한_경우_본인의_정보를_조회할_수_있다() {
         Workspace workspace = KKOGKKOG.getWorkspace();
         Member rookie = ROOKIE.getMember(1L, workspace);
-        String rookieAccessToken = 회원가입_및_닉네임을_수정하고(rookie);
+        String rookieAccessToken = 회원가입을_하고(rookie);
         회원가입을_하고(AUTHOR.getMember(workspace));
 
         ExtractableResponse<Response> extract = 본인_정보_조회를_요청한다(rookieAccessToken);

--- a/backend/src/test/java/com/woowacourse/kkogkkog/auth/application/AuthServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/auth/application/AuthServiceTest.java
@@ -26,7 +26,8 @@ class AuthServiceTest extends ServiceTest {
     private static final String AUTHORIZATION_CODE = "code";
     private static final String WORKSPACE_ID = "T03LX3C5540";
     private static final String WORKSPACE_NAME = "workspace_name";
-    private static final String ACCESS_TOKEN = "ACCESS_TOKEN";
+    private static final String USER_ACCESS_TOKEN = "USER_ACCESS_TOKEN";
+    private static final String BOT_ACCESS_TOKEN = "BOT_ACCESS_TOKEN";
 
     @Autowired
     private AuthService authService;
@@ -40,7 +41,9 @@ class AuthServiceTest extends ServiceTest {
         void success() {
             MemberResponse memberResponse = MemberResponse.of(ROOKIE.getMember());
             WorkspaceResponse workspaceResponse = WorkspaceResponse.of(KKOGKKOG.getWorkspace());
-            given(slackClient.getUserInfoByCode(AUTHORIZATION_CODE))
+            given(slackClient.requestAccessToken(AUTHORIZATION_CODE))
+                .willReturn(USER_ACCESS_TOKEN);
+            given(slackClient.requestUserInfo(USER_ACCESS_TOKEN))
                 .willReturn(
                     new SlackUserInfo(
                         memberResponse.getUserId(),
@@ -58,7 +61,7 @@ class AuthServiceTest extends ServiceTest {
         @Test
         @DisplayName("올바르지 않은 임시 코드를 입력하면, 예외를 던진다")
         void fail_invalidCode() {
-            given(slackClient.getUserInfoByCode("invalid_code"))
+            given(slackClient.requestAccessToken("invalid_code"))
                 .willThrow(new AccessTokenRetrievalFailedException());
 
             assertThatThrownBy(
@@ -76,7 +79,9 @@ class AuthServiceTest extends ServiceTest {
         void success() {
             MemberResponse memberResponse = MemberResponse.of(ROOKIE.getMember());
             WorkspaceResponse workspaceResponse = WorkspaceResponse.of(KKOGKKOG.getWorkspace());
-            given(slackClient.getUserInfoByCode(AUTHORIZATION_CODE))
+            given(slackClient.requestAccessToken(AUTHORIZATION_CODE))
+                .willReturn(USER_ACCESS_TOKEN);
+            given(slackClient.requestUserInfo(USER_ACCESS_TOKEN))
                 .willReturn(
                     new SlackUserInfo(
                         memberResponse.getUserId(),
@@ -88,7 +93,7 @@ class AuthServiceTest extends ServiceTest {
             authService.login(AUTHORIZATION_CODE);
 
             given(slackClient.requestBotAccessToken(AUTHORIZATION_CODE))
-                .willReturn(new WorkspaceResponse(WORKSPACE_ID, WORKSPACE_NAME, ACCESS_TOKEN));
+                .willReturn(new WorkspaceResponse(WORKSPACE_ID, WORKSPACE_NAME, BOT_ACCESS_TOKEN));
 
             assertThatNoException()
                 .isThrownBy(() -> authService.installSlackApp(AUTHORIZATION_CODE));

--- a/backend/src/test/java/com/woowacourse/kkogkkog/auth/documentation/AuthDocumentTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/auth/documentation/AuthDocumentTest.java
@@ -16,6 +16,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.woowacourse.kkogkkog.auth.application.dto.TokenResponse;
 import com.woowacourse.kkogkkog.auth.presentation.dto.InstallSlackAppRequest;
+import com.woowacourse.kkogkkog.member.application.dto.MemberCreateResponse;
 import com.woowacourse.kkogkkog.support.documenation.DocumentTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
@@ -26,7 +27,7 @@ import org.springframework.test.web.servlet.ResultActions;
 class AuthDocumentTest extends DocumentTest {
 
     @Test
-    void 회원가입_또는_로그인을_요청한다() throws Exception {
+    void 로그인을_요청한다() throws Exception {
         // given
         TokenResponse tokenResponse = new TokenResponse("accessToken", true);
         given(authService.login(any())).willReturn(tokenResponse);
@@ -50,6 +51,34 @@ class AuthDocumentTest extends DocumentTest {
                 responseFields(
                     fieldWithPath("accessToken").type(JsonFieldType.STRING).description("토큰"),
                     fieldWithPath("isNew").type(JsonFieldType.BOOLEAN).description("회원가입 여부")
+                )
+            ));
+    }
+
+    @Test
+    void 회원가입을_요청한다() throws Exception {
+        // given
+        MemberCreateResponse memberCreateResponse = new MemberCreateResponse("accessToken");
+        given(authService.loginByMemberId(any())).willReturn(memberCreateResponse);
+
+        // when
+        ResultActions perform = mockMvc.perform(post("/api/signup/token")
+            .content(objectMapper.writeValueAsString(memberCreateResponse))
+            .contentType(MediaType.APPLICATION_JSON));
+
+        // then
+        perform
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.accessToken").value("accessToken"));
+
+        // docs
+        perform
+            .andDo(print())
+            .andDo(document("auth-signUp",
+                getDocumentRequest(),
+                getDocumentResponse(),
+                responseFields(
+                    fieldWithPath("accessToken").type(JsonFieldType.STRING).description("토큰")
                 )
             ));
     }

--- a/backend/src/test/java/com/woowacourse/kkogkkog/member/application/MemberServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/member/application/MemberServiceTest.java
@@ -10,7 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import com.woowacourse.kkogkkog.support.application.ServiceTest;
-import com.woowacourse.kkogkkog.auth.application.dto.MemberCreateResponse;
+import com.woowacourse.kkogkkog.auth.application.dto.MemberUpdateResponse;
 import com.woowacourse.kkogkkog.coupon.application.CouponService;
 import com.woowacourse.kkogkkog.member.exception.MemberNotFoundException;
 import com.woowacourse.kkogkkog.support.fixture.domain.WorkspaceFixture;
@@ -62,22 +62,21 @@ class MemberServiceTest extends ServiceTest {
     }
 
     @Nested
-    @DisplayName("saveOrUpdate 메서드는")
-    class SaveOrUpdate {
+    @DisplayName("save 메서드는")
+    class Save {
 
         @Test
         @DisplayName("가입되지 않은 이메일 정보를 받으면 신규 회원과 워크스페이스 계정을 저장한다.")
         void initialSignUp() {
             SlackUserInfo slackUserInfo = new SlackUserInfo("URookie", null, null, "루키",
                 "rookie@gmail.com", "image");
-            MemberCreateResponse response = memberService.saveOrUpdate(slackUserInfo, workspace);
+            Long id = memberService.save(slackUserInfo, workspace, slackUserInfo.getName());
             Optional<Member> savedMember = memberRepository.findByEmail("rookie@gmail.com");
             Optional<WorkspaceUser> savedWorkspaceUser = workspaceUserRepository.findByUserId(
                 "URookie");
 
             assertAll(
-                () -> assertThat(response.getId()).isNotNull(),
-                () -> assertThat(response.getIsNew()).isTrue(),
+                () -> assertThat(id).isNotNull(),
                 () -> assertThat(savedMember).isPresent(),
                 () -> assertThat(savedWorkspaceUser).isPresent()
             );
@@ -88,9 +87,8 @@ class MemberServiceTest extends ServiceTest {
         void signIn() {
             SlackUserInfo slackUserInfo = new SlackUserInfo("URookie", null, null, "루키",
                 "rookie@gmail.com", "image");
-            memberService.saveOrUpdate(slackUserInfo, workspace);
-
-            MemberCreateResponse response = memberService.saveOrUpdate(slackUserInfo, workspace);
+            memberService.save(slackUserInfo, workspace, slackUserInfo.getName());
+            MemberUpdateResponse response = memberService.update(slackUserInfo, workspace);
 
             assertAll(
                 () -> assertThat(response.getId()).isNotNull(),
@@ -106,8 +104,8 @@ class MemberServiceTest extends ServiceTest {
             SlackUserInfo slackUserInfo2 = new SlackUserInfo("URookie2", null, null, "루키",
                 "rookie@gmail.com", "image2");
 
-            memberService.saveOrUpdate(slackUserInfo, workspace);
-            MemberCreateResponse response = memberService.saveOrUpdate(slackUserInfo2, workspace);
+            memberService.save(slackUserInfo, workspace, slackUserInfo.getName());
+            MemberUpdateResponse response = memberService.update(slackUserInfo2, workspace);
             Member savedMember = memberRepository.findByEmail("rookie@gmail.com").get();
             Optional<WorkspaceUser> integratedWorkspaceUser = workspaceUserRepository.findByUserId(
                 "URookie2");
@@ -214,8 +212,8 @@ class MemberServiceTest extends ServiceTest {
     }
 
     @Nested
-    @DisplayName("update 메서드는")
-    class Update {
+    @DisplayName("updateNickname 메서드는")
+    class UpdateNickname {
 
         @Test
         @DisplayName("사용자의 닉네임을 수정한다.")
@@ -223,7 +221,7 @@ class MemberServiceTest extends ServiceTest {
             Long memberId = memberRepository.save(ROOKIE.getMember(workspace)).getId();
             String expected = "새로운닉네임";
 
-            memberService.update(new MemberUpdateRequest(memberId, expected));
+            memberService.updateNickname(new MemberUpdateRequest(memberId, expected));
             String actual = memberService.findById(memberId).getNickname();
 
             assertThat(actual).isEqualTo(expected);

--- a/backend/src/test/java/com/woowacourse/kkogkkog/member/application/MemberServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/member/application/MemberServiceTest.java
@@ -17,7 +17,7 @@ import com.woowacourse.kkogkkog.support.fixture.domain.WorkspaceFixture;
 import com.woowacourse.kkogkkog.infrastructure.dto.SlackUserInfo;
 import com.woowacourse.kkogkkog.member.application.dto.MemberHistoryResponse;
 import com.woowacourse.kkogkkog.member.application.dto.MemberResponse;
-import com.woowacourse.kkogkkog.member.application.dto.MemberUpdateRequest;
+import com.woowacourse.kkogkkog.member.application.dto.MemberNicknameUpdateRequest;
 import com.woowacourse.kkogkkog.member.application.dto.MyProfileResponse;
 import com.woowacourse.kkogkkog.member.domain.Member;
 import com.woowacourse.kkogkkog.member.domain.Workspace;
@@ -221,7 +221,7 @@ class MemberServiceTest extends ServiceTest {
             Long memberId = memberRepository.save(ROOKIE.getMember(workspace)).getId();
             String expected = "새로운닉네임";
 
-            memberService.updateNickname(new MemberUpdateRequest(memberId, expected));
+            memberService.updateNickname(new MemberNicknameUpdateRequest(memberId, expected));
             String actual = memberService.findById(memberId).getNickname();
 
             assertThat(actual).isEqualTo(expected);

--- a/backend/src/test/java/com/woowacourse/kkogkkog/member/documentation/MemberDocumentTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/member/documentation/MemberDocumentTest.java
@@ -232,7 +232,7 @@ public class MemberDocumentTest extends DocumentTest {
         // docs
         perform
             .andDo(print())
-            .andDo(document("member-update",
+            .andDo(document("member-updateNickname",
                 getDocumentRequest(),
                 getDocumentResponse(),
                 requestHeaders(


### PR DESCRIPTION
## 작업 내용
기존 소셜 로그인 시 서버에서 회원의 존재유무에 따라 알아서 회원가입을 시켰습니다.

변경된 구조로는
소셜 로그인 시 회원이 존재하면 jwt accessToken, isNew=false를 반환하고,
회원이 존재하지 않으면 slackAccessToken과 isNew = true 를 반환합니다.

프론트에서 리다이렉트하여 /api/sign-up으로 slackAccessToken과 닉네임을 전달해주면 회원가입에 성공합니다.

## 공유사항

Resolves #307
