### PR TITLE
refactor: QueryClient.setQueryData의 Typing Issue 해결

### DIFF
--- a/frontend/src/@hooks/@queries/user.ts
+++ b/frontend/src/@hooks/@queries/user.ts
@@ -172,10 +172,6 @@ export const useReadHistory = () => {
 
   const readHistory = (id: number) => {
     queryClient.setQueryData<UserHistoryListResponse>([QUERY_KEY.userHistoryList], oldData => {
-      if (oldData === undefined) {
-        return;
-      }
-
       const newData = {
         ...oldData,
         data: oldData?.data?.map(history =>

--- a/frontend/src/@hooks/@queries/user.ts
+++ b/frontend/src/@hooks/@queries/user.ts
@@ -171,23 +171,20 @@ export const useReadHistory = () => {
   const queryClient = useQueryClient();
 
   const readHistory = (id: number) => {
-    queryClient.setQueryData<UserHistoryListResponse | undefined>(
-      [QUERY_KEY.userHistoryList],
-      oldData => {
-        if (oldData === undefined) {
-          return;
-        }
-
-        const newData = {
-          ...oldData,
-          data: oldData?.data?.map(history =>
-            history.id === id ? { ...history, isRead: true } : { ...history }
-          ),
-        };
-
-        return newData;
+    queryClient.setQueryData<UserHistoryListResponse>([QUERY_KEY.userHistoryList], oldData => {
+      if (oldData === undefined) {
+        return;
       }
-    );
+
+      const newData = {
+        ...oldData,
+        data: oldData?.data?.map(history =>
+          history.id === id ? { ...history, isRead: true } : { ...history }
+        ),
+      };
+
+      return newData;
+    });
   };
 
   return { readHistory };

--- a/frontend/src/@hooks/@queries/user.ts
+++ b/frontend/src/@hooks/@queries/user.ts
@@ -172,6 +172,10 @@ export const useReadHistory = () => {
 
   const readHistory = (id: number) => {
     queryClient.setQueryData<UserHistoryListResponse>([QUERY_KEY.userHistoryList], oldData => {
+      if (oldData === undefined) {
+        return;
+      }
+
       const newData = {
         ...oldData,
         data: oldData?.data?.map(history =>

--- a/frontend/src/types/react-query.d.ts
+++ b/frontend/src/types/react-query.d.ts
@@ -1,0 +1,12 @@
+import type { QueryKey, SetDataOptions } from 'react-query';
+import type { Updater } from 'react-query/types/core/utils';
+
+declare module 'react-query' {
+  export interface QueryClient {
+    setQueryData<TData>(
+      queryKey: QueryKey,
+      updater: Updater<TData | undefined, TData | undefined>,
+      options?: SetDataOptions
+    ): TData;
+  }
+}


### PR DESCRIPTION
## 작업 내용

현재 React Query 버전에서는 개선된 setQueryData의 타이핑 영역을 선언 병합을 통해 수정합니다. (`setQueryData`의 `Updater` 함수는 쿼리 데이터를 갱신할 수도 있고 갱신하지 않을 수도 있습니다. 고로 `Input`의 타입과 `Output`의 타입은 동일해야합니다.

[@beta 버젼에는 배포가 됨 - 풀리퀘 링크](https://github.com/TanStack/query/pull/3615)

## 공유사항



Resolves #399 
