### PR TITLE
feat: 구글로 로그인했을 경우 기존 회원과 통합할 수 있도록 구현

### DIFF
--- a/backend/src/docs/asciidoc/auth.adoc
+++ b/backend/src/docs/asciidoc/auth.adoc
@@ -15,5 +15,8 @@ operation::auth-google-login[snippets='http-request,http-response']
 === 회원가입
 operation::auth-signUp[snippets='http-request,http-response']
 
+=== 구글 회원가입
+operation::auth-signUp-google[snippets='http-request,http-response']
+
 === 슬랙 앱 설치
 operation::slack-bot-install[snippets='http-request,http-response,request-fields']

--- a/backend/src/main/java/com/woowacourse/kkogkkog/auth/application/AuthService.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/auth/application/AuthService.java
@@ -10,6 +10,7 @@ import com.woowacourse.kkogkkog.infrastructure.dto.SlackUserInfo;
 import com.woowacourse.kkogkkog.infrastructure.dto.WorkspaceResponse;
 import com.woowacourse.kkogkkog.member.application.MemberService;
 import com.woowacourse.kkogkkog.member.application.dto.MemberCreateResponse;
+import com.woowacourse.kkogkkog.member.domain.Member;
 import com.woowacourse.kkogkkog.member.domain.Workspace;
 import com.woowacourse.kkogkkog.member.domain.repository.WorkspaceRepository;
 import com.woowacourse.kkogkkog.member.presentation.dto.MemberCreateRequest;
@@ -45,6 +46,13 @@ public class AuthService {
         return memberService.save(userInfo, workspace, nickname);
     }
 
+    public Long signUpGoogle(MemberCreateRequest memberCreateRequest) {
+        String accessToken = memberCreateRequest.getAccessToken();
+        GoogleUserInfo userInfo = googleClient.requestUserInfo(accessToken);
+        String nickname = memberCreateRequest.getNickname();
+        return memberService.save(userInfo, nickname);
+    }
+
     public TokenResponse login(String code) {
         String accessToken = slackClient.requestAccessToken(code);
         SlackUserInfo userInfo = slackClient.requestUserInfo(accessToken);
@@ -61,9 +69,11 @@ public class AuthService {
         String accessToken = googleClient.requestAccessToken(code);
         GoogleUserInfo userInfo = googleClient.requestUserInfo(accessToken);
 
-        //TODO 기존 SlackMember와 신규 GoogleMember 통합이후 회원가입 관련 로직 추가 필요
-        String test = jwtTokenProvider.createToken("임시");
-        return new TokenResponse(test, true);
+        Optional<Member> member = memberService.findByEmail(userInfo.getEmail());
+        return member.map(it -> new TokenResponse(
+                jwtTokenProvider.createToken(it.getId().toString()),
+                false))
+            .orElseGet(() -> new TokenResponse(accessToken, true));
     }
 
     public MemberCreateResponse loginByMemberId(Long id) {

--- a/backend/src/main/java/com/woowacourse/kkogkkog/auth/application/AuthService.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/auth/application/AuthService.java
@@ -5,7 +5,7 @@ import com.woowacourse.kkogkkog.auth.application.dto.TokenResponse;
 import com.woowacourse.kkogkkog.auth.support.JwtTokenProvider;
 import com.woowacourse.kkogkkog.infrastructure.application.GoogleClient;
 import com.woowacourse.kkogkkog.infrastructure.application.SlackClient;
-import com.woowacourse.kkogkkog.infrastructure.dto.GoogleUserInfo;
+import com.woowacourse.kkogkkog.infrastructure.dto.GoogleUserDto;
 import com.woowacourse.kkogkkog.infrastructure.dto.SlackUserInfo;
 import com.woowacourse.kkogkkog.infrastructure.dto.WorkspaceResponse;
 import com.woowacourse.kkogkkog.member.application.MemberService;
@@ -48,9 +48,9 @@ public class AuthService {
 
     public Long signUpGoogle(MemberCreateRequest memberCreateRequest) {
         String accessToken = memberCreateRequest.getAccessToken();
-        GoogleUserInfo userInfo = googleClient.requestUserInfo(accessToken);
+        GoogleUserDto userDto = googleClient.requestUserInfo(accessToken);
         String nickname = memberCreateRequest.getNickname();
-        return memberService.save(userInfo, nickname);
+        return memberService.save(userDto, nickname);
     }
 
     public TokenResponse login(String code) {
@@ -67,9 +67,9 @@ public class AuthService {
 
     public TokenResponse loginGoogle(String code) {
         String accessToken = googleClient.requestAccessToken(code);
-        GoogleUserInfo userInfo = googleClient.requestUserInfo(accessToken);
+        GoogleUserDto userDto = googleClient.requestUserInfo(accessToken);
 
-        Optional<Member> member = memberService.findByEmail(userInfo.getEmail());
+        Optional<Member> member = memberService.findByEmail(userDto.getEmail());
         return member.map(it -> new TokenResponse(
                 jwtTokenProvider.createToken(it.getId().toString()),
                 false))

--- a/backend/src/main/java/com/woowacourse/kkogkkog/auth/presentation/AuthController.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/auth/presentation/AuthController.java
@@ -30,13 +30,6 @@ public class AuthController {
         return ResponseEntity.ok(tokenResponse);
     }
 
-    @GetMapping("/login/google")
-    public ResponseEntity<TokenResponse> googleLogin(@RequestParam String code) {
-        TokenResponse tokenResponse = authService.loginGoogle(code);
-
-        return ResponseEntity.ok(tokenResponse);
-    }
-
     @PostMapping("/install/bot")
     public ResponseEntity<Void> installSlackApp(
         @RequestBody InstallSlackAppRequest installSlackAppRequest) {

--- a/backend/src/main/java/com/woowacourse/kkogkkog/auth/presentation/AuthV2Controller.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/auth/presentation/AuthV2Controller.java
@@ -31,15 +31,33 @@ public class AuthV2Controller {
     }
 
     @PostMapping("/install/bot")
-    public ResponseEntity<Void> installSlackApp(@RequestBody InstallSlackAppRequest installSlackAppRequest) {
+    public ResponseEntity<Void> installSlackApp(
+        @RequestBody InstallSlackAppRequest installSlackAppRequest) {
         authService.installSlackApp(installSlackAppRequest.getCode());
 
         return ResponseEntity.ok().build();
     }
 
     @PostMapping("/signup/token")
-    public ResponseEntity<MemberCreateResponse> save(@RequestBody MemberCreateRequest memberCreateRequest) {
+    public ResponseEntity<MemberCreateResponse> save(
+        @RequestBody MemberCreateRequest memberCreateRequest) {
         Long id = authService.signUp(memberCreateRequest);
+        MemberCreateResponse memberCreateResponse = authService.loginByMemberId(id);
+
+        return ResponseEntity.created(null).body(memberCreateResponse);
+    }
+
+    @GetMapping("/login/google")
+    public ResponseEntity<TokenResponse> googleLogin(@RequestParam String code) {
+        TokenResponse tokenResponse = authService.loginGoogle(code);
+
+        return ResponseEntity.ok(tokenResponse);
+    }
+
+    @PostMapping("/signup/google")
+    public ResponseEntity<MemberCreateResponse> saveGoogle(
+        @RequestBody MemberCreateRequest memberCreateRequest) {
+        Long id = authService.signUpGoogle(memberCreateRequest);
         MemberCreateResponse memberCreateResponse = authService.loginByMemberId(id);
 
         return ResponseEntity.created(null).body(memberCreateResponse);

--- a/backend/src/main/java/com/woowacourse/kkogkkog/infrastructure/application/GoogleClient.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/infrastructure/application/GoogleClient.java
@@ -1,7 +1,7 @@
 package com.woowacourse.kkogkkog.infrastructure.application;
 
 import com.woowacourse.kkogkkog.infrastructure.dto.GoogleAccessTokenResponse;
-import com.woowacourse.kkogkkog.infrastructure.dto.GoogleUserInfo;
+import com.woowacourse.kkogkkog.infrastructure.dto.GoogleUserDto;
 import com.woowacourse.kkogkkog.infrastructure.exception.AccessTokenRetrievalFailedException;
 import com.woowacourse.kkogkkog.infrastructure.exception.OAuthUserInfoRequestFailedException;
 import lombok.extern.slf4j.Slf4j;
@@ -79,13 +79,13 @@ public class GoogleClient {
         return formData;
     }
 
-    public GoogleUserInfo requestUserInfo(String accessToken) {
+    public GoogleUserDto requestUserInfo(String accessToken) {
         try {
             return userInfoClient
                 .get()
                 .headers(header -> header.setBearerAuth(accessToken))
                 .retrieve()
-                .bodyToMono(GoogleUserInfo.class)
+                .bodyToMono(GoogleUserDto.class)
                 .blockOptional()
                 .orElseThrow(OAuthUserInfoRequestFailedException::new);
         } catch (WebClientException e) {

--- a/backend/src/main/java/com/woowacourse/kkogkkog/infrastructure/dto/GoogleUserDto.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/infrastructure/dto/GoogleUserDto.java
@@ -5,13 +5,13 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
-public class GoogleUserInfo {
+public class GoogleUserDto {
 
     private String name;
     private String email;
     private String picture;
 
-    public GoogleUserInfo(String name, String email, String picture) {
+    public GoogleUserDto(String name, String email, String picture) {
         this.name = name;
         this.email = email;
         this.picture = picture;

--- a/backend/src/main/java/com/woowacourse/kkogkkog/member/application/MemberService.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/member/application/MemberService.java
@@ -5,6 +5,7 @@ import static java.util.stream.Collectors.toList;
 import com.woowacourse.kkogkkog.auth.application.dto.MemberUpdateResponse;
 import com.woowacourse.kkogkkog.coupon.domain.CouponHistory;
 import com.woowacourse.kkogkkog.coupon.domain.repository.CouponHistoryRepository;
+import com.woowacourse.kkogkkog.infrastructure.dto.GoogleUserInfo;
 import com.woowacourse.kkogkkog.infrastructure.dto.SlackUserInfo;
 import com.woowacourse.kkogkkog.member.application.dto.MemberHistoryResponse;
 import com.woowacourse.kkogkkog.member.application.dto.MemberNicknameUpdateRequest;
@@ -18,7 +19,6 @@ import com.woowacourse.kkogkkog.member.domain.repository.MemberRepository;
 import com.woowacourse.kkogkkog.member.domain.repository.WorkspaceUserRepository;
 import com.woowacourse.kkogkkog.member.exception.MemberHistoryNotFoundException;
 import com.woowacourse.kkogkkog.member.exception.MemberNotFoundException;
-import com.woowacourse.kkogkkog.member.presentation.dto.MembersResponse;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -57,6 +57,15 @@ public class MemberService {
         workspaceUserRepository.save(
             new WorkspaceUser(newMember, userId, workspace, nickname, email, imageUrl));
         return newMember.getId();
+    }
+
+    public Long save(GoogleUserInfo userInfo, String nickname) {
+        String email = userInfo.getEmail();
+        String imageUrl = userInfo.getPicture();
+        Member savedMember = memberRepository.save(
+            new Member(new Nickname(nickname), email, imageUrl)
+        );
+        return savedMember.getId();
     }
 
     public MemberUpdateResponse update(SlackUserInfo userInfo, Workspace workspace) {
@@ -103,6 +112,11 @@ public class MemberService {
             .countByHostMemberAndIsReadFalse(findMember);
 
         return MyProfileResponse.of(findMember, unreadHistoryCount);
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<Member> findByEmail(String email) {
+        return memberRepository.findByEmail(email);
     }
 
     @Transactional(readOnly = true)

--- a/backend/src/main/java/com/woowacourse/kkogkkog/member/application/MemberService.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/member/application/MemberService.java
@@ -5,7 +5,7 @@ import static java.util.stream.Collectors.toList;
 import com.woowacourse.kkogkkog.auth.application.dto.MemberUpdateResponse;
 import com.woowacourse.kkogkkog.coupon.domain.CouponHistory;
 import com.woowacourse.kkogkkog.coupon.domain.repository.CouponHistoryRepository;
-import com.woowacourse.kkogkkog.infrastructure.dto.GoogleUserInfo;
+import com.woowacourse.kkogkkog.infrastructure.dto.GoogleUserDto;
 import com.woowacourse.kkogkkog.infrastructure.dto.SlackUserInfo;
 import com.woowacourse.kkogkkog.member.application.dto.MemberHistoryResponse;
 import com.woowacourse.kkogkkog.member.application.dto.MemberNicknameUpdateRequest;
@@ -59,9 +59,9 @@ public class MemberService {
         return newMember.getId();
     }
 
-    public Long save(GoogleUserInfo userInfo, String nickname) {
-        String email = userInfo.getEmail();
-        String imageUrl = userInfo.getPicture();
+    public Long save(GoogleUserDto userDto, String nickname) {
+        String email = userDto.getEmail();
+        String imageUrl = userDto.getPicture();
         Member savedMember = memberRepository.save(
             new Member(nickname, email, imageUrl)
         );

--- a/backend/src/main/java/com/woowacourse/kkogkkog/member/application/MemberService.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/member/application/MemberService.java
@@ -63,7 +63,7 @@ public class MemberService {
         String email = userInfo.getEmail();
         String imageUrl = userInfo.getPicture();
         Member savedMember = memberRepository.save(
-            new Member(new Nickname(nickname), email, imageUrl)
+            new Member(nickname, email, imageUrl)
         );
         return savedMember.getId();
     }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/member/domain/Member.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/member/domain/Member.java
@@ -22,7 +22,6 @@ public class Member {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false)
     private String userId;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/backend/src/main/java/com/woowacourse/kkogkkog/member/domain/Member.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/member/domain/Member.java
@@ -37,8 +37,8 @@ public class Member {
     @Column(nullable = false)
     private String imageUrl;
 
-    public Member(Nickname nickname, String email, String imageUrl) {
-        this(null, null, null, nickname, email, imageUrl);
+    public Member(String nickname, String email, String imageUrl) {
+        this(null, null, null, new Nickname(nickname), email, imageUrl);
     }
 
     public Member(String userId, Workspace workspace, Nickname nickname, String email,

--- a/backend/src/main/java/com/woowacourse/kkogkkog/member/domain/Member.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/member/domain/Member.java
@@ -37,6 +37,10 @@ public class Member {
     @Column(nullable = false)
     private String imageUrl;
 
+    public Member(Nickname nickname, String email, String imageUrl) {
+        this(null, null, null, nickname, email, imageUrl);
+    }
+
     public Member(String userId, Workspace workspace, Nickname nickname, String email,
                   String imageUrl) {
         this(null, userId, workspace, nickname, email, imageUrl);

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -42,5 +42,5 @@ security:
     client-id: "11111111111.apps.googleusercontent.com"
     client-secret: "111111-111111111-11111111"
     redirect:
-      login: "http://localhost:3000"
+      login: "http://localhost:3000/login/google/redirect"
 

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -42,5 +42,5 @@ security:
     client-id: "11111111111.apps.googleusercontent.com"
     client-secret: "111111-111111111-11111111"
     redirect:
-      login: "http://localhost:8080"
+      login: "http://localhost:3000"
 

--- a/backend/src/main/resources/db/migration/V2.3__make_user_id_nullable.sql
+++ b/backend/src/main/resources/db/migration/V2.3__make_user_id_nullable.sql
@@ -1,2 +1,4 @@
 ALTER TABLE `member`
     MODIFY COLUMN `user_id` VARCHAR(255);
+ALTER TABLE `member`
+    MODIFY COLUMN `workspace_id` VARCHAR(255);

--- a/backend/src/main/resources/db/migration/V2.3__make_user_id_nullable.sql
+++ b/backend/src/main/resources/db/migration/V2.3__make_user_id_nullable.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `member`
+    MODIFY COLUMN `user_id` VARCHAR(255);

--- a/backend/src/test/java/com/woowacourse/kkogkkog/auth/application/AuthServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/auth/application/AuthServiceTest.java
@@ -9,7 +9,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 
 import com.woowacourse.kkogkkog.auth.application.dto.TokenResponse;
-import com.woowacourse.kkogkkog.infrastructure.dto.GoogleUserInfo;
+import com.woowacourse.kkogkkog.infrastructure.dto.GoogleUserDto;
 import com.woowacourse.kkogkkog.infrastructure.dto.SlackUserInfo;
 import com.woowacourse.kkogkkog.infrastructure.dto.WorkspaceResponse;
 import com.woowacourse.kkogkkog.infrastructure.exception.AccessTokenRetrievalFailedException;
@@ -89,7 +89,7 @@ class AuthServiceTest extends ServiceTest {
                 .willReturn(USER_ACCESS_TOKEN);
             given(googleClient.requestUserInfo(USER_ACCESS_TOKEN))
                 .willReturn(
-                    new GoogleUserInfo(
+                    new GoogleUserDto(
                         memberResponse.getNickname(),
                         memberResponse.getEmail(),
                         memberResponse.getImageUrl()));
@@ -102,7 +102,7 @@ class AuthServiceTest extends ServiceTest {
         @DisplayName("기존 회원이 가입을 하면, 토큰과 isNew를 false로 반환한다.")
         void success_registeredMember() {
             MemberResponse memberResponse = MemberResponse.of(ROOKIE.getMember());
-            GoogleUserInfo userInfo = new GoogleUserInfo(
+            GoogleUserDto userInfo = new GoogleUserDto(
                 memberResponse.getNickname(),
                 memberResponse.getEmail(),
                 memberResponse.getImageUrl());
@@ -137,7 +137,7 @@ class AuthServiceTest extends ServiceTest {
         @DisplayName("acceesToken,닉네임을 받으면 회원가입을 완료한다.")
         void success() {
             MemberCreateRequest memberCreateRequest = new MemberCreateRequest("accessToken", "닉네임");
-            GoogleUserInfo userInfo = new GoogleUserInfo("testName", "test@email.com", "testimage");
+            GoogleUserDto userInfo = new GoogleUserDto("testName", "test@email.com", "testimage");
             given(googleClient.requestUserInfo(anyString())).willReturn(userInfo);
 
             Long id = authService.signUpGoogle(memberCreateRequest);

--- a/backend/src/test/java/com/woowacourse/kkogkkog/auth/application/AuthServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/auth/application/AuthServiceTest.java
@@ -144,7 +144,6 @@ class AuthServiceTest extends ServiceTest {
 
             assertThat(id).isNotNull();
         }
-
     }
 
     @Nested

--- a/backend/src/test/java/com/woowacourse/kkogkkog/auth/application/AuthServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/auth/application/AuthServiceTest.java
@@ -5,6 +5,7 @@ import static com.woowacourse.kkogkkog.support.fixture.domain.WorkspaceFixture.K
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 
 import com.woowacourse.kkogkkog.auth.application.dto.TokenResponse;
@@ -12,7 +13,9 @@ import com.woowacourse.kkogkkog.infrastructure.dto.GoogleUserInfo;
 import com.woowacourse.kkogkkog.infrastructure.dto.SlackUserInfo;
 import com.woowacourse.kkogkkog.infrastructure.dto.WorkspaceResponse;
 import com.woowacourse.kkogkkog.infrastructure.exception.AccessTokenRetrievalFailedException;
+import com.woowacourse.kkogkkog.member.application.MemberService;
 import com.woowacourse.kkogkkog.member.application.dto.MemberResponse;
+import com.woowacourse.kkogkkog.member.presentation.dto.MemberCreateRequest;
 import com.woowacourse.kkogkkog.support.application.ServiceTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -32,6 +35,9 @@ class AuthServiceTest extends ServiceTest {
 
     @Autowired
     private AuthService authService;
+
+    @Autowired
+    private MemberService memberService;
 
     @Nested
     @DisplayName("login 메서드는")
@@ -76,8 +82,8 @@ class AuthServiceTest extends ServiceTest {
     class LoginGoogle {
 
         @Test
-        @DisplayName("임시 코드를 입력받으면, 토큰과 초기 사용자 여부를 반환한다.")
-        void success() {
+        @DisplayName("신규 회원이 가입을 하면, 토큰과 isNew를 true로 반환한다.")
+        void success_newMember() {
             MemberResponse memberResponse = MemberResponse.of(ROOKIE.getMember());
             given(googleClient.requestAccessToken(AUTHORIZATION_CODE))
                 .willReturn(USER_ACCESS_TOKEN);
@@ -89,7 +95,26 @@ class AuthServiceTest extends ServiceTest {
                         memberResponse.getImageUrl()));
             TokenResponse tokenResponse = authService.loginGoogle(AUTHORIZATION_CODE);
 
-            assertThat(tokenResponse).isNotNull();
+            assertThat(tokenResponse.getIsNew()).isTrue();
+        }
+
+        @Test
+        @DisplayName("기존 회원이 가입을 하면, 토큰과 isNew를 false로 반환한다.")
+        void success_registeredMember() {
+            MemberResponse memberResponse = MemberResponse.of(ROOKIE.getMember());
+            GoogleUserInfo userInfo = new GoogleUserInfo(
+                memberResponse.getNickname(),
+                memberResponse.getEmail(),
+                memberResponse.getImageUrl());
+            memberService.save(userInfo, "닉네임");
+
+            given(googleClient.requestAccessToken(AUTHORIZATION_CODE))
+                .willReturn(USER_ACCESS_TOKEN);
+            given(googleClient.requestUserInfo(USER_ACCESS_TOKEN))
+                .willReturn(userInfo);
+            TokenResponse tokenResponse = authService.loginGoogle(AUTHORIZATION_CODE);
+
+            assertThat(tokenResponse.getIsNew()).isFalse();
         }
 
         @Test
@@ -102,6 +127,24 @@ class AuthServiceTest extends ServiceTest {
                 () -> authService.loginGoogle("invalid_code")
             ).isInstanceOf(AccessTokenRetrievalFailedException.class);
         }
+    }
+
+    @Nested
+    @DisplayName("signUpGoogle 메서드는")
+    class signUpGoogle {
+
+        @Test
+        @DisplayName("acceesToken,닉네임을 받으면 회원가입을 완료한다.")
+        void success() {
+            MemberCreateRequest memberCreateRequest = new MemberCreateRequest("accessToken", "닉네임");
+            GoogleUserInfo userInfo = new GoogleUserInfo("testName", "test@email.com", "testimage");
+            given(googleClient.requestUserInfo(anyString())).willReturn(userInfo);
+
+            Long id = authService.signUpGoogle(memberCreateRequest);
+
+            assertThat(id).isNotNull();
+        }
+
     }
 
     @Nested

--- a/backend/src/test/java/com/woowacourse/kkogkkog/documentation/AuthDocumentTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/documentation/AuthDocumentTest.java
@@ -63,7 +63,7 @@ class AuthDocumentTest extends DocumentTest {
         given(authService.loginGoogle(any())).willReturn(tokenResponse);
 
         // when
-        ResultActions perform = mockMvc.perform(get("/api/login/google")
+        ResultActions perform = mockMvc.perform(get("/api/v2/login/google")
             .param("code", "code_here"));
 
         // then
@@ -88,7 +88,8 @@ class AuthDocumentTest extends DocumentTest {
     @Test
     void 회원가입을_요청한다() throws Exception {
         // given
-        MemberCreateRequest memberCreateRequest = new MemberCreateRequest("slack-accessToken", "변경할닉네임");
+        MemberCreateRequest memberCreateRequest = new MemberCreateRequest("slack-accessToken",
+            "변경할닉네임");
         MemberCreateResponse memberCreateResponse = new MemberCreateResponse("accessToken");
         given(authService.loginByMemberId(any())).willReturn(memberCreateResponse);
 
@@ -106,6 +107,33 @@ class AuthDocumentTest extends DocumentTest {
         perform
             .andDo(print())
             .andDo(document("auth-signUp",
+                getDocumentRequest(),
+                getDocumentResponse()
+            ));
+    }
+
+    @Test
+    void 구글_회원가입을_요청한다() throws Exception {
+        // given
+        MemberCreateRequest memberCreateRequest = new MemberCreateRequest("google-accessToken",
+            "변경할닉네임");
+        MemberCreateResponse memberCreateResponse = new MemberCreateResponse("accessToken");
+        given(authService.loginByMemberId(any())).willReturn(memberCreateResponse);
+
+        // when
+        ResultActions perform = mockMvc.perform(post("/api/v2/signup/google")
+            .content(objectMapper.writeValueAsString(memberCreateRequest))
+            .contentType(MediaType.APPLICATION_JSON));
+
+        // then
+        perform
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.accessToken").value("accessToken"));
+
+        // docs
+        perform
+            .andDo(print())
+            .andDo(document("auth-signUp-google",
                 getDocumentRequest(),
                 getDocumentResponse()
             ));

--- a/backend/src/test/java/com/woowacourse/kkogkkog/infrastructure/application/GoogleClientTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/infrastructure/application/GoogleClientTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.woowacourse.kkogkkog.infrastructure.dto.GoogleUserInfo;
+import com.woowacourse.kkogkkog.infrastructure.dto.GoogleUserDto;
 import com.woowacourse.kkogkkog.infrastructure.exception.AccessTokenRetrievalFailedException;
 import java.io.IOException;
 import java.util.HashMap;
@@ -67,8 +67,8 @@ class GoogleClientTest {
         setUpResponse(mockWebServer, objectMapper.writeValueAsString(GOOGLE_USER_INFO_RESPONSE));
         GoogleClient googleClient = buildMockGoogleClient(mockWebServer);
 
-        GoogleUserInfo googleUserInfo = googleClient.requestUserInfo(ACCESS_TOKEN);
-        String userName = googleUserInfo.getName();
+        GoogleUserDto googleUserDto = googleClient.requestUserInfo(ACCESS_TOKEN);
+        String userName = googleUserDto.getName();
 
         assertThat(userName).isEqualTo(USER_NAME);
         mockWebServer.shutdown();


### PR DESCRIPTION
## 작업 내용

구글로 로그인했을 경우 2가지 경우가 있습니다.
1. 기존에 가입된 구글 or 슬랙 회원이 있는 경우
  - member의 Id 값을 받아와서 토큰으로 만들어 반환한다.
2. 신규 회원인 경우
  - accessToken과 isNew=true를 반환한다.
  - 닉네임과 accessToken을 받아 signUp/google로 요청이 온다.
  - 새로운 member를 생성한다(userId, workSpaceId는 null 이다.)
  - member의 Id값을 받아와서 토큰으로 만들어 반환한다.

회원가입된 회원이 구글로 로그인하는 경우 일어나는 일은 조회 후 memberId를 읽어오는 과정만 있습니다.
문제가 될 수도 있다고 판단된 부분은 구글로 회원가입한 사용자가 다시 Slack으로 로그인 하는 경우입니다.

<구글로 회원가입한 사용자가 Slack으로 로그인하는 Flow>
1. SlackUserInfo에서 중복되는 이메일이 존재하므로 memberService의 update를 실행합니다.
2. workspaceUserRepository에는 userId와 동일한 회원이 존재하지 않습니다.
3. memberRepository에 findByEmail을 하면 구글로 가입했던 Member가 반환됩니다.
4. integrateNewWorkSpaceUser 메서드에서 현재 로그인한 Slack 계정을 기반으로 userId, imageUrl, workspace를 받아옵니다.

위 flow대로 흘러가면 문제가 없다고 판단되어서 우선 제출합니다. 혹시 이상한점 있으면 커멘트로 남겨주세요.


## 공유사항

merge된 이후 pushAlarm 부분도 고려해보겠습니다.

Resolves #392 
