### PR TITLE
refactor: 슬랙 외부 라이브러리 응답 Response 객체들 구현

### DIFF
--- a/backend/src/main/java/com/woowacourse/kkogkkog/infrastructure/application/SlackClient.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/infrastructure/application/SlackClient.java
@@ -137,7 +137,7 @@ public class SlackClient {
                 .bodyToMono(PostSlackMessageResponse.class)
                 .blockOptional()
                 .orElseThrow(PostMessageRequestFailedException::new);
-            if (!response.getOk()) {
+            if (response.isError()) {
                 throw new PostMessageRequestFailedException(response.getError());
             }
         } catch (PostMessageRequestFailedException e) {

--- a/backend/src/main/java/com/woowacourse/kkogkkog/infrastructure/dto/BotTokenResponse.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/infrastructure/dto/BotTokenResponse.java
@@ -33,14 +33,4 @@ public class BotTokenResponse {
             this.name = name;
         }
     }
-
-    @Override
-    public String toString() {
-        return "BotTokenResponse{" +
-            "ok=" + ok +
-            ", accessToken='" + accessToken + '\'' +
-            ", team=" + team +
-            ", error='" + error + '\'' +
-            '}';
-    }
 }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/infrastructure/dto/PostSlackMessageResponse.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/infrastructure/dto/PostSlackMessageResponse.java
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 public class PostSlackMessageResponse {
 
     private Boolean ok;
-    private String error;
+    private String error = "";
 
     public PostSlackMessageResponse(Boolean ok, String error) {
         this.ok = ok;

--- a/backend/src/main/java/com/woowacourse/kkogkkog/infrastructure/dto/PostSlackMessageResponse.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/infrastructure/dto/PostSlackMessageResponse.java
@@ -1,0 +1,18 @@
+package com.woowacourse.kkogkkog.infrastructure.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class PostSlackMessageResponse {
+
+    private Boolean ok;
+    private String error;
+
+    public PostSlackMessageResponse(Boolean ok, String error) {
+        this.ok = ok;
+        this.error = error;
+    }
+}

--- a/backend/src/main/java/com/woowacourse/kkogkkog/infrastructure/dto/PostSlackMessageResponse.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/infrastructure/dto/PostSlackMessageResponse.java
@@ -15,4 +15,8 @@ public class PostSlackMessageResponse {
         this.ok = ok;
         this.error = error;
     }
+
+    public boolean isError() {
+        return ok == null || !ok;
+    }
 }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/infrastructure/dto/SlackUserTokenResponse.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/infrastructure/dto/SlackUserTokenResponse.java
@@ -1,0 +1,28 @@
+package com.woowacourse.kkogkkog.infrastructure.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class SlackUserTokenResponse {
+
+    private Boolean ok;
+
+    @JsonProperty(value = "access_token")
+    private String accessToken;
+
+    private String error;
+
+    public SlackUserTokenResponse(Boolean ok, String accessToken, String error) {
+        this.ok = ok;
+        this.accessToken = accessToken;
+        this.error = error;
+    }
+
+    public boolean isError() {
+        return ok == null || !ok;
+    }
+}

--- a/backend/src/main/java/com/woowacourse/kkogkkog/infrastructure/dto/SlackUserTokenResponse.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/infrastructure/dto/SlackUserTokenResponse.java
@@ -14,7 +14,7 @@ public class SlackUserTokenResponse {
     @JsonProperty(value = "access_token")
     private String accessToken;
 
-    private String error;
+    private String error = "";
 
     public SlackUserTokenResponse(Boolean ok, String accessToken, String error) {
         this.ok = ok;


### PR DESCRIPTION
## 작업 내용

- 슬랙 OAuth Response 구현
- 슬랙 알림 Response 구현
- SlackClient [PARAMETERIZED_TYPE_REFERENCE 제거](https://github.com/woowacourse-teams/2022-kkogkkog/pull/386/commits/77b514a011e6ef709d6766c6f11b511ecdf7e86e)

## 공유사항

아서가 구글 소셜 로그인 구현 중 슬랙 클라이언트 변경을 요청하여 작업하였습니다. 
정적 Map으로 응답을 받아오던 부분을 제거하고 각각 해당하는 객체로 받아오도록 수정하였습니다. 
requestAccessToken 부분을 String 대신 Response Dto로 바꾸는 것도 제안하여 시도해봤는데 
관련 테스트의 변경과 accessToken 하나만 필요한 상황에서 현재 불 필요한 작업이라 판단하여 적용하지 않았습니다.
장기적으로 기존 구현된 SlackClient를 완전히 바꿔 구현 하는걸로 계획하고 있습니다.
