### PR TITLE
refactor: React-Query 쿼리 2차 리팩터링 (query 훅의 쓰임 제한하기, 필드 유틸 함수화, 이슈 해결)

### DIFF
--- a/frontend/src/@hooks/business/coupon.ts
+++ b/frontend/src/@hooks/business/coupon.ts
@@ -1,5 +1,3 @@
-import { AxiosError } from 'axios';
-
 import { useToast } from '@/@hooks/@common/useToast';
 import { COUPON_ENG_TYPE, COUPON_HASHTAGS } from '@/types/client/coupon';
 import { UserResponse } from '@/types/remote/response';

--- a/frontend/src/@hooks/business/user.ts
+++ b/frontend/src/@hooks/business/user.ts
@@ -1,9 +1,8 @@
-import { AxiosError } from 'axios';
-
 import { useToast } from '@/@hooks/@common/useToast';
 import {
   useAddSlackAppMutation,
   useEditMeMutation,
+  useFetchUserHistoryList,
   useLoginMutation,
   useReadAllHistoryMutation,
   useSlackOAuthLoginMutation,
@@ -86,9 +85,17 @@ export const useAddSlackApp = () => {
 };
 
 export const useReadAllHistory = () => {
+  const { checkIsReadAll } = useFetchUserHistoryList();
+
   const readAllHistoryMutation = useReadAllHistoryMutation();
 
   const readAllHistory = () => {
+    const isReadAll = checkIsReadAll();
+
+    if (isReadAll) {
+      return;
+    }
+
     return readAllHistoryMutation.mutateAsync();
   };
 

--- a/frontend/src/@pages/coupon-list/coupon-detail/request/index.tsx
+++ b/frontend/src/@pages/coupon-list/coupon-detail/request/index.tsx
@@ -64,6 +64,8 @@ const CouponRequestPage = () => {
     }
 
     await requestCoupon({ meetingDate, message });
+
+    navigate(`/coupon-list/${couponId}`, { replace: true });
   };
 
   return (

--- a/frontend/src/@pages/coupon-list/index.tsx
+++ b/frontend/src/@pages/coupon-list/index.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
+import { useMemo } from 'react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 
 import Icon from '@/@components/@shared/Icon';
@@ -26,7 +27,10 @@ const CouponListPage = () => {
   const couponListType: COUPON_LIST_TYPE =
     useLocation().pathname === PATH.SENT_COUPON_LIST ? 'sent' : 'received';
 
-  const { parsedSentCouponList, parsedReceivedCouponList } = useFetchCouponList();
+  const { couponList, parseCouponList } = useFetchCouponList();
+
+  const parsedSentCouponList = useMemo(() => parseCouponList('sent'), [couponList]);
+  const parsedReceivedCouponList = useMemo(() => parseCouponList('received'), [couponList]);
 
   // 항상 전체가 기본값으로 들어가야 하는가?
   const { status, changeStatus } = useStatus<FilterOption>('전체');

--- a/frontend/src/@pages/history/index.tsx
+++ b/frontend/src/@pages/history/index.tsx
@@ -12,7 +12,7 @@ import { couponListDetailPageRegExp } from '@/utils/regularExpression';
 const UserHistoryPage = () => {
   const navigate = useNavigate();
 
-  const { historyList, isReadAll, refetch } = useFetchUserHistoryList();
+  const { historyList, synchronizeServerUserHistory } = useFetchUserHistoryList();
   const { readAllHistory } = useReadAllHistory();
   const { readHistory } = useReadHistory();
 
@@ -23,20 +23,16 @@ const UserHistoryPage = () => {
       return;
     }
 
-    refetch();
+    synchronizeServerUserHistory();
   }, []);
 
   useEffect(() => {
-    if (isReadAll) {
-      return;
-    }
-
     const readUserHisory = async () => {
       await readAllHistory();
     };
 
     readUserHisory();
-  }, [isReadAll]);
+  }, [historyList]);
 
   const onClickHistoryItem = ({ id, couponId, isRead }: UserHistory) => {
     if (!isRead) {

--- a/frontend/src/@pages/landing/index.tsx
+++ b/frontend/src/@pages/landing/index.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/react';
+import { useMemo } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 
 import Button from '@/@components/@shared/Button';
@@ -67,8 +68,12 @@ const UnAuthorizedLanding = () => {
 
 const AuthorizedLanding = () => {
   const navigate = useNavigate();
-  const { reservationRecord, receivedOpenCouponList, sentOpenCouponList, isLoading } =
+  const { couponList, isLoading, parseOpenCouponList, generateReservationRecord } =
     useFetchCouponList();
+
+  const reservationRecord = useMemo(() => generateReservationRecord(), [couponList]);
+  const receivedOpenCouponList = useMemo(() => parseOpenCouponList('received'), [couponList]);
+  const sentOpenCouponList = useMemo(() => parseOpenCouponList('sent'), [couponList]);
 
   const onClickCouponItem = (coupon: CouponResponse) => {
     navigate(`/coupon-list/${coupon.couponId}`);

--- a/frontend/src/@pages/profile/index.tsx
+++ b/frontend/src/@pages/profile/index.tsx
@@ -3,7 +3,6 @@ import { Link, useNavigate } from 'react-router-dom';
 import Button from '@/@components/@shared/Button';
 import PageTemplate from '@/@components/@shared/PageTemplate';
 import { useFetchMe } from '@/@hooks/@queries/user';
-import { client } from '@/apis';
 import { PATH } from '@/Router';
 
 import * as Styled from './style';
@@ -11,14 +10,10 @@ import * as Styled from './style';
 const ProfilePage = () => {
   const navigate = useNavigate();
 
-  const { me, remove } = useFetchMe();
+  const { me, logout } = useFetchMe();
 
   const onClickLogoutButton = () => {
-    client.defaults.headers['Authorization'] = '';
-
-    localStorage.removeItem('user-token');
-
-    remove();
+    logout();
 
     navigate(PATH.LANDING);
   };


### PR DESCRIPTION
## 작업 내용

소통하면서 개발하였기에 자세한 설명은 생략합니다!!

- query 훅의 쓰임 제한하기
    - [x] 현재 훅단에서 파싱되어 전달되는 데이터들을 `파싱하는 함수`로 변경하여 컴포넌트에 전달한다. 이외 관련된 유틸 함수들을 만들어 전달한다. (선택적으로 파싱 데이터를 활용할 수 있도록 한다)
  - [x] 반환 값을 제한하여 컴포넌트 단에 전달한다. 





- 이슈 해결

  - [x] 네이밍 및 불필요한 패키지 import 문들을 확인 후 제거한다.
  - [x] 사용처들을 확인하며 불필요한 로직이 없는지 파악하고 수정한다.
  - [x] 쿠폰 요청 시 라우팅이 안되는 이슈 사항 해결하기

## 공유사항

해당 작업 내용에 관한 부연 설명 및 및 향후 작업해야 할 내용 등에 대한 설명

Resolves #336
