### PR TITLE
feat: Slack 통합 알림봇 사용 

### DIFF
--- a/backend/src/main/java/com/woowacourse/kkogkkog/infrastructure/application/CommonPushAlarmClient.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/infrastructure/application/CommonPushAlarmClient.java
@@ -1,0 +1,48 @@
+package com.woowacourse.kkogkkog.infrastructure.application;
+
+import com.woowacourse.kkogkkog.infrastructure.dto.PushAlarmRequest;
+import com.woowacourse.kkogkkog.infrastructure.exception.PostMessageRequestFailedException;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Slf4j
+@Component
+public class CommonPushAlarmClient implements PushAlarmClient {
+
+    private static final String PUSH_ALARM_REQUEST_URL = "https://slack.com/api/chat.postMessage";
+
+
+    private final WebClient messageClient;
+
+    private static final ParameterizedTypeReference<Map<String, Object>> PARAMETERIZED_TYPE_REFERENCE = new ParameterizedTypeReference<>() {
+    };
+
+    public CommonPushAlarmClient(@Value(PUSH_ALARM_REQUEST_URL) String requestUrl, WebClient webClient) {
+        this.messageClient = toWebClient(webClient, requestUrl);
+    }
+
+    @Override
+    public void requestPushAlarm(String token, String userId, String message) {
+        try {
+            Map<String, Object> responseBody = messageClient
+                .post()
+                .headers(httpHeaders -> httpHeaders.setBearerAuth(token))
+                .bodyValue(PushAlarmRequest.of(userId, message))
+                .accept(MediaType.APPLICATION_JSON)
+                .retrieve()
+                .bodyToMono(PARAMETERIZED_TYPE_REFERENCE)
+                .blockOptional()
+                .orElseThrow(PostMessageRequestFailedException::new);
+            if (responseBody.get("ok").equals("false")) {
+                throw new PostMessageRequestFailedException((String) responseBody.get("error"));
+            }
+        } catch (PostMessageRequestFailedException e) {
+            log.info("Exception has been thrown : ", e);
+        }
+    }
+}

--- a/backend/src/main/java/com/woowacourse/kkogkkog/infrastructure/application/PushAlarmClient.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/infrastructure/application/PushAlarmClient.java
@@ -1,0 +1,17 @@
+package com.woowacourse.kkogkkog.infrastructure.application;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.client.WebClient;
+
+public interface PushAlarmClient {
+
+    void requestPushAlarm(String token, String userId, String message);
+
+    default WebClient toWebClient(WebClient webClient, String baseUrl) {
+        return webClient.mutate()
+            .baseUrl(baseUrl)
+            .defaultHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
+            .build();
+    }
+}

--- a/backend/src/main/java/com/woowacourse/kkogkkog/infrastructure/application/PushAlarmListener.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/infrastructure/application/PushAlarmListener.java
@@ -26,10 +26,12 @@ public class PushAlarmListener {
         String accessToken = pushAlarmEvent.getBotAccessToken();
         String hostMemberId = pushAlarmEvent.getHostMemberId();
         String message = pushAlarmEvent.getMessage();
+        if (pushAlarmEvent.isWoowacourseWorkspace()) {
+            woowacoursePushAlarmClient.requestPushAlarm(accessToken, hostMemberId, message);
+        }
         if (pushAlarmEvent.hasBotAccessToken()) {
             commonPushAlarmClient.requestPushAlarm(accessToken, hostMemberId, message);
-            return;
         }
-        woowacoursePushAlarmClient.requestPushAlarm(accessToken, hostMemberId, message);
+
     }
 }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/infrastructure/application/PushAlarmListener.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/infrastructure/application/PushAlarmListener.java
@@ -8,10 +8,13 @@ import org.springframework.stereotype.Component;
 @Component
 public class PushAlarmListener {
 
-    private final SlackClient slackClient;
+    private final CommonPushAlarmClient commonPushAlarmClient;
+    private final WoowacoursePushAlarmClient woowacoursePushAlarmClient;
 
-    public PushAlarmListener(SlackClient slackClient) {
-        this.slackClient = slackClient;
+    public PushAlarmListener(CommonPushAlarmClient commonPushAlarmClient,
+                             WoowacoursePushAlarmClient woowacoursePushAlarmClient) {
+        this.commonPushAlarmClient = commonPushAlarmClient;
+        this.woowacoursePushAlarmClient = woowacoursePushAlarmClient;
     }
 
     @EventListener
@@ -23,6 +26,10 @@ public class PushAlarmListener {
         String accessToken = pushAlarmEvent.getBotAccessToken();
         String hostMemberId = pushAlarmEvent.getHostMemberId();
         String message = pushAlarmEvent.getMessage();
-        slackClient.requestPushAlarm(accessToken, hostMemberId, message);
+        if (pushAlarmEvent.hasBotAccessToken()) {
+            commonPushAlarmClient.requestPushAlarm(accessToken, hostMemberId, message);
+            return;
+        }
+        woowacoursePushAlarmClient.requestPushAlarm(accessToken, hostMemberId, message);
     }
 }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/infrastructure/application/WoowacoursePushAlarmClient.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/infrastructure/application/WoowacoursePushAlarmClient.java
@@ -38,10 +38,7 @@ public class WoowacoursePushAlarmClient implements PushAlarmClient {
                 .onStatus(HttpStatus::isError,
                     status -> Mono.error(new PostMessageRequestFailedException(
                         String.format(POST_MESSAGE_FAILED_CAUSE_FORMAT, status.statusCode(), userId,
-                            message))))
-                .toBodilessEntity()
-                .blockOptional()
-                .orElseThrow(PostMessageRequestFailedException::new);
+                            message))));
         } catch (PostMessageRequestFailedException e) {
             log.info("Exception has been thrown : ", e);
         }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/infrastructure/application/WoowacoursePushAlarmClient.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/infrastructure/application/WoowacoursePushAlarmClient.java
@@ -1,0 +1,49 @@
+package com.woowacourse.kkogkkog.infrastructure.application;
+
+import com.woowacourse.kkogkkog.infrastructure.dto.PushAlarmRequest;
+import com.woowacourse.kkogkkog.infrastructure.exception.PostMessageRequestFailedException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+@Slf4j
+@Component
+public class WoowacoursePushAlarmClient implements PushAlarmClient {
+
+    private static final String POST_MESSAGE_FAILED_CAUSE_FORMAT = "상태코드: %s, 유저 ID: %s, 보낼 메세지: %s";
+    private final String token;
+    private final WebClient messageClient;
+
+    public WoowacoursePushAlarmClient(
+        @Value("security.slack.workspace.woowacourse.request-url") String requestUrl,
+        @Value("security.slack.workspace.woowacourse.token") String token,
+        WebClient webClient) {
+        this.token = token;
+        this.messageClient = toWebClient(webClient, requestUrl);
+    }
+
+    @Override
+    public void requestPushAlarm(String token, String userId, String message) {
+        try {
+            messageClient
+                .post()
+                .headers(httpHeaders -> httpHeaders.setBearerAuth(this.token))
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(PushAlarmRequest.of(userId, message))
+                .retrieve()
+                .onStatus(HttpStatus::isError,
+                    status -> Mono.error(new PostMessageRequestFailedException(
+                        String.format(POST_MESSAGE_FAILED_CAUSE_FORMAT, status.statusCode(), userId,
+                            message))))
+                .toBodilessEntity()
+                .blockOptional()
+                .orElseThrow(PostMessageRequestFailedException::new);
+        } catch (PostMessageRequestFailedException e) {
+            log.info("Exception has been thrown : ", e);
+        }
+    }
+}

--- a/backend/src/main/java/com/woowacourse/kkogkkog/infrastructure/event/PushAlarmEvent.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/infrastructure/event/PushAlarmEvent.java
@@ -30,6 +30,10 @@ public class PushAlarmEvent {
     }
 
     public boolean shouldNotSendPushAlarm() {
-        return botAccessToken == null || couponEvent == CouponEvent.FINISH;
+        return couponEvent == CouponEvent.FINISH;
+    }
+
+    public boolean hasBotAccessToken() {
+        return botAccessToken != null;
     }
 }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/infrastructure/event/PushAlarmEvent.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/infrastructure/event/PushAlarmEvent.java
@@ -10,6 +10,7 @@ import lombok.Getter;
 public class PushAlarmEvent {
 
     private static final String WOOWACOURSE_WORKSPACE_ID = "TFELTJB7V";
+
     private final String workspaceId;
     private final String botAccessToken;
     private final String hostMemberId;

--- a/backend/src/main/java/com/woowacourse/kkogkkog/infrastructure/event/PushAlarmEvent.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/infrastructure/event/PushAlarmEvent.java
@@ -9,13 +9,16 @@ import lombok.Getter;
 @Getter
 public class PushAlarmEvent {
 
+    private static final String WOOWACOURSE_WORKSPACE_ID = "TFELTJB7V";
+    private final String workspaceId;
     private final String botAccessToken;
     private final String hostMemberId;
     private final String message;
     private final CouponEvent couponEvent;
 
-    public PushAlarmEvent(String botAccessToken, String hostMemberId, String message,
+    public PushAlarmEvent(String workspaceId, String botAccessToken, String hostMemberId, String message,
                           CouponEvent couponEvent) {
+        this.workspaceId = workspaceId;
         this.botAccessToken = botAccessToken;
         this.hostMemberId = hostMemberId;
         this.message = message;
@@ -25,7 +28,7 @@ public class PushAlarmEvent {
     public static PushAlarmEvent of(MemberHistory memberHistory) {
         Member hostMember = memberHistory.getHostMember();
         Workspace workspace = hostMember.getWorkspace();
-        return new PushAlarmEvent(workspace.getAccessToken(), hostMember.getUserId(),
+        return new PushAlarmEvent(workspace.getWorkspaceId(), workspace.getAccessToken(), hostMember.getUserId(),
             memberHistory.toNoticeMessage(), memberHistory.getCouponEvent());
     }
 
@@ -35,5 +38,9 @@ public class PushAlarmEvent {
 
     public boolean hasBotAccessToken() {
         return botAccessToken != null;
+    }
+
+    public boolean isWoowacourseWorkspace() {
+        return WOOWACOURSE_WORKSPACE_ID.equals(workspaceId);
     }
 }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -33,3 +33,8 @@ security:
     redirect:
       login: "https://abc.com/login/redirect"
       bot-token: "https://abc.com/download/redirect"
+    workspace:
+      woowacourse:
+        request-url: "https://sample.woowacourse.com"
+        token: "aaa.bbb.ccc"
+

--- a/backend/src/test/java/com/woowacourse/kkogkkog/infrastructure/application/CommonPushAlarmClientTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/infrastructure/application/CommonPushAlarmClientTest.java
@@ -1,0 +1,54 @@
+package com.woowacourse.kkogkkog.infrastructure.application;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+import java.io.IOException;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.client.WebClient;
+
+class CommonPushAlarmClientTest {
+
+    private static final String USER_ID = "ABC123";
+    private static final String BOT_ACCESS_TOKEN = "xoxb-bot-access-token";
+    private static final String MESSAGE = "MESSAGE_HERE";
+
+    private static final String POST_MESSAGE_RESPONSE = "{\n"
+        + "    \"ok\": true,\n"
+        + "    \"channel\": \"" + USER_ID + "\",\n"
+        + "    \"ts\": \"1503435956.000247\",\n"
+        + "    \"message\": {\n"
+        + "        \"text\": \"" + MESSAGE + "\",\n"
+        + "        \"username\": \"ecto1\",\n"
+        + "        \"type\": \"message\"\n"
+        + "    }\n"
+        + "}";
+
+    @Test
+    @DisplayName("슬랙 서버로 푸쉬 알람 요청을 보낸다.")
+    void requestPushAlarm() throws IOException {
+        MockWebServer mockWebServer = new MockWebServer();
+        mockWebServer.start();
+        setUpResponse(mockWebServer, POST_MESSAGE_RESPONSE);
+        CommonPushAlarmClient pushAlarmClient = buildMockSlackClient(mockWebServer);
+
+        assertThatNoException().isThrownBy(() ->
+            pushAlarmClient.requestPushAlarm(BOT_ACCESS_TOKEN, USER_ID, MESSAGE));
+    }
+
+    private CommonPushAlarmClient buildMockSlackClient(MockWebServer mockWebServer) {
+        String mockWebClientURI = String.format("http://%s:%s",
+            mockWebServer.getHostName(), mockWebServer.getPort());
+        return new CommonPushAlarmClient(mockWebClientURI, WebClient.create());
+    }
+
+    private void setUpResponse(MockWebServer mockWebServer, String responseBody) {
+        mockWebServer.enqueue(new MockResponse()
+            .setBody(responseBody)
+            .addHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE));
+    }
+}

--- a/backend/src/test/java/com/woowacourse/kkogkkog/infrastructure/application/PushAlarmListenerTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/infrastructure/application/PushAlarmListenerTest.java
@@ -49,7 +49,7 @@ public class PushAlarmListenerTest {
     @Autowired
     ReservationRepository reservationRepository;
     @MockBean
-    CommonPushAlarmClient commonPushAlarmClient;
+    CommonPushAlarmClient pushAlarmClient;
     @MockBean
     WoowacoursePushAlarmClient woowacoursePushAlarmClient;
 
@@ -83,7 +83,7 @@ public class PushAlarmListenerTest {
             couponService.save(
                 CouponDtoFixture.COFFEE_쿠폰_저장_요청(sender.getId(), List.of(receiver.getId())));
 
-            Mockito.verify(commonPushAlarmClient, Mockito.timeout(1000))
+            Mockito.verify(pushAlarmClient, Mockito.timeout(1000))
                 .requestPushAlarm(workspace.getAccessToken(), receiver.getUserId(),
                     "`"+sender.getNickname() + "` 님이 `커피` 쿠폰을 *보냈어요*\uD83D\uDC4B");
         }
@@ -107,7 +107,7 @@ public class PushAlarmListenerTest {
                 LocalDate.now());
 
             reservationService.save(reservationSaveRequest);
-            Mockito.verify(commonPushAlarmClient, Mockito.timeout(1000))
+            Mockito.verify(pushAlarmClient, Mockito.timeout(1000))
                 .requestPushAlarm(workspace.getAccessToken(), sender.getUserId(),
                     "`" + receiver.getNickname() + "` 님이 `커피` 쿠폰 사용을 *요청했어요*🙏");
         }
@@ -121,7 +121,7 @@ public class PushAlarmListenerTest {
 
             reservationService.update(reservationUpdateRequest);
 
-            Mockito.verify(commonPushAlarmClient, Mockito.timeout(1000))
+            Mockito.verify(pushAlarmClient, Mockito.timeout(1000))
                 .requestPushAlarm(workspace.getAccessToken(), receiver.getUserId(),
                     "`" + sender.getNickname() + "` 님이 `커피` 쿠폰 사용을 *승인했어요*\uD83D\uDE00");
         }

--- a/backend/src/test/java/com/woowacourse/kkogkkog/infrastructure/application/PushAlarmListenerTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/infrastructure/application/PushAlarmListenerTest.java
@@ -70,8 +70,7 @@ public class PushAlarmListenerTest {
         @BeforeEach
         void setUp() {
             workspace = workspaceRepository.save(WorkspaceFixture.KKOGKKOG.getWorkspace(1L));
-            workspace2 = workspaceRepository.save(
-                WorkspaceFixture.KKOGKKOG.getWorkspace(2L, null));
+            workspace2 = workspaceRepository.save(WorkspaceFixture.WOOWACOURSE.getWorkspace(2L));
             sender = memberRepository.save(MemberFixture.SENDER.getMember(workspace));
             receiver = memberRepository.save(MemberFixture.RECEIVER.getMember(workspace));
             receiver2 = memberRepository.save(MemberFixture.RECEIVER2.getMember(workspace2));
@@ -85,11 +84,11 @@ public class PushAlarmListenerTest {
 
             Mockito.verify(pushAlarmClient, Mockito.timeout(1000))
                 .requestPushAlarm(workspace.getAccessToken(), receiver.getUserId(),
-                    "`"+sender.getNickname() + "` 님이 `커피` 쿠폰을 *보냈어요*\uD83D\uDC4B");
+                    "`" + sender.getNickname() + "` 님이 `커피` 쿠폰을 *보냈어요*\uD83D\uDC4B");
         }
 
         @Test
-        @DisplayName("쿠폰을 생성할 때, 받는 사람의 워크스페이스에 봇 토큰이 없으면 WoowaCorsePushAlarmClient로 Push 알림을 보낸다.")
+        @DisplayName("쿠폰을 생성할 때, 받는 사람의 워크스페이스가 woowacourse 이면 WoowaCorsePushAlarmClient로 Push 알림을 보낸다.")
         void success_couponSave_woowacourse() {
             couponService.save(
                 CouponDtoFixture.COFFEE_쿠폰_저장_요청(sender.getId(), List.of(receiver2.getId())));

--- a/backend/src/test/java/com/woowacourse/kkogkkog/infrastructure/application/SlackClientTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/infrastructure/application/SlackClientTest.java
@@ -127,23 +127,11 @@ class SlackClientTest {
             .isInstanceOf(BotInstallationFailedException.class);
     }
 
-    @Test
-    @DisplayName("슬랙 서버로 푸쉬 알람 요청을 보낸다.")
-    void requestPushAlarm() throws IOException {
-        MockWebServer mockWebServer = new MockWebServer();
-        mockWebServer.start();
-        setUpResponse(mockWebServer, POST_MESSAGE_RESPONSE);
-        SlackClient slackClient = buildMockSlackClient(mockWebServer);
-
-        assertThatNoException().isThrownBy(() ->
-            slackClient.requestPushAlarm(BOT_ACCESS_TOKEN, USER_ID, MESSAGE));
-    }
-
     private SlackClient buildMockSlackClient(MockWebServer mockWebServer) {
         String mockWebClientURI = String.format("http://%s:%s",
             mockWebServer.getHostName(), mockWebServer.getPort());
         return new SlackClient("clientId", "secretId", mockWebClientURI, mockWebClientURI,
-            mockWebClientURI, mockWebClientURI, mockWebClientURI, mockWebClientURI, WebClient.create());
+            mockWebClientURI, mockWebClientURI, mockWebClientURI, WebClient.create());
     }
 
     private void setUpResponse(MockWebServer mockWebServer, String responseBody) {

--- a/backend/src/test/java/com/woowacourse/kkogkkog/infrastructure/application/WoowacoursePushAlarmClientTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/infrastructure/application/WoowacoursePushAlarmClientTest.java
@@ -1,0 +1,66 @@
+package com.woowacourse.kkogkkog.infrastructure.application;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+import java.io.IOException;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.reactive.function.client.WebClient;
+
+class WoowacoursePushAlarmClientTest {
+
+    private static final String USER_ID = "ABC123";
+    private static final String REQUEST_PUSH_ALARM_ACCESS_TOKEN = "aaa.bbb.ccc";
+    private static final String MESSAGE = "MESSAGE_HERE";
+
+    @Test
+    @DisplayName("슬랙 서버로 푸쉬 알람 요청을 보낸다.")
+    void requestPushAlarm_success() throws IOException {
+        MockWebServer mockWebServer = new MockWebServer();
+        mockWebServer.start();
+        setUpResponse(mockWebServer, HttpStatus.OK);
+        WoowacoursePushAlarmClient pushAlarmClient = buildMockSlackClient(mockWebServer);
+
+        assertThatNoException().isThrownBy(() ->
+            pushAlarmClient.requestPushAlarm(null, USER_ID, MESSAGE));
+    }
+
+    @Test
+    @DisplayName("Woowacourse 워크스페이스에 존재하지 않는 사용자이면 404 상태코드를 반환한다.")
+    void requestPushAlarm_not_found() throws IOException {
+        MockWebServer mockWebServer = new MockWebServer();
+        mockWebServer.start();
+        setUpResponse(mockWebServer, HttpStatus.NOT_FOUND);
+        WoowacoursePushAlarmClient pushAlarmClient = buildMockSlackClient(mockWebServer);
+
+        assertThatNoException().isThrownBy(() ->
+            pushAlarmClient.requestPushAlarm(null, USER_ID, MESSAGE));
+    }
+
+    @Test
+    @DisplayName("알림 서버에 장애가 발생하면 500 상태코드를 반환한다.")
+    void requestPushAlarm_bad_request() throws IOException {
+        MockWebServer mockWebServer = new MockWebServer();
+        mockWebServer.start();
+        setUpResponse(mockWebServer, HttpStatus.INTERNAL_SERVER_ERROR);
+        WoowacoursePushAlarmClient pushAlarmClient = buildMockSlackClient(mockWebServer);
+
+        assertThatNoException().isThrownBy(() ->
+            pushAlarmClient.requestPushAlarm(null, USER_ID, MESSAGE));
+    }
+
+    private WoowacoursePushAlarmClient buildMockSlackClient(MockWebServer mockWebServer) {
+        String mockWebClientURI = String.format("http://%s:%s",
+            mockWebServer.getHostName(), mockWebServer.getPort());
+        return new WoowacoursePushAlarmClient(mockWebClientURI, REQUEST_PUSH_ALARM_ACCESS_TOKEN,
+            WebClient.create());
+    }
+
+    private void setUpResponse(MockWebServer mockWebServer, HttpStatus statusCode) {
+        mockWebServer.enqueue(new MockResponse()
+            .setResponseCode(statusCode.value()));
+    }
+}

--- a/backend/src/test/java/com/woowacourse/kkogkkog/infrastructure/event/PushAlarmEventTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/infrastructure/event/PushAlarmEventTest.java
@@ -1,0 +1,27 @@
+package com.woowacourse.kkogkkog.infrastructure.event;
+
+import static com.woowacourse.kkogkkog.support.fixture.domain.WorkspaceFixture.WOOWACOURSE;
+
+import com.woowacourse.kkogkkog.coupon.domain.CouponEvent;
+import com.woowacourse.kkogkkog.member.domain.Workspace;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class PushAlarmEventTest {
+
+    @Test
+    @DisplayName("워크스페이스 아이디가 Woowacourse 워크스페이스와 같으면 True를 반환한다.")
+    void isWoowacourseWorkspace() {
+        PushAlarmEvent pushAlarmEvent = 푸시_알림_이벤트_생성(WOOWACOURSE.getWorkspace());
+
+        Boolean actual = pushAlarmEvent.isWoowacourseWorkspace();
+
+        Assertions.assertThat(actual).isTrue();
+    }
+
+    private static PushAlarmEvent 푸시_알림_이벤트_생성(Workspace workspace) {
+        return new PushAlarmEvent(workspace.getWorkspaceId(), workspace.getAccessToken(),
+            "hostMemberId", "message", CouponEvent.REQUEST);
+    }
+}

--- a/backend/src/test/java/com/woowacourse/kkogkkog/support/fixture/domain/WorkspaceFixture.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/support/fixture/domain/WorkspaceFixture.java
@@ -4,7 +4,9 @@ import com.woowacourse.kkogkkog.member.domain.Workspace;
 
 public enum WorkspaceFixture {
 
-    KKOGKKOG("ABC1234", "Kkogkkog", "xoxb-bot-access-token");
+    KKOGKKOG("ABC1234", "Kkogkkog", "xoxb-bot-access-token"),
+    WOOWACOURSE("TFELTJB7V", "Kkogkkog", "xoxb-bot-access-token")
+    ;
 
     private final String workspaceId;
     private final String name;

--- a/backend/src/test/java/com/woowacourse/kkogkkog/support/fixture/domain/WorkspaceFixture.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/support/fixture/domain/WorkspaceFixture.java
@@ -23,4 +23,8 @@ public enum WorkspaceFixture {
     public Workspace getWorkspace(Long id) {
         return new Workspace(id, workspaceId, name, accessToken);
     }
+
+    public Workspace getWorkspace(Long id, String accessToken) {
+        return new Workspace(id, workspaceId, name, accessToken);
+    }
 }

--- a/backend/src/test/java/com/woowacourse/kkogkkog/support/fixture/domain/WorkspaceFixture.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/support/fixture/domain/WorkspaceFixture.java
@@ -5,7 +5,7 @@ import com.woowacourse.kkogkkog.member.domain.Workspace;
 public enum WorkspaceFixture {
 
     KKOGKKOG("ABC1234", "Kkogkkog", "xoxb-bot-access-token"),
-    WOOWACOURSE("TFELTJB7V", "Kkogkkog", "xoxb-bot-access-token")
+    WOOWACOURSE("TFELTJB7V", "woowacourse", null)
     ;
 
     private final String workspaceId;

--- a/backend/src/test/java/com/woowacourse/kkogkkog/support/fixture/domain/WorkspaceFixture.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/support/fixture/domain/WorkspaceFixture.java
@@ -25,8 +25,4 @@ public enum WorkspaceFixture {
     public Workspace getWorkspace(Long id) {
         return new Workspace(id, workspaceId, name, accessToken);
     }
-
-    public Workspace getWorkspace(Long id, String accessToken) {
-        return new Workspace(id, workspaceId, name, accessToken);
-    }
 }


### PR DESCRIPTION
## 작업 내용

- woowacourse 통합 알림 봇 서버로 요청을 보내는 클래스를 구현한다.
  - request url, jwt token을 환경변수로 받는다.
- 알림을 받는 hostMember의 워크스페이스 아이디가 woowacourse 워크스페이스 아이디와 같으면 통합 알림 봇으로 요청을 보낸다.

- SlackClient의 알림 전송 기능 새로운 클래스로 분리한다.

- PushAlarmClient 인터페이스를 구현해 일반적인 전송과 woowacourse 워크스페이스 전송 과정을 추상화한다.

## 공유사항

비즈니스 로직을 건드리지 않게 infrastructure 패키지만 변경하였습니다.
pushAlarmEvent 클래스에 워크스페이스 아이디가 woowacourse 아이디와 같은지 확인하는 메서드를 추가하여 우아코스 워크스페이스이면 통합 알림 봇으로 요청을 전송합니다.
이제 통합 알림 봇 api의 엑세스 토큰과 요청 url를 서브모듈 내 설정파일에 추가하면 됩니다.

Resolves #308 
