### PR TITLE
feat: 쿠폰 상세 조회를 받는 사람 또는 보낸 사람만 조회할 수 있게 변경

### DIFF
--- a/backend/src/main/java/com/woowacourse/kkogkkog/common/config/InterceptorConfig.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/common/config/InterceptorConfig.java
@@ -26,6 +26,7 @@ public class InterceptorConfig implements WebMvcConfigurer {
             .addPathPatterns("/api/coupons/received")
             .addPathPatterns("/api/coupons/me")
             .addPathPatterns("/api/v2/coupons")
+            .addPathPatterns("/api/v2/coupons/*")
             .addPathPatterns("/api/v2/coupons/accept")
             .addPathPatterns("/api/v2/coupons/send")
             .addPathPatterns("/api/v2/coupons/received")

--- a/backend/src/main/java/com/woowacourse/kkogkkog/coupon/application/CouponService.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/coupon/application/CouponService.java
@@ -14,6 +14,7 @@ import com.woowacourse.kkogkkog.coupon.domain.CouponHistory;
 import com.woowacourse.kkogkkog.coupon.domain.CouponStatus;
 import com.woowacourse.kkogkkog.coupon.domain.repository.CouponHistoryRepository;
 import com.woowacourse.kkogkkog.coupon.domain.repository.CouponRepository;
+import com.woowacourse.kkogkkog.coupon.exception.CouponNotAccessibleException;
 import com.woowacourse.kkogkkog.coupon.exception.CouponNotFoundException;
 import com.woowacourse.kkogkkog.infrastructure.event.PushAlarmPublisher;
 import com.woowacourse.kkogkkog.member.domain.Member;
@@ -49,7 +50,9 @@ public class CouponService {
     public CouponDetailResponse find(Long memberId, Long couponId) {
         Member member = findMember(memberId);
         Coupon coupon = findCoupon(couponId);
-        coupon.validateAccessibleMember(member);
+        if (coupon.isSenderOrReceiver(member)) {
+            throw new CouponNotAccessibleException();
+        }
         List<CouponHistory> couponHistories = couponHistoryRepository.findAllByCouponIdOrderByCreatedTimeDesc(
             couponId);
         return CouponDetailResponse.of(coupon, couponHistories);

--- a/backend/src/main/java/com/woowacourse/kkogkkog/coupon/application/CouponService.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/coupon/application/CouponService.java
@@ -46,8 +46,10 @@ public class CouponService {
     }
 
     @Transactional(readOnly = true)
-    public CouponDetailResponse find(Long couponId) {
+    public CouponDetailResponse find(Long memberId, Long couponId) {
+        Member member = findMember(memberId);
         Coupon coupon = findCoupon(couponId);
+        coupon.validateAccessibleMember(member);
         List<CouponHistory> couponHistories = couponHistoryRepository.findAllByCouponIdOrderByCreatedTimeDesc(
             couponId);
         return CouponDetailResponse.of(coupon, couponHistories);

--- a/backend/src/main/java/com/woowacourse/kkogkkog/coupon/application/CouponService.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/coupon/application/CouponService.java
@@ -50,7 +50,7 @@ public class CouponService {
     public CouponDetailResponse find(Long memberId, Long couponId) {
         Member member = findMember(memberId);
         Coupon coupon = findCoupon(couponId);
-        if (coupon.isSenderOrReceiver(member)) {
+        if (!coupon.isSenderOrReceiver(member)) {
             throw new CouponNotAccessibleException();
         }
         List<CouponHistory> couponHistories = couponHistoryRepository.findAllByCouponIdOrderByCreatedTimeDesc(

--- a/backend/src/main/java/com/woowacourse/kkogkkog/coupon/domain/Coupon.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/coupon/domain/Coupon.java
@@ -92,9 +92,7 @@ public class Coupon extends BaseEntity {
         couponState.changeStatus(couponEvent);
     }
 
-    public void validateAccessibleMember(Member member) {
-        if (!(sender.equals(member) || receiver.equals(member))) {
-            throw new CouponNotAccessibleException();
-        }
+    public boolean isSenderOrReceiver(Member member) {
+        return !(sender.equals(member) || receiver.equals(member));
     }
 }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/coupon/domain/Coupon.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/coupon/domain/Coupon.java
@@ -1,6 +1,7 @@
 package com.woowacourse.kkogkkog.coupon.domain;
 
 import com.woowacourse.kkogkkog.common.domain.BaseEntity;
+import com.woowacourse.kkogkkog.coupon.exception.CouponNotAccessibleException;
 import com.woowacourse.kkogkkog.coupon.exception.SameSenderReceiverException;
 import com.woowacourse.kkogkkog.member.domain.Member;
 import javax.persistence.Column;
@@ -89,5 +90,11 @@ public class Coupon extends BaseEntity {
     public void changeState(CouponEvent couponEvent, Member member) {
         couponEvent.checkExecutable(sender.equals(member), receiver.equals(member));
         couponState.changeStatus(couponEvent);
+    }
+
+    public void validateAccessibleMember(Member member) {
+        if (!(sender.equals(member) || receiver.equals(member))) {
+            throw new CouponNotAccessibleException();
+        }
     }
 }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/coupon/domain/Coupon.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/coupon/domain/Coupon.java
@@ -1,7 +1,6 @@
 package com.woowacourse.kkogkkog.coupon.domain;
 
 import com.woowacourse.kkogkkog.common.domain.BaseEntity;
-import com.woowacourse.kkogkkog.coupon.exception.CouponNotAccessibleException;
 import com.woowacourse.kkogkkog.coupon.exception.SameSenderReceiverException;
 import com.woowacourse.kkogkkog.member.domain.Member;
 import javax.persistence.Column;

--- a/backend/src/main/java/com/woowacourse/kkogkkog/coupon/domain/Coupon.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/coupon/domain/Coupon.java
@@ -93,6 +93,6 @@ public class Coupon extends BaseEntity {
     }
 
     public boolean isSenderOrReceiver(Member member) {
-        return !(sender.equals(member) || receiver.equals(member));
+        return sender.equals(member) || receiver.equals(member);
     }
 }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/coupon/exception/CouponNotAccessibleException.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/coupon/exception/CouponNotAccessibleException.java
@@ -1,0 +1,10 @@
+package com.woowacourse.kkogkkog.coupon.exception;
+
+import com.woowacourse.kkogkkog.common.exception.ForbiddenException;
+
+public class CouponNotAccessibleException extends ForbiddenException {
+
+    public CouponNotAccessibleException() {
+        super("접근할 수 없는 쿠폰입니다.");
+    }
+}

--- a/backend/src/main/java/com/woowacourse/kkogkkog/coupon/presentation/CouponController.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/coupon/presentation/CouponController.java
@@ -57,8 +57,9 @@ public class CouponController {
     }
 
     @GetMapping("/{couponId}")
-    public ResponseEntity<CouponDetailResponse> show(@PathVariable Long couponId) {
-        CouponDetailResponse couponDetailResponse = couponService.find(couponId);
+    public ResponseEntity<CouponDetailResponse> show(@LoginMemberId Long loginMemberId,
+                                                     @PathVariable Long couponId) {
+        CouponDetailResponse couponDetailResponse = couponService.find(loginMemberId, couponId);
         return ResponseEntity.ok(couponDetailResponse);
     }
 

--- a/backend/src/test/java/com/woowacourse/kkogkkog/acceptance/CouponAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/acceptance/CouponAcceptanceTest.java
@@ -86,7 +86,7 @@ public class CouponAcceptanceTest extends AcceptanceTest {
             COFFEE_쿠폰_생성_요청(List.of(1L, 2L)));
 
         CouponsResponse couponsResponse = extractableResponse.as(CouponsResponse.class);
-        ExtractableResponse<Response> extract = 회원의_단일쿠폰_상세정보를_조회한다(
+        ExtractableResponse<Response> extract = 회원의_단일쿠폰_상세정보를_조회한다(senderToken,
             couponsResponse.getData().get(0).getId());
 
         CouponDetailResponse couponDetailResponse = extract.as(CouponDetailResponse.class);
@@ -321,8 +321,8 @@ public class CouponAcceptanceTest extends AcceptanceTest {
         return invokeGetWithToken("/api/v2/coupons/received", token);
     }
 
-    static ExtractableResponse<Response> 회원의_단일쿠폰_상세정보를_조회한다(Long couponId) {
-        return invokeGet("/api/v2/coupons/" + couponId);
+    static ExtractableResponse<Response> 회원의_단일쿠폰_상세정보를_조회한다(String token, Long couponId) {
+        return invokeGetWithToken("/api/v2/coupons/" + couponId, token);
     }
 
     static ExtractableResponse<Response> 쿠폰_이벤트_요청을_한다(String token, Long couponId, Object data) {
@@ -346,7 +346,8 @@ public class CouponAcceptanceTest extends AcceptanceTest {
     }
 
     static CouponsResponse 쿠폰_생성을_요청하고(String token, Object data) {
-        ExtractableResponse<Response> response = invokePostWithToken("/api/v2/coupons", token, data);
+        ExtractableResponse<Response> response = invokePostWithToken("/api/v2/coupons", token,
+            data);
         return response.as(CouponsResponse.class);
     }
 }

--- a/backend/src/test/java/com/woowacourse/kkogkkog/coupon/application/CouponServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/coupon/application/CouponServiceTest.java
@@ -248,7 +248,6 @@ class CouponServiceTest {
             assertThatThrownBy(() -> couponService.find(anotherMemberId, couponId))
                 .isInstanceOf(CouponNotAccessibleException.class);
         }
-
     }
 
     @Nested

--- a/backend/src/test/java/com/woowacourse/kkogkkog/coupon/application/CouponServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/coupon/application/CouponServiceTest.java
@@ -213,13 +213,14 @@ class CouponServiceTest {
         }
 
         @Test
-        @DisplayName("쿠폰 아이디를 받으면, 쿠폰 상세 정보를 반환한다.")
+        @DisplayName("유저 아이디와 쿠폰 아이디를 받고 유저 아이디가 보낸 사람 또는 받은 사람이면, 쿠폰 상세 정보를 반환한다.")
         void success() {
             List<CouponResponse> response = couponService.save(
                 CouponDtoFixture.COFFEE_쿠폰_저장_요청(sender.getId(), List.of(receiver.getId())));
             Long couponId = response.get(0).getId();
+            Long senderId = sender.getId();
 
-            CouponDetailResponse couponDetailResponse = couponService.find(couponId);
+            CouponDetailResponse couponDetailResponse = couponService.find(senderId, couponId);
             String couponStatus = couponDetailResponse.getCouponStatus();
             LocalDateTime meetingDate = couponDetailResponse.getMeetingDate();
             List<CouponHistoryResponse> couponHistories = couponDetailResponse.getCouponHistories();

--- a/backend/src/test/java/com/woowacourse/kkogkkog/coupon/application/CouponServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/coupon/application/CouponServiceTest.java
@@ -243,8 +243,9 @@ class CouponServiceTest {
             List<CouponResponse> response = couponService.save(
                 CouponDtoFixture.COFFEE_쿠폰_저장_요청(sender.getId(), List.of(receiver1.getId())));
             Long couponId = response.get(0).getId();
+            Long anotherMemberId = receiver2.getId();
 
-            assertThatThrownBy(() -> couponService.find(receiver2.getId(), couponId))
+            assertThatThrownBy(() -> couponService.find(anotherMemberId, couponId))
                 .isInstanceOf(CouponNotAccessibleException.class);
         }
 

--- a/backend/src/test/java/com/woowacourse/kkogkkog/coupon/domain/CouponTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/coupon/domain/CouponTest.java
@@ -72,14 +72,13 @@ class CouponTest {
     class IsSenderOrReceiver {
 
         @Test
-        @DisplayName("보낸 사람 또는 받는 사람이 아니면, true 를 반환한다.")
+        @DisplayName("보낸 사람 또는 받는 사람이면, true 를 반환한다.")
         void success() {
             Member sender = SENDER.getMember();
             Member receiver = RECEIVER.getMember();
-            Member receiver2 = RECEIVER2.getMember();
             Coupon coupon = COFFEE.getCoupon(sender, receiver);
 
-            Boolean actual = coupon.isSenderOrReceiver(receiver2);
+            Boolean actual = coupon.isSenderOrReceiver(receiver);
 
             assertThat(actual).isTrue();
         }

--- a/backend/src/test/java/com/woowacourse/kkogkkog/coupon/domain/CouponTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/coupon/domain/CouponTest.java
@@ -3,12 +3,14 @@ package com.woowacourse.kkogkkog.coupon.domain;
 import static com.woowacourse.kkogkkog.coupon.domain.CouponEventType.FINISH;
 import static com.woowacourse.kkogkkog.support.fixture.domain.CouponFixture.COFFEE;
 import static com.woowacourse.kkogkkog.support.fixture.domain.MemberFixture.RECEIVER;
+import static com.woowacourse.kkogkkog.support.fixture.domain.MemberFixture.RECEIVER2;
 import static com.woowacourse.kkogkkog.support.fixture.domain.MemberFixture.ROOKIE;
 import static com.woowacourse.kkogkkog.support.fixture.domain.MemberFixture.SENDER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
+import com.woowacourse.kkogkkog.coupon.exception.CouponNotAccessibleException;
 import com.woowacourse.kkogkkog.coupon.exception.SameSenderReceiverException;
 import com.woowacourse.kkogkkog.member.domain.Member;
 import org.junit.jupiter.api.DisplayName;
@@ -62,6 +64,23 @@ class CouponTest {
 
             Member actual = coffee.getOppositeMember(sender);
             assertThat(actual).isEqualTo(receiver);
+        }
+    }
+
+    @Nested
+    @DisplayName("validateAccessibleMember 메서드는")
+    class ValidateAccessibleMember {
+
+        @Test
+        @DisplayName("보낸 사람과 받는 사람이 아니면, 예외를 발생시킨다.")
+        void success() {
+            Member sender = SENDER.getMember();
+            Member receiver = RECEIVER.getMember();
+            Coupon coupon = COFFEE.getCoupon(sender, receiver);
+
+            Member receiver2 = RECEIVER2.getMember();
+            assertThatThrownBy(() -> coupon.validateAccessibleMember(receiver2))
+                .isInstanceOf(CouponNotAccessibleException.class);
         }
     }
 }

--- a/backend/src/test/java/com/woowacourse/kkogkkog/coupon/domain/CouponTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/coupon/domain/CouponTest.java
@@ -68,19 +68,20 @@ class CouponTest {
     }
 
     @Nested
-    @DisplayName("validateAccessibleMember 메서드는")
-    class ValidateAccessibleMember {
+    @DisplayName("isSenderOrReceiver 메서드는")
+    class IsSenderOrReceiver {
 
         @Test
-        @DisplayName("보낸 사람과 받는 사람이 아니면, 예외를 발생시킨다.")
+        @DisplayName("보낸 사람 또는 받는 사람이 아니면, true 를 반환한다.")
         void success() {
             Member sender = SENDER.getMember();
             Member receiver = RECEIVER.getMember();
+            Member receiver2 = RECEIVER2.getMember();
             Coupon coupon = COFFEE.getCoupon(sender, receiver);
 
-            Member receiver2 = RECEIVER2.getMember();
-            assertThatThrownBy(() -> coupon.validateAccessibleMember(receiver2))
-                .isInstanceOf(CouponNotAccessibleException.class);
+            Boolean actual = coupon.isSenderOrReceiver(receiver2);
+
+            assertThat(actual).isTrue();
         }
     }
 }

--- a/backend/src/test/java/com/woowacourse/kkogkkog/coupon/domain/CouponTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/coupon/domain/CouponTest.java
@@ -73,7 +73,7 @@ class CouponTest {
 
         @Test
         @DisplayName("보낸 사람 또는 받는 사람이면, true 를 반환한다.")
-        void success() {
+        void success_true() {
             Member sender = SENDER.getMember();
             Member receiver = RECEIVER.getMember();
             Coupon coupon = COFFEE.getCoupon(sender, receiver);
@@ -81,6 +81,19 @@ class CouponTest {
             Boolean actual = coupon.isSenderOrReceiver(receiver);
 
             assertThat(actual).isTrue();
+        }
+
+        @Test
+        @DisplayName("보낸 사람이 아니고 받는 사람도 아니면, false 를 반환한다.")
+        void success_false() {
+            Member sender = SENDER.getMember();
+            Member receiver = RECEIVER.getMember();
+            Coupon coupon = COFFEE.getCoupon(sender, receiver);
+
+            Member receiver2 = RECEIVER2.getMember();
+            Boolean actual = coupon.isSenderOrReceiver(receiver2);
+
+            assertThat(actual).isFalse();
         }
     }
 }

--- a/backend/src/test/java/com/woowacourse/kkogkkog/documentation/CouponDocumentTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/documentation/CouponDocumentTest.java
@@ -162,7 +162,7 @@ class CouponDocumentTest extends DocumentTest {
     @Test
     void 상세_쿠폰_조회_API() throws Exception {
         given(jwtTokenProvider.getValidatedPayload(any())).willReturn("1");
-        given(couponService.find(any())).willReturn(
+        given(couponService.find(any(), any())).willReturn(
             쿠폰_상세_응답(1L, ROOKIE.getMember(1L), AUTHOR.getMember(2L),
                 쿠폰_상세_내역_응답(1L, ROOKIE.getMember(1L)))
         );


### PR DESCRIPTION
## 작업 내용

- 쿠폰 상세 조회 인터셉터를 등록한다.
- 받는 사람과 보낸 사람이 아니면 쿠폰 정보를 조회하지 않고 403 Forbbiden 상태 코드를 반환한다.

## 공유사항

없음

Resolves #388 