### PR TITLE
chore: dev build 명령어에 BABEL_ENV 추가

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,7 @@
     "start:prod": "cross-env NODE_ENV=production webpack serve  --mode=production",
     "build": " cross-env NODE_ENV=production webpack --progress --mode=production",
     "build:local": " cross-env NODE_ENV=local webpack --progress --mode=development",
-    "build:dev": "cross-env NODE_ENV=development webpack --progress --mode=production",
+    "build:dev": "cross-env NODE_ENV=development BABEL_ENV=production webpack --progress --mode=production",
     "test": "jest --watchAll",
     "coverage": "jest --coverage",
     "storybook": "start-storybook -p 6006",


### PR DESCRIPTION
## 작업 내용

- build:env 환경에서 webpack mode는 production을 가리키고, api.env는 development 를 가리킵니다.

api.env가 형성되는 조건을 찾아보았습니다.
[api.env](https://babeljs.io/docs/en/config-files#apienv)는 바벨의 envName에 따라 형성됩니다. 
[envName](https://babeljs.io/docs/en/options#envname) 은 `Default: process.env.BABEL_ENV || process.env.NODE_ENV || "development"` 입니다. 

간단하게 scripts 명령어에 BABEL_ENV를 추가해줘서 해결했습니다.

Resolves #343 
