### PR TITLE
feat: 쿠폰 리스트 페이지의 필터링을 기억한다.

### DIFF
--- a/frontend/src/@components/@shared/PrevPathMemoization/index.tsx
+++ b/frontend/src/@components/@shared/PrevPathMemoization/index.tsx
@@ -1,24 +1,13 @@
 import { PropsWithChildren, useEffect } from 'react';
 
-export const { getPrevURL, setPrevURL } = (() => {
-  const sessionStorageKey = 'prevURL';
-
-  return {
-    getPrevURL() {
-      return sessionStorage.getItem(sessionStorageKey) ?? '';
-    },
-    setPrevURL(prevPath: string) {
-      sessionStorage.setItem(sessionStorageKey, prevPath);
-    },
-  };
-})();
+import { setPrevUrl } from '@/storage/session';
 
 const PrevPathMemoization = ({ children }: PropsWithChildren) => {
   useEffect(() => {
     const prevPath = window.location.pathname;
 
     return () => {
-      setPrevURL(prevPath);
+      setPrevUrl(prevPath);
     };
   }, []);
 

--- a/frontend/src/@components/@shared/PrevPathMemoization/index.tsx
+++ b/frontend/src/@components/@shared/PrevPathMemoization/index.tsx
@@ -1,13 +1,13 @@
 import { PropsWithChildren, useEffect } from 'react';
 
-import { setPrevUrl } from '@/storage/session';
+import { prevUrlSessionStorage } from '@/storage/session';
 
 const PrevPathMemoization = ({ children }: PropsWithChildren) => {
   useEffect(() => {
     const prevPath = window.location.pathname;
 
     return () => {
-      setPrevUrl(prevPath);
+      prevUrlSessionStorage.set(prevPath);
     };
   }, []);
 

--- a/frontend/src/@pages/404/style.tsx
+++ b/frontend/src/@pages/404/style.tsx
@@ -1,4 +1,5 @@
-import { css, Theme } from '@emotion/react';
+import type { Theme } from '@emotion/react';
+import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 
 export const Root = styled.div`

--- a/frontend/src/@pages/coupon-list/index.tsx
+++ b/frontend/src/@pages/coupon-list/index.tsx
@@ -13,6 +13,7 @@ import VerticalCouponList from '@/@components/coupon/CouponList/vertical';
 import { useStatus } from '@/@hooks/@common/useStatus';
 import { useFetchCouponList } from '@/@hooks/@queries/coupon';
 import { DYNAMIC_PATH, PATH } from '@/Router';
+import { getCouponListStatus, setCouponListStatus } from '@/storage/session';
 import theme from '@/styles/theme';
 import { COUPON_LIST_TYPE } from '@/types/client/coupon';
 import { CouponResponse } from '@/types/remote/response';
@@ -33,10 +34,11 @@ const CouponListPage = () => {
   const parsedReceivedCouponList = useMemo(() => parseCouponList('received'), [couponList]);
 
   // 항상 전체가 기본값으로 들어가야 하는가?
-  const { status, changeStatus } = useStatus<FilterOption>('전체');
+  const { status, changeStatus } = useStatus<FilterOption>(getCouponListStatus() ?? '전체');
 
   const onClickFilterButton = (status: FilterOption) => {
     changeStatus(status);
+    setCouponListStatus(status);
   };
 
   const onClickCouponItem = (coupon: CouponResponse) => {

--- a/frontend/src/@pages/coupon-list/index.tsx
+++ b/frontend/src/@pages/coupon-list/index.tsx
@@ -13,7 +13,7 @@ import VerticalCouponList from '@/@components/coupon/CouponList/vertical';
 import { useStatus } from '@/@hooks/@common/useStatus';
 import { useFetchCouponList } from '@/@hooks/@queries/coupon';
 import { DYNAMIC_PATH, PATH } from '@/Router';
-import { getCouponListStatus, setCouponListStatus } from '@/storage/session';
+import { filterOptionsSessionStorage } from '@/storage/session';
 import theme from '@/styles/theme';
 import { COUPON_LIST_TYPE } from '@/types/client/coupon';
 import { CouponResponse } from '@/types/remote/response';
@@ -34,11 +34,13 @@ const CouponListPage = () => {
   const parsedReceivedCouponList = useMemo(() => parseCouponList('received'), [couponList]);
 
   // 항상 전체가 기본값으로 들어가야 하는가?
-  const { status, changeStatus } = useStatus<FilterOption>(getCouponListStatus() ?? '전체');
+  const { status, changeStatus } = useStatus<FilterOption>(
+    filterOptionsSessionStorage.get() ?? '전체'
+  );
 
   const onClickFilterButton = (status: FilterOption) => {
     changeStatus(status);
-    setCouponListStatus(status);
+    filterOptionsSessionStorage.set(status);
   };
 
   const onClickCouponItem = (coupon: CouponResponse) => {

--- a/frontend/src/@pages/history/index.tsx
+++ b/frontend/src/@pages/history/index.tsx
@@ -6,7 +6,7 @@ import UserHistoryList from '@/@components/user/UserHistoryList';
 import { useFetchUserHistoryList, useReadHistory } from '@/@hooks/@queries/user';
 import { useReadAllHistory } from '@/@hooks/business/user';
 import { DYNAMIC_PATH } from '@/Router';
-import { getPrevUrl } from '@/storage/session';
+import { prevUrlSessionStorage } from '@/storage/session';
 import { UserHistory } from '@/types/client/user';
 import { couponListDetailPageRegExp } from '@/utils/regularExpression';
 
@@ -18,7 +18,7 @@ const UserHistoryPage = () => {
   const { readHistory } = useReadHistory();
 
   useEffect(() => {
-    const prevURL = getPrevUrl() || '';
+    const prevURL = prevUrlSessionStorage.get() || '';
 
     if (couponListDetailPageRegExp.test(prevURL)) {
       return;

--- a/frontend/src/@pages/history/index.tsx
+++ b/frontend/src/@pages/history/index.tsx
@@ -18,7 +18,7 @@ const UserHistoryPage = () => {
   const { readHistory } = useReadHistory();
 
   useEffect(() => {
-    const prevURL = getPrevUrl();
+    const prevURL = getPrevUrl() || '';
 
     if (couponListDetailPageRegExp.test(prevURL)) {
       return;

--- a/frontend/src/@pages/history/index.tsx
+++ b/frontend/src/@pages/history/index.tsx
@@ -2,11 +2,11 @@ import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import PageTemplate from '@/@components/@shared/PageTemplate';
-import { getPrevURL } from '@/@components/@shared/PrevPathMemoization';
 import UserHistoryList from '@/@components/user/UserHistoryList';
 import { useFetchUserHistoryList, useReadHistory } from '@/@hooks/@queries/user';
 import { useReadAllHistory } from '@/@hooks/business/user';
 import { DYNAMIC_PATH } from '@/Router';
+import { getPrevUrl } from '@/storage/session';
 import { UserHistory } from '@/types/client/user';
 import { couponListDetailPageRegExp } from '@/utils/regularExpression';
 
@@ -18,7 +18,7 @@ const UserHistoryPage = () => {
   const { readHistory } = useReadHistory();
 
   useEffect(() => {
-    const prevURL = getPrevURL();
+    const prevURL = getPrevUrl();
 
     if (couponListDetailPageRegExp.test(prevURL)) {
       return;

--- a/frontend/src/@pages/main/index.tsx
+++ b/frontend/src/@pages/main/index.tsx
@@ -12,6 +12,7 @@ import HorizontalCouponList from '@/@components/coupon/CouponList/horizontal';
 import ReservationSection from '@/@components/reservation/ReservationSection';
 import { useFetchCouponList } from '@/@hooks/@queries/coupon';
 import { DYNAMIC_PATH, PATH } from '@/Router';
+import { setCouponListStatus } from '@/storage/session';
 import { CouponResponse } from '@/types/remote/response';
 
 import * as Styled from './style';
@@ -27,6 +28,10 @@ const MainPage = () => {
 
   const onClickCouponItem = (coupon: CouponResponse) => {
     navigate(DYNAMIC_PATH.COUPON_DETAIL(coupon.couponId));
+  };
+
+  const onClickViewMoreCoupon = () => {
+    setCouponListStatus('전체');
   };
 
   return (
@@ -81,7 +86,11 @@ const MainPage = () => {
           <div>
             <Styled.ListTitle>
               <span>받은 쿠폰</span>
-              <Link to={PATH.RECEIVED_COUPON_LIST} css={Styled.ExtendedLink}>
+              <Link
+                to={PATH.RECEIVED_COUPON_LIST}
+                css={Styled.ExtendedLink}
+                onClick={onClickViewMoreCoupon}
+              >
                 더보기
               </Link>
             </Styled.ListTitle>
@@ -102,7 +111,11 @@ const MainPage = () => {
           <div>
             <Styled.ListTitle>
               <span>보낸 쿠폰</span>
-              <Link to={PATH.SENT_COUPON_LIST} css={Styled.ExtendedLink}>
+              <Link
+                to={PATH.SENT_COUPON_LIST}
+                css={Styled.ExtendedLink}
+                onClick={onClickViewMoreCoupon}
+              >
                 더보기
               </Link>
             </Styled.ListTitle>

--- a/frontend/src/@pages/main/index.tsx
+++ b/frontend/src/@pages/main/index.tsx
@@ -12,7 +12,7 @@ import HorizontalCouponList from '@/@components/coupon/CouponList/horizontal';
 import ReservationSection from '@/@components/reservation/ReservationSection';
 import { useFetchCouponList } from '@/@hooks/@queries/coupon';
 import { DYNAMIC_PATH, PATH } from '@/Router';
-import { setCouponListStatus } from '@/storage/session';
+import { filterOptionsSessionStorage } from '@/storage/session';
 import { CouponResponse } from '@/types/remote/response';
 
 import * as Styled from './style';
@@ -31,7 +31,7 @@ const MainPage = () => {
   };
 
   const onClickViewMoreCoupon = () => {
-    setCouponListStatus('전체');
+    filterOptionsSessionStorage.set('전체');
   };
 
   return (

--- a/frontend/src/@pages/main/style.tsx
+++ b/frontend/src/@pages/main/style.tsx
@@ -1,4 +1,5 @@
-import { css, Theme } from '@emotion/react';
+import type { Theme } from '@emotion/react';
+import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 
 export const Root = styled.div`

--- a/frontend/src/storage/session/index.ts
+++ b/frontend/src/storage/session/index.ts
@@ -1,0 +1,24 @@
+const SESSION_KEY = {
+  couponListStatus: 'couponListStatus',
+  prevUrl: 'prevUrl',
+};
+
+class SessionStorage {
+  constructor(public key: string) {
+    this.key = key;
+  }
+
+  get = () => {
+    return sessionStorage.getItem(this.key) ?? '';
+  };
+
+  set = (value: string) => {
+    sessionStorage.setItem(this.key, value);
+  };
+}
+
+export const { get: getCouponListStatus, set: setCouponListStatus } = new SessionStorage(
+  SESSION_KEY.couponListStatus
+);
+
+export const { get: getPrevUrl, set: setPrevUrl } = new SessionStorage(SESSION_KEY.prevUrl);

--- a/frontend/src/storage/session/index.ts
+++ b/frontend/src/storage/session/index.ts
@@ -1,7 +1,7 @@
 import { FilterOption } from '@/@pages/coupon-list';
 
 const SESSION_KEY = {
-  couponListStatus: 'couponListStatus',
+  filterOptions: 'filterOptions',
   prevUrl: 'prevUrl',
 };
 
@@ -10,16 +10,17 @@ class SessionStorage<T extends string> {
     this.key = key;
   }
 
-  get = (): T | null => {
+  get(): T | null {
     return sessionStorage.getItem(this.key) as T | null;
-  };
+  }
 
-  set = (value: T) => {
+  set(value: T) {
     sessionStorage.setItem(this.key, value);
-  };
+  }
 }
 
-export const { get: getCouponListStatus, set: setCouponListStatus } =
-  new SessionStorage<FilterOption>(SESSION_KEY.couponListStatus);
+export const filterOptionsSessionStorage = new SessionStorage<FilterOption>(
+  SESSION_KEY.filterOptions
+);
 
-export const { get: getPrevUrl, set: setPrevUrl } = new SessionStorage(SESSION_KEY.prevUrl);
+export const prevUrlSessionStorage = new SessionStorage(SESSION_KEY.prevUrl);

--- a/frontend/src/storage/session/index.ts
+++ b/frontend/src/storage/session/index.ts
@@ -1,24 +1,25 @@
+import { FilterOption } from '@/@pages/coupon-list';
+
 const SESSION_KEY = {
   couponListStatus: 'couponListStatus',
   prevUrl: 'prevUrl',
 };
 
-class SessionStorage {
+class SessionStorage<T extends string> {
   constructor(public key: string) {
     this.key = key;
   }
 
-  get = () => {
-    return sessionStorage.getItem(this.key) ?? '';
+  get = (): T | null => {
+    return sessionStorage.getItem(this.key) as T | null;
   };
 
-  set = (value: string) => {
+  set = (value: T) => {
     sessionStorage.setItem(this.key, value);
   };
 }
 
-export const { get: getCouponListStatus, set: setCouponListStatus } = new SessionStorage(
-  SESSION_KEY.couponListStatus
-);
+export const { get: getCouponListStatus, set: setCouponListStatus } =
+  new SessionStorage<FilterOption>(SESSION_KEY.couponListStatus);
 
 export const { get: getPrevUrl, set: setPrevUrl } = new SessionStorage(SESSION_KEY.prevUrl);


### PR DESCRIPTION
## 작업 내용

- 세션 스토리지를 활용하여 쿠폰 리스트 페이지의 필터링을 기억하도록 했습니다.
- 세션 스토로지에서 중복 코드가 발생하여 class로 분리했고, 사용처를 제한하기 위해 도메인별 getter, setter를 만들어서 export 합니다.

## 공유사항

라이브러리에서 Theme 같은 타입을 불러올 때 타입에러가 발생합니다. 이때 import type으로 선언하면 에러가 발생하지 않습니다.

Resolves #354
