### PR TITLE
fix: 보내거나 받은 쿠폰을 상태별로 전체 조회할 때 Coupon을 반환하도록 수정

### DIFF
--- a/backend/src/main/java/com/woowacourse/kkogkkog/coupon/application/CouponService.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/coupon/application/CouponService.java
@@ -64,7 +64,9 @@ public class CouponService {
     @Transactional(readOnly = true)
     public List<CouponResponse> findAllBySender(Long memberId, String couponStatus) {
         Member member = findMember(memberId);
-        return couponRepository.findAllBySender(member, CouponStatus.valueOf(couponStatus));
+        return couponRepository.findAllBySender(member, CouponStatus.valueOf(couponStatus)).stream()
+            .map(CouponResponse::of)
+            .collect(Collectors.toList());
     }
 
     @Transactional(readOnly = true)
@@ -79,8 +81,9 @@ public class CouponService {
     public List<CouponResponse> findAllByReceiver(Long memberId,
                                                   String couponStatus) {
         Member member = findMember(memberId);
-        return couponRepository.findAllByReceiver(member, CouponStatus.valueOf(couponStatus));
-
+        return couponRepository.findAllByReceiver(member, CouponStatus.valueOf(couponStatus)).stream()
+            .map(CouponResponse::of)
+            .collect(Collectors.toList());
     }
 
     public List<CouponResponse> save(CouponSaveRequest request) {

--- a/backend/src/main/java/com/woowacourse/kkogkkog/coupon/domain/repository/CouponRepository.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/coupon/domain/repository/CouponRepository.java
@@ -24,7 +24,7 @@ public interface CouponRepository extends JpaRepository<Coupon, Long> {
         + "JOIN FETCH c.sender "
         + "WHERE c.sender = :member AND c.couponState.couponStatus = :status "
         + "ORDER BY c.couponState.meetingDate DESC")
-    List<CouponResponse> findAllBySender(@Param("member") Member member,
+    List<Coupon> findAllBySender(@Param("member") Member member,
                                          @Param("status") CouponStatus couponStatus);
 
     @Query("SELECT c "
@@ -39,7 +39,7 @@ public interface CouponRepository extends JpaRepository<Coupon, Long> {
         + "JOIN FETCH c.receiver "
         + "WHERE c.receiver = :member AND c.couponState.couponStatus = :status "
         + "ORDER BY c.couponState.meetingDate DESC")
-    List<CouponResponse> findAllByReceiver(@Param("member") Member member,
+    List<Coupon> findAllByReceiver(@Param("member") Member member,
                                            @Param("status") CouponStatus couponStatus);
 
     @Query("SELECT c "

--- a/backend/src/main/java/com/woowacourse/kkogkkog/coupon/domain/repository/CouponRepository.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/coupon/domain/repository/CouponRepository.java
@@ -1,6 +1,5 @@
 package com.woowacourse.kkogkkog.coupon.domain.repository;
 
-import com.woowacourse.kkogkkog.coupon.application.dto.CouponResponse;
 import com.woowacourse.kkogkkog.coupon.domain.Coupon;
 import com.woowacourse.kkogkkog.coupon.domain.CouponStatus;
 import com.woowacourse.kkogkkog.member.domain.Member;
@@ -25,7 +24,7 @@ public interface CouponRepository extends JpaRepository<Coupon, Long> {
         + "WHERE c.sender = :member AND c.couponState.couponStatus = :status "
         + "ORDER BY c.couponState.meetingDate DESC")
     List<Coupon> findAllBySender(@Param("member") Member member,
-                                         @Param("status") CouponStatus couponStatus);
+                                 @Param("status") CouponStatus couponStatus);
 
     @Query("SELECT c "
         + "FROM Coupon c "
@@ -40,7 +39,7 @@ public interface CouponRepository extends JpaRepository<Coupon, Long> {
         + "WHERE c.receiver = :member AND c.couponState.couponStatus = :status "
         + "ORDER BY c.couponState.meetingDate DESC")
     List<Coupon> findAllByReceiver(@Param("member") Member member,
-                                           @Param("status") CouponStatus couponStatus);
+                                   @Param("status") CouponStatus couponStatus);
 
     @Query("SELECT c "
         + "FROM Coupon c "


### PR DESCRIPTION
## 작업 내용
Repository에서 Dto를 반환하고 있던 로직을 수정했습니다.

## 공유사항
SpringDataJpa에서 Dto로 바로 매핑해주고 있어서 로직상 문제는 없었지만, 의존성을 분리하기 위해서 수정합니다.
