### PR TITLE
refactor: QueryClient 선언 병합 수정 및 useCouponPartner 함수 오버로드 수정

### DIFF
--- a/frontend/src/@hooks/ui/coupon/useCouponPartner.ts
+++ b/frontend/src/@hooks/ui/coupon/useCouponPartner.ts
@@ -1,5 +1,4 @@
 import { useFetchMe } from '@/@hooks/@queries/user';
-import { Coupon } from '@/types/coupon/client';
 import { Member } from '@/types/user/client';
 
 interface useCouponPartnerProps {
@@ -11,11 +10,14 @@ function useCouponPartner(coupon: useCouponPartnerProps): {
   isSent: boolean;
   member: Member;
 };
-function useCouponPartner(coupon: Coupon | undefined): {
+function useCouponPartner(coupon: useCouponPartnerProps | undefined): {
   isSent: boolean;
   member: Member | undefined;
 };
-function useCouponPartner(coupon: any) {
+function useCouponPartner(coupon: useCouponPartnerProps | undefined): {
+  isSent: boolean;
+  member: Member | undefined;
+} {
   const { me } = useFetchMe();
 
   const isSent = coupon?.sender.id === me?.id;

--- a/frontend/src/types/react-query.d.ts
+++ b/frontend/src/types/react-query.d.ts
@@ -2,7 +2,7 @@ import type { QueryKey, SetDataOptions } from 'react-query';
 import type { Updater } from 'react-query/types/core/utils';
 
 declare module 'react-query' {
-  export interface QueryClient {
+  export class QueryClient {
     setQueryData<TData>(
       queryKey: QueryKey,
       updater: Updater<TData | undefined, TData | undefined>,


### PR DESCRIPTION
## 작업 내용

- QueryClient를 interface로 작성해서, new QueryClient로 생성할 때 오류가 발생했습니다. 그래서 class로 바꾸어줬습니다. class 타입도 선언 병합 되는 것 같네요.
- 함수 오버로딩은 <오버로드 시그니처>, <구현 시그니처> 를 가집니다. 구현 시그니처는 오버로드 시그니처를 포함하는 타입이어야 합니다. 그래서 보통 any나 unknown으로 선언된 것들을 많이 보았는데요. 어떤 차이일지는 모르겠으나, 일단 가장 좁게 선언해두는 것이 좋을 것 같습니다.

```typescript
function add(a: string, b?: string, c?: string): string; // (1) overload signature
function add(a: number, b?: number, c?: number): number; // (2) overload signature
function add(a: any, b?: any, c?: any): any { // (3) implementation signature
  if (b) {
    if (c) {
      return a + b + c;
    }
    return a + b;
  }
  return a;
};
```

Resolves #410
