### PR TITLE
feat: coupon 테이블에 meeting_date 추가 및 reservation과 동기화

### DIFF
--- a/backend/src/main/java/com/woowacourse/kkogkkog/coupon/domain/Coupon.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/coupon/domain/Coupon.java
@@ -3,6 +3,7 @@ package com.woowacourse.kkogkkog.coupon.domain;
 import com.woowacourse.kkogkkog.coupon.exception.SameSenderReceiverException;
 import com.woowacourse.kkogkkog.common.domain.BaseEntity;
 import com.woowacourse.kkogkkog.member.domain.Member;
+import java.time.LocalDateTime;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -49,6 +50,9 @@ public class Coupon extends BaseEntity {
     @Column(nullable = false)
     private CouponStatus couponStatus;
 
+    @Column
+    private LocalDateTime meetingDate;
+
     public Coupon(Member sender, Member receiver, String hashtag, String description,
                   CouponType couponType, CouponStatus couponStatus) {
         this(null, sender, receiver, hashtag, description, couponType, couponStatus);
@@ -82,5 +86,9 @@ public class Coupon extends BaseEntity {
     public void changeStatus(CouponEvent couponEvent, Member member) {
         couponEvent.checkExecutable(sender.equals(member), receiver.equals(member));
         this.couponStatus = couponStatus.handle(couponEvent);
+    }
+
+    public void updateMeetingDate(LocalDateTime meetingDate) {
+        this.meetingDate = meetingDate;
     }
 }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/reservation/application/ReservationService.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/reservation/application/ReservationService.java
@@ -49,9 +49,11 @@ public class ReservationService {
 
         Reservation reservation = request.toEntity(findCoupon);
         reservation.changeCouponStatus(REQUEST, loginMember);
+        LocalDateTime meetingDate = request.getMeetingDate();
         MemberHistory memberHistory = saveMemberHistory(
-            findCoupon.getSender(), loginMember, findCoupon, REQUEST, request.getMeetingDate(),
+            findCoupon.getSender(), loginMember, findCoupon, REQUEST, meetingDate,
             request.getMessage());
+        findCoupon.updateMeetingDate(meetingDate);
 
         publisher.publishEvent(PushAlarmEvent.of(memberHistory));
 
@@ -81,6 +83,7 @@ public class ReservationService {
 
         if (validateCancelReservation(request)) {
             reservationRepository.delete(reservation);
+            coupon.updateMeetingDate(null);
         }
 
         publisher.publishEvent(PushAlarmEvent.of(memberHistory));

--- a/backend/src/main/resources/db/migration/V2.0__move_meeting_date.sql
+++ b/backend/src/main/resources/db/migration/V2.0__move_meeting_date.sql
@@ -1,7 +1,2 @@
 ALTER TABLE `coupon`
     ADD `meeting_date` DATETIME;
-
-UPDATE coupon
-    INNER JOIN reservation
-    ON reservation.coupon_id = coupon.id
-SET coupon.meeting_date = reservation.meeting_date;

--- a/backend/src/main/resources/db/migration/V2.0__move_meeting_date.sql
+++ b/backend/src/main/resources/db/migration/V2.0__move_meeting_date.sql
@@ -1,0 +1,7 @@
+ALTER TABLE `coupon`
+    ADD `meeting_date` DATETIME;
+
+UPDATE coupon
+    INNER JOIN reservation
+    ON reservation.coupon_id = coupon.id
+SET coupon.meeting_date = reservation.meeting_date;


### PR DESCRIPTION
## 작업 내용

- 현재 진행 중인 리팩토링 작업이 끝나면 reservation 테이블의 meeting_date 컬럼은 coupon 테이블로 이전되어야 합니다.
- DB 마이그레이션 작업과 그에 따른 트러블슈팅을 리팩토링 작업과 분리시키기 위해 **현재 API를 그대로 사용하는 상태로 DB 마이그레이션 작업을 단계적으로 수행**하고자 합니다.

  - coupon 테이블에 meeting_date 추가
  - reservation 데이터가 생겨나거나 제거되면 coupon_id에 대응되는 coupon 데이터의 meeting_date 값 수정. 두 테이블의 meeting_date 데이터를 동기화시킨다.

## 공유사항

기존 API를 그대로 사용하므로 해당 PR이 머지되어도 여전히 reservation 테이블의 meeting_date 값이 사용됩니다.

무중단 DB 마이그레이션 시나리오의 2단계에 해당. (#322 )