### PR TITLE
hotfix: woowacourse 슬랙 푸시 알림이 전송되지 않는 문제

### DIFF
--- a/backend/src/main/java/com/woowacourse/kkogkkog/infrastructure/application/WoowacoursePushAlarmClient.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/infrastructure/application/WoowacoursePushAlarmClient.java
@@ -54,7 +54,10 @@ public class WoowacoursePushAlarmClient {
     private void checkErrorStatusCode(ResponseSpec response, String userId, String message) {
         try {
             response.onStatus(HttpStatus::isError,
-                status -> throwPostMessageFailedException(userId, message, status));
+                status -> throwPostMessageFailedException(userId, message, status))
+                .toBodilessEntity()
+                .blockOptional()
+                .orElseThrow(WoowacoursePostMessageRequestFailedException::new);
         } catch (WoowacoursePostMessageRequestFailedException e) {
             log.info("Exception has been thrown : ", e);
         }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/infrastructure/application/WoowacoursePushAlarmClient.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/infrastructure/application/WoowacoursePushAlarmClient.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.ClientResponse;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -56,8 +57,7 @@ public class WoowacoursePushAlarmClient {
             response.onStatus(HttpStatus::isError,
                 status -> throwPostMessageFailedException(userId, message, status))
                 .toBodilessEntity()
-                .blockOptional()
-                .orElseThrow(WoowacoursePostMessageRequestFailedException::new);
+                .blockOptional();
         } catch (WoowacoursePostMessageRequestFailedException e) {
             log.info("Exception has been thrown : ", e);
         }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/infrastructure/application/WoowacoursePushAlarmClient.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/infrastructure/application/WoowacoursePushAlarmClient.java
@@ -1,7 +1,6 @@
 package com.woowacourse.kkogkkog.infrastructure.application;
 
 import com.woowacourse.kkogkkog.infrastructure.dto.PushAlarmRequest;
-import com.woowacourse.kkogkkog.infrastructure.exception.PostMessageRequestFailedException;
 import com.woowacourse.kkogkkog.infrastructure.exception.WoowacoursePostMessageRequestFailedException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -24,8 +23,8 @@ public class WoowacoursePushAlarmClient {
     private final WebClient messageClient;
 
     public WoowacoursePushAlarmClient(
-        @Value("security.slack.workspace.woowacourse.token") String token,
-        @Value("security.slack.workspace.woowacourse.request-url") String requestUrl,
+        @Value("${security.slack.workspace.woowacourse.token}") String token,
+        @Value("${security.slack.workspace.woowacourse.request-url}") String requestUrl,
         WebClient webClient) {
         this.token = token;
         this.messageClient = toWebClient(webClient, requestUrl);

--- a/backend/src/main/java/com/woowacourse/kkogkkog/infrastructure/exception/WoowacoursePostMessageRequestFailedException.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/infrastructure/exception/WoowacoursePostMessageRequestFailedException.java
@@ -2,10 +2,6 @@ package com.woowacourse.kkogkkog.infrastructure.exception;
 
 public class WoowacoursePostMessageRequestFailedException extends RuntimeException {
 
-    public WoowacoursePostMessageRequestFailedException() {
-        super("Woowacourse 워크스페이스의 슬랙 DM 전송 요청에 실패하였습니다.");
-    }
-
     public WoowacoursePostMessageRequestFailedException(String message) {
         super(String.format("Woowacourse 워크스페이스의 슬랙 DM 전송 요청에 실패하였습니다. [%s]", message));
     }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/infrastructure/exception/WoowacoursePostMessageRequestFailedException.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/infrastructure/exception/WoowacoursePostMessageRequestFailedException.java
@@ -2,6 +2,10 @@ package com.woowacourse.kkogkkog.infrastructure.exception;
 
 public class WoowacoursePostMessageRequestFailedException extends RuntimeException {
 
+    public WoowacoursePostMessageRequestFailedException() {
+        super("Woowacourse 워크스페이스의 슬랙 DM 전송 요청에 실패하였습니다.");
+    }
+
     public WoowacoursePostMessageRequestFailedException(String message) {
         super(String.format("Woowacourse 워크스페이스의 슬랙 DM 전송 요청에 실패하였습니다. [%s]", message));
     }

--- a/backend/src/test/java/com/woowacourse/kkogkkog/infrastructure/application/WoowacoursePushAlarmClientTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/infrastructure/application/WoowacoursePushAlarmClientTest.java
@@ -22,7 +22,7 @@ class WoowacoursePushAlarmClientTest {
         MockWebServer mockWebServer = new MockWebServer();
         mockWebServer.start();
         setUpResponse(mockWebServer, HttpStatus.OK);
-        WoowacoursePushAlarmClient pushAlarmClient = buildMockSlackClient(mockWebServer);
+        WoowacoursePushAlarmClient pushAlarmClient = buildMockClient(mockWebServer);
 
         assertThatNoException().isThrownBy(() ->
             pushAlarmClient.requestPushAlarm(USER_ID, MESSAGE));
@@ -34,7 +34,7 @@ class WoowacoursePushAlarmClientTest {
         MockWebServer mockWebServer = new MockWebServer();
         mockWebServer.start();
         setUpResponse(mockWebServer, HttpStatus.NOT_FOUND);
-        WoowacoursePushAlarmClient pushAlarmClient = buildMockSlackClient(mockWebServer);
+        WoowacoursePushAlarmClient pushAlarmClient = buildMockClient(mockWebServer);
 
         assertThatNoException().isThrownBy(() ->
             pushAlarmClient.requestPushAlarm(USER_ID, MESSAGE));
@@ -46,16 +46,16 @@ class WoowacoursePushAlarmClientTest {
         MockWebServer mockWebServer = new MockWebServer();
         mockWebServer.start();
         setUpResponse(mockWebServer, HttpStatus.INTERNAL_SERVER_ERROR);
-        WoowacoursePushAlarmClient pushAlarmClient = buildMockSlackClient(mockWebServer);
+        WoowacoursePushAlarmClient pushAlarmClient = buildMockClient(mockWebServer);
 
         assertThatNoException().isThrownBy(() ->
             pushAlarmClient.requestPushAlarm(USER_ID, MESSAGE));
     }
 
-    private WoowacoursePushAlarmClient buildMockSlackClient(MockWebServer mockWebServer) {
+    private WoowacoursePushAlarmClient buildMockClient(MockWebServer mockWebServer) {
         String mockWebClientURI = String.format("http://%s:%s",
             mockWebServer.getHostName(), mockWebServer.getPort());
-        return new WoowacoursePushAlarmClient(mockWebClientURI, REQUEST_PUSH_ALARM_ACCESS_TOKEN,
+        return new WoowacoursePushAlarmClient(REQUEST_PUSH_ALARM_ACCESS_TOKEN, mockWebClientURI,
             WebClient.create());
     }
 


### PR DESCRIPTION
## 작업 내용

- 환경변수 경로 설정
- 예외 발생시 로그가 error 레벨로 찍히는 문제 발견하여 요청 Webclient 재설정

## 공유 사항
작동 확인 완료하였습니다. 푸시 알림 자체는 보내지니 woowacourse일 때 잘 가는지 QA 하면 됩니다.