### PR TITLE
[BE] Gradle BootJar 실패 문제 발생

### DIFF
--- a/backend/src/test/java/com/woowacourse/kkogkkog/infrastructure/application/PushAlarmListenerTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/infrastructure/application/PushAlarmListenerTest.java
@@ -76,7 +76,7 @@ public class PushAlarmListenerTest {
             couponService.save(
                 CouponDtoFixture.COFFEE_쿠폰_저장_요청(sender.getId(), List.of(receiver.getId())));
 
-            Mockito.verify(slackClient, Mockito.timeout(1000))
+            Mockito.verify(slackClient, Mockito.timeout(5000))
                 .requestPushAlarm(workspace.getAccessToken(), receiver.getUserId(),
                     "`"+sender.getNickname() + "` 님이 `커피` 쿠폰을 *보냈어요*\uD83D\uDC4B");
         }
@@ -89,7 +89,7 @@ public class PushAlarmListenerTest {
                 LocalDate.now());
 
             reservationService.save(reservationSaveRequest);
-            Mockito.verify(slackClient, Mockito.timeout(1000))
+            Mockito.verify(slackClient, Mockito.timeout(5000))
                 .requestPushAlarm(workspace.getAccessToken(), sender.getUserId(),
                     "`" + receiver.getNickname() + "` 님이 `커피` 쿠폰 사용을 *요청했어요*🙏");
         }
@@ -103,7 +103,7 @@ public class PushAlarmListenerTest {
 
             reservationService.update(reservationUpdateRequest);
 
-            Mockito.verify(slackClient, Mockito.timeout(1000))
+            Mockito.verify(slackClient, Mockito.timeout(5000))
                 .requestPushAlarm(workspace.getAccessToken(), receiver.getUserId(),
                     "`" + sender.getNickname() + "` 님이 `커피` 쿠폰 사용을 *승인했어요*\uD83D\uDE00");
         }


### PR DESCRIPTION
## 작업 내용

- Mockito.verify() 메서드의 최대 대기 시간인 timeout을 5000ms(5초)로 변경한다.

## 공유사항

슬랙 알림 비동기 테스트 코드 문제입니다. 자세한 내용은 이슈 참고해주세요.

Resolves #318 
