### PR TITLE
feat: 회원의 닉네임을 기반으로 검색하는 기능 구현

### DIFF
--- a/backend/src/main/java/com/woowacourse/kkogkkog/member/application/MemberService.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/member/application/MemberService.java
@@ -18,8 +18,10 @@ import com.woowacourse.kkogkkog.member.domain.repository.MemberRepository;
 import com.woowacourse.kkogkkog.member.domain.repository.WorkspaceUserRepository;
 import com.woowacourse.kkogkkog.member.exception.MemberHistoryNotFoundException;
 import com.woowacourse.kkogkkog.member.exception.MemberNotFoundException;
+import com.woowacourse.kkogkkog.member.presentation.dto.MembersResponse;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -143,5 +145,13 @@ public class MemberService {
         for (CouponHistory couponHistory : couponHistories) {
             couponHistory.updateIsRead();
         }
+    }
+
+    public MembersResponse findByNickname(String searchName) {
+        List<Member> members = memberRepository.findByNickname(searchName);
+
+        return new MembersResponse(members.stream()
+            .map(MemberResponse::of)
+            .collect(Collectors.toList()));
     }
 }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/member/application/MemberService.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/member/application/MemberService.java
@@ -112,6 +112,15 @@ public class MemberService {
             .collect(toList());
     }
 
+    @Transactional(readOnly = true)
+    public MembersResponse findByNickname(String searchName) {
+        List<Member> members = memberRepository.findByNickname(searchName);
+
+        return new MembersResponse(members.stream()
+            .map(MemberResponse::of)
+            .collect(Collectors.toList()));
+    }
+
     public void updateNickname(MemberNicknameUpdateRequest memberNicknameUpdateRequest) {
         Member member = memberRepository.findById(memberNicknameUpdateRequest.getMemberId())
             .orElseThrow(MemberNotFoundException::new);
@@ -145,13 +154,5 @@ public class MemberService {
         for (CouponHistory couponHistory : couponHistories) {
             couponHistory.updateIsRead();
         }
-    }
-
-    public MembersResponse findByNickname(String searchName) {
-        List<Member> members = memberRepository.findByNickname(searchName);
-
-        return new MembersResponse(members.stream()
-            .map(MemberResponse::of)
-            .collect(Collectors.toList()));
     }
 }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/member/domain/repository/MemberRepository.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/member/domain/repository/MemberRepository.java
@@ -1,12 +1,18 @@
 package com.woowacourse.kkogkkog.member.domain.repository;
 
 import com.woowacourse.kkogkkog.member.domain.Member;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByEmail(String email);
+
+    @Query("SELECT m FROM Member m WHERE m.nickname.value LIKE :nickname%")
+    List<Member> findByNickname(@Param("nickname") String nickname);
 }

--- a/backend/src/test/java/com/woowacourse/kkogkkog/member/application/MemberServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/member/application/MemberServiceTest.java
@@ -9,6 +9,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
+import com.woowacourse.kkogkkog.member.presentation.dto.MembersResponse;
 import com.woowacourse.kkogkkog.support.application.ServiceTest;
 import com.woowacourse.kkogkkog.auth.application.dto.MemberUpdateResponse;
 import com.woowacourse.kkogkkog.coupon.application.CouponService;
@@ -225,6 +226,22 @@ class MemberServiceTest extends ServiceTest {
             String actual = memberService.findById(memberId).getNickname();
 
             assertThat(actual).isEqualTo(expected);
+        }
+    }
+
+    @Nested
+    @DisplayName("findByNickname 메서드는")
+    class FindByNickname {
+
+        @Test
+        @DisplayName("사용자의 닉네임을 기준으로 회원 검색을 한다.")
+        void success() {
+            Member member = ROOKIE.getMember(workspace);
+            Long memberId = memberRepository.save(member).getId();
+
+            MembersResponse actual = memberService.findByNickname(member.getNickname());
+
+            assertThat(actual.getData()).hasSize(1);
         }
     }
 }

--- a/backend/src/test/java/com/woowacourse/kkogkkog/member/domain/repository/MemberRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/member/domain/repository/MemberRepositoryTest.java
@@ -1,0 +1,42 @@
+package com.woowacourse.kkogkkog.member.domain.repository;
+
+import static com.woowacourse.kkogkkog.support.fixture.domain.MemberFixture.LEO;
+import static com.woowacourse.kkogkkog.support.fixture.domain.MemberFixture.ROOKIE;
+import static com.woowacourse.kkogkkog.support.fixture.domain.WorkspaceFixture.KKOGKKOG;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.woowacourse.kkogkkog.member.domain.Member;
+import com.woowacourse.kkogkkog.member.domain.Workspace;
+import com.woowacourse.kkogkkog.support.repository.RepositoryTest;
+import java.util.List;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@RepositoryTest
+class MemberRepositoryTest {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Autowired
+    private WorkspaceRepository workspaceRepository;
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Test
+    @DisplayName("회원의 nickname이 앞글자부터 동일한 nickname을 찾는다.")
+    void findByNickname() {
+        Workspace workspace = workspaceRepository.save(KKOGKKOG.getWorkspace());
+        memberRepository.save(ROOKIE.getMember(workspace));
+        memberRepository.save(LEO.getMember(workspace));
+
+        entityManager.clear();
+
+        List<Member> members = memberRepository.findByNickname("루");
+
+        assertThat(members).hasSize(1);
+    }
+}


### PR DESCRIPTION
## 작업 내용

- 회원 닉네임을 기반으로 검색하는 기능을 구현하였습니다.

  - `nickname%`을 통해 닉네임을 검색합니다.

## 공유사항

- API는 개발하지 않았습니다. 추후 기획이 변경될경우 해당 로직을 사용하면 될 것으로 보입니다.

Resolves  #345