### PR TITLE
feat: ErrorFallback 스타일링, 에러 바운더리 리팩터링

### DIFF
--- a/frontend/src/@components/@shared/ErrorBoundary.tsx
+++ b/frontend/src/@components/@shared/ErrorBoundary.tsx
@@ -101,10 +101,6 @@ class ErrorBoundary extends Component<
 
     const { error, errorCase } = this.state;
 
-    if (errorCase === null) {
-      return children;
-    }
-
     if (errorCase === 'get') {
       return <FallbackComponent error={error} resetErrorBoundary={this.resetErrorBoundary} />;
     }

--- a/frontend/src/@components/@shared/ErrorBoundary.tsx
+++ b/frontend/src/@components/@shared/ErrorBoundary.tsx
@@ -17,9 +17,11 @@ interface ErrorBoundaryProps {
 type ErrorBoundaryState =
   | {
       error: null;
+      errorCase: null;
     }
   | {
       error: Error;
+      errorCase: null;
     }
   | {
       error: AxiosError;
@@ -28,6 +30,7 @@ type ErrorBoundaryState =
 
 const initialState: ErrorBoundaryState = {
   error: null,
+  errorCase: null,
 };
 
 class ErrorBoundary extends Component<
@@ -38,6 +41,7 @@ class ErrorBoundary extends Component<
 > {
   state: ErrorBoundaryState = {
     error: null,
+    errorCase: null,
   };
 
   resetErrorBoundary = () => {
@@ -47,7 +51,7 @@ class ErrorBoundary extends Component<
 
   static getDerivedStateFromError(error: Error): ErrorBoundaryState {
     if (!(error instanceof AxiosError)) {
-      return { error };
+      return { error, errorCase: null };
     }
 
     /** 우선순위를 고려하여 배치한다. */
@@ -65,7 +69,7 @@ class ErrorBoundary extends Component<
       };
     }
 
-    return { error };
+    return { error, errorCase: null };
   }
 
   static contextType = ToastContext;
@@ -73,15 +77,15 @@ class ErrorBoundary extends Component<
   componentDidCatch(error: Error, errorInfo: ErrorInfo) {
     const { displayMessage } = this.context as ToastContextType;
 
-    if (!('errorCase' in this.state)) {
+    const { error: errorState, errorCase } = this.state;
+
+    if (errorCase === null) {
       displayMessage('알 수 없는 에러가 발생했습니다.', true);
 
       return;
     }
 
     const { navigate } = this.props;
-
-    const { error: errorState, errorCase } = this.state;
 
     if (errorCase === 'unauthorized') {
       localStorage.removeItem('user-token');
@@ -95,11 +99,11 @@ class ErrorBoundary extends Component<
   render() {
     const { fallback: FallbackComponent, children } = this.props;
 
-    if (!('errorCase' in this.state)) {
+    const { error, errorCase } = this.state;
+
+    if (errorCase === null) {
       return children;
     }
-
-    const { error, errorCase } = this.state;
 
     if (errorCase === 'get') {
       return <FallbackComponent error={error} resetErrorBoundary={this.resetErrorBoundary} />;

--- a/frontend/src/@components/@shared/ErrorFallback/index.tsx
+++ b/frontend/src/@components/@shared/ErrorFallback/index.tsx
@@ -3,6 +3,7 @@ import { AxiosError } from 'axios';
 import theme from '@/styles/theme';
 
 import Icon from '../Icon';
+import PageTemplate from '../PageTemplate';
 import * as Styled from './style';
 
 export interface ErrorFallbackProps {
@@ -12,10 +13,15 @@ export interface ErrorFallbackProps {
 
 const ErrorFallback = ({ error, resetErrorBoundary }: ErrorFallbackProps) => {
   return (
-    <Styled.Root onClick={resetErrorBoundary}>
-      <Icon iconName='reload' color={theme.colors.light_grey_200} />
-      <button>다시 불러오기</button>
-    </Styled.Root>
+    <PageTemplate title='꼭꼭' hasHeader={false}>
+      <Styled.Root>
+        <img src='/assets/images/landing_logo.png' alt='로고' width='86' />
+        <Styled.ResetSection onClick={resetErrorBoundary}>
+          <Icon iconName='reload' color={theme.colors.light_grey_200} />
+          <button>다시 불러오기</button>
+        </Styled.ResetSection>
+      </Styled.Root>
+    </PageTemplate>
   );
 };
 

--- a/frontend/src/@components/@shared/ErrorFallback/style.tsx
+++ b/frontend/src/@components/@shared/ErrorFallback/style.tsx
@@ -1,3 +1,4 @@
+import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 
 export const Root = styled.div`
@@ -7,8 +8,23 @@ export const Root = styled.div`
   align-items: center;
   gap: 20px;
 
-  height: 100%;
-  cursor: pointer;
+  height: calc(var(--vh, 1vh) * 100);
+
+  ${({ theme }) => css`
+    background-color: ${theme.colors.primary_400_opacity};
+  `}
+`;
+
+export const ResetSection = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
 
   color: ${({ theme }) => theme.colors.light_grey_200};
+  cursor: pointer;
+
+  & > button {
+    font-size: 20px;
+  }
 `;

--- a/frontend/src/@pages/landing/index.tsx
+++ b/frontend/src/@pages/landing/index.tsx
@@ -35,18 +35,7 @@ const LandingPage = () => {
           `}
         >
           <Link to={PATH.MAIN}>
-            <Button
-              css={css`
-                display: flex;
-                padding: 15px;
-                justify-content: center;
-                align-items: center;
-
-                font-size: 16px;
-
-                gap: 15px;
-              `}
-            >
+            <Button css={Styled.ButtonExtended}>
               꼭꼭 시작하기 <Icon iconName='airplane' />
             </Button>
           </Link>

--- a/frontend/src/@pages/landing/index.tsx
+++ b/frontend/src/@pages/landing/index.tsx
@@ -12,8 +12,8 @@ import * as Styled from './style';
 const LandingPage = () => {
   return (
     <PageTemplate title='꼭꼭' hasHeader={false}>
-      <Styled.UnAuthorizedRoot>
-        <Styled.UnAuthorizedContainer>
+      <Styled.Root>
+        <Styled.Branding>
           <img src='/assets/images/landing_logo.png' alt='로고' width='86' />
 
           <div>
@@ -25,7 +25,7 @@ const LandingPage = () => {
           <Styled.AdditionalExplanation>
             시간을 보내고 싶어하는 사람들이 있을지 모릅니다.
           </Styled.AdditionalExplanation>
-        </Styled.UnAuthorizedContainer>
+        </Styled.Branding>
         <Position
           position='absolute'
           bottom='50px'
@@ -35,16 +35,14 @@ const LandingPage = () => {
           `}
         >
           <Link to={PATH.MAIN}>
-            <Button css={Styled.ButtonExtended}>
+            <Button css={Styled.ExtendedButton}>
               꼭꼭 시작하기 <Icon iconName='airplane' />
             </Button>
           </Link>
         </Position>
-      </Styled.UnAuthorizedRoot>
+      </Styled.Root>
     </PageTemplate>
   );
 };
-
-/** ListHeaderContainer는 어디에 있어야하는가? */
 
 export default LandingPage;

--- a/frontend/src/@pages/landing/index.tsx
+++ b/frontend/src/@pages/landing/index.tsx
@@ -5,11 +5,14 @@ import Button from '@/@components/@shared/Button';
 import Icon from '@/@components/@shared/Icon';
 import PageTemplate from '@/@components/@shared/PageTemplate';
 import Position from '@/@components/@shared/Position';
+import { useFetchMe } from '@/@hooks/@queries/user';
 import { PATH } from '@/Router';
 
 import * as Styled from './style';
 
 const LandingPage = () => {
+  const { me } = useFetchMe();
+
   return (
     <PageTemplate title='꼭꼭' hasHeader={false}>
       <Styled.Root>
@@ -34,7 +37,7 @@ const LandingPage = () => {
             padding: 30px;
           `}
         >
-          <Link to={PATH.MAIN}>
+          <Link to={me ? PATH.MAIN : PATH.LOGIN}>
             <Button css={Styled.ExtendedButton}>
               꼭꼭 시작하기 <Icon iconName='airplane' />
             </Button>

--- a/frontend/src/@pages/landing/index.tsx
+++ b/frontend/src/@pages/landing/index.tsx
@@ -5,14 +5,11 @@ import Button from '@/@components/@shared/Button';
 import Icon from '@/@components/@shared/Icon';
 import PageTemplate from '@/@components/@shared/PageTemplate';
 import Position from '@/@components/@shared/Position';
-import { useFetchMe } from '@/@hooks/@queries/user';
 import { PATH } from '@/Router';
 
 import * as Styled from './style';
 
 const LandingPage = () => {
-  const { me } = useFetchMe();
-
   return (
     <PageTemplate title='꼭꼭' hasHeader={false}>
       <Styled.UnAuthorizedRoot>
@@ -37,7 +34,7 @@ const LandingPage = () => {
             padding: 30px;
           `}
         >
-          <Link to={me ? PATH.MAIN : PATH.LOGIN}>
+          <Link to={PATH.MAIN}>
             <Button
               css={css`
                 display: flex;

--- a/frontend/src/@pages/landing/style.tsx
+++ b/frontend/src/@pages/landing/style.tsx
@@ -43,3 +43,14 @@ export const AdditionalExplanation = styled.div`
 
   margin-top: 10px;
 `;
+
+export const ButtonExtended = css`
+  display: flex;
+  padding: 15px;
+  justify-content: center;
+  align-items: center;
+
+  font-size: 16px;
+
+  gap: 15px;
+`;

--- a/frontend/src/@pages/landing/style.tsx
+++ b/frontend/src/@pages/landing/style.tsx
@@ -1,13 +1,7 @@
-import type { Theme } from '@emotion/react';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 
 export const Root = styled.div`
-  background-color: ${({ theme }) => theme.colors.white_100};
-  border-radius: 4px;
-`;
-
-export const UnAuthorizedRoot = styled.div`
   min-height: calc(var(--vh, 1vh) * 100);
   display: flex;
   justify-content: center;
@@ -20,7 +14,7 @@ export const UnAuthorizedRoot = styled.div`
   `}
 `;
 
-export const UnAuthorizedContainer = styled.div`
+export const Branding = styled.div`
   display: flex;
 
   flex-direction: column;
@@ -44,7 +38,7 @@ export const AdditionalExplanation = styled.div`
   margin-top: 10px;
 `;
 
-export const ButtonExtended = css`
+export const ExtendedButton = css`
   display: flex;
   padding: 15px;
   justify-content: center;

--- a/frontend/src/Router.tsx
+++ b/frontend/src/Router.tsx
@@ -171,7 +171,7 @@ const PrivateRoute = () => {
     <Outlet />
   ) : (
     <CustomSuspense isLoading={isLoading} fallback={<Loading />}>
-      <Navigate to={PATH.LANDING} replace />
+      <Navigate to={PATH.LOGIN} replace />
     </CustomSuspense>
   );
 };


### PR DESCRIPTION
## 작업 내용

- ErrorFallback 페이지 스타일링
- ErrorBoundary 우선순위 조정을 위한 리팩터링 (401 > get)
- PrivateRoute의 fallback을 Login으로 수정. 401 에러가 뜬다면, 바로 로그인으로 보내주는 것이 사용성을 증대시킨다고 생각했습니다.

## 공유사항

Resolves #358
