### PR TITLE
fix: 쿠폰 상태 동시 수정시 배타 락 설정

### DIFF
--- a/backend/src/main/java/com/woowacourse/kkogkkog/coupon/application/CouponService.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/coupon/application/CouponService.java
@@ -99,7 +99,7 @@ public class CouponService {
     public void updateStatus(CouponStatusRequest request) {
         CouponEvent event = request.getEvent();
         Member loginMember = findMember(request.getMemberId());
-        Coupon coupon = findCoupon(request.getCouponId());
+        Coupon coupon = couponRepository.findByIdWithLock(request.getCouponId());
         coupon.changeState(event, loginMember);
         saveCouponHistory(CouponHistory.of(loginMember, coupon, event, request.getMessage()));
     }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/coupon/domain/repository/CouponRepository.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/coupon/domain/repository/CouponRepository.java
@@ -2,10 +2,14 @@ package com.woowacourse.kkogkkog.coupon.domain.repository;
 
 import com.woowacourse.kkogkkog.coupon.domain.Coupon;
 import com.woowacourse.kkogkkog.coupon.domain.CouponStatus;
+import com.woowacourse.kkogkkog.coupon.exception.CouponNotFoundException;
 import com.woowacourse.kkogkkog.member.domain.Member;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
+import javax.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -50,4 +54,12 @@ public interface CouponRepository extends JpaRepository<Coupon, Long> {
         + "ORDER BY c.couponState.meetingDate DESC")
     List<Coupon> findAllByMemberAndMeetingDate(@Param("member") Member member,
                                                @Param("nowDate") LocalDateTime nowDate);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT c FROM Coupon c where c.id = :id")
+    Optional<Coupon> findByIdWithExclusiveLock(@Param("id") Long id);
+
+    default Coupon findByIdWithLock(Long id) {
+        return findByIdWithExclusiveLock(id).orElseThrow(CouponNotFoundException::new);
+    }
 }

--- a/backend/src/test/java/com/woowacourse/kkogkkog/coupon/application/ConcurrentCouponServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/coupon/application/ConcurrentCouponServiceTest.java
@@ -1,0 +1,96 @@
+package com.woowacourse.kkogkkog.coupon.application;
+
+import static com.woowacourse.kkogkkog.coupon.domain.CouponEventType.ACCEPT;
+import static com.woowacourse.kkogkkog.coupon.domain.CouponEventType.CANCEL;
+import static com.woowacourse.kkogkkog.support.fixture.domain.CouponFixture.COFFEE;
+import static com.woowacourse.kkogkkog.support.fixture.domain.MemberFixture.JEONG;
+import static com.woowacourse.kkogkkog.support.fixture.domain.MemberFixture.LEO;
+import static com.woowacourse.kkogkkog.support.fixture.domain.WorkspaceFixture.KKOGKKOG;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.woowacourse.kkogkkog.common.exception.InvalidRequestException;
+import com.woowacourse.kkogkkog.coupon.application.dto.CouponStatusRequest;
+import com.woowacourse.kkogkkog.coupon.domain.Coupon;
+import com.woowacourse.kkogkkog.coupon.domain.CouponEventType;
+import com.woowacourse.kkogkkog.coupon.domain.repository.CouponRepository;
+import com.woowacourse.kkogkkog.member.domain.Member;
+import com.woowacourse.kkogkkog.member.domain.Workspace;
+import com.woowacourse.kkogkkog.member.domain.repository.MemberRepository;
+import com.woowacourse.kkogkkog.member.domain.repository.WorkspaceRepository;
+import com.woowacourse.kkogkkog.support.common.DatabaseCleaner;
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadPoolExecutor;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@DisplayName("동시성을 고려했을 때 CouponService의")
+class ConcurrentCouponServiceTest {
+
+    @Autowired
+    private CouponService couponService;
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private CouponRepository couponRepository;
+    @Autowired
+    private WorkspaceRepository workspaceRepository;
+    @Autowired
+    private DatabaseCleaner databaseCleaner;
+
+    @AfterEach
+    void tearDown() {
+        databaseCleaner.execute();
+    }
+
+    @Nested
+    @DisplayName("updateStatus 메서드는")
+    class UpdateStatus {
+
+        private Member sender;
+        private Member receiver;
+
+        @BeforeEach
+        void setUp() {
+            Workspace workspace = workspaceRepository.save(KKOGKKOG.getWorkspace());
+            sender = memberRepository.save(JEONG.getMember(workspace));
+            receiver = memberRepository.save(LEO.getMember(workspace));
+        }
+
+        @Test
+        @DisplayName("동일한 쿠폰에 대해 동시에 복수의 수정 요청이 들어와도 베타락을 통해 순차적으로 처리한다.")
+        void exclusiveLockToPreventLostUpdate() throws Exception {
+            Coupon coupon = couponRepository.save(COFFEE.getRequestedCoupon(sender, receiver));
+            final var executor = (ThreadPoolExecutor) Executors.newFixedThreadPool(2);
+            Future<Boolean> cancelRequest = executor.submit(
+                () -> runAndCheckSuccess(receiver, coupon, CANCEL));
+            Future<Boolean> acceptRequest = executor.submit(
+                () -> runAndCheckSuccess(sender, coupon, ACCEPT));
+
+            List<Boolean> actual = List.of(cancelRequest.get(), acceptRequest.get());
+
+            assertThat(actual).containsExactlyInAnyOrder(false, true);
+        }
+
+        private boolean runAndCheckSuccess(Member member,
+                                           Coupon coupon,
+                                           CouponEventType eventType) {
+            CouponStatusRequest couponStatusRequest = new CouponStatusRequest(member.getId(),
+                coupon.getId(), eventType, null, "쿠폰 이벤트 관련 메시지");
+            try {
+                couponService.updateStatus(couponStatusRequest);
+                return true;
+            } catch (InvalidRequestException e) {
+                return false;
+            }
+        }
+    }
+}

--- a/backend/src/test/java/com/woowacourse/kkogkkog/support/fixture/domain/CouponFixture.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/support/fixture/domain/CouponFixture.java
@@ -2,8 +2,10 @@ package com.woowacourse.kkogkkog.support.fixture.domain;
 
 import com.woowacourse.kkogkkog.coupon.domain.Coupon;
 import com.woowacourse.kkogkkog.coupon.domain.CouponState;
+import com.woowacourse.kkogkkog.coupon.domain.CouponStatus;
 import com.woowacourse.kkogkkog.coupon.domain.CouponType;
 import com.woowacourse.kkogkkog.member.domain.Member;
+import java.time.LocalDateTime;
 
 public enum CouponFixture {
 
@@ -29,6 +31,11 @@ public enum CouponFixture {
 
     public Coupon getCoupon(Member sender, Member receiver) {
         return new Coupon(sender, receiver, couponTag, couponMessage, couponType);
+    }
+
+    public Coupon getRequestedCoupon(Member sender, Member receiver) {
+        return new Coupon(null, sender, receiver, couponTag, couponMessage, couponType,
+            new CouponState(CouponStatus.REQUESTED, LocalDateTime.now().plusDays(7)));
     }
 
     public Coupon getCoupon(Member sender,


### PR DESCRIPTION
## 작업 내용

- 수정할 쿠폰에 대해 배타락(select ~ for update)을 건다.
  - 일반적인 select문에서도 배타락 걸린 쿠폰 데이터 조회 가능
  - 배타락이 걸린 쿠폰을 다른 트랜잭션에서 베타락을 걸려는 경우에만 잠시 블록킹으로 대기하게 됨
  - 배타락이 풀리게 되면 대기 중이던 (베타락을 걸려는) 트랜잭션은 수정이 완료된 쿠폰을 조회하여 수정 가능 여부를 애플리케이션 레벨에서 검증함.

## 공유사항

- 이 악물고 테스트 코드 작성 성공
- `@Transaction`이 붙은 테스트 코드에서는 동시성 검증이 불가능해서 `ConcurrentCouponServiceTest`로 분리하여 구현함.

Resolves #413
