### PR TITLE
fix: 예약시간이 null인 경우에 대한 조건 추가

### DIFF
--- a/backend/src/main/java/com/woowacourse/kkogkkog/coupon/domain/repository/CouponRepository.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/coupon/domain/repository/CouponRepository.java
@@ -49,7 +49,7 @@ public interface CouponRepository extends JpaRepository<Coupon, Long> {
         + "FROM Coupon c "
         + "JOIN FETCH c.sender "
         + "JOIN FETCH c.receiver  "
-        + "WHERE c.receiver = :member OR c.sender = :member "
+        + "WHERE (c.receiver = :member OR c.sender = :member) "
         + "AND c.couponState.meetingDate IS NOT NULL "
         + "AND c.couponState.meetingDate >= :nowDate "
         + "ORDER BY c.couponState.meetingDate DESC")

--- a/backend/src/test/java/com/woowacourse/kkogkkog/coupon/application/CouponServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/coupon/application/CouponServiceTest.java
@@ -277,6 +277,9 @@ class CouponServiceTest {
             coupon2 = couponRepository.save(ACCEPTED_COUPON.getCoupon(
                 sender, receiver, CouponType.COFFEE,
                 new CouponState(CouponStatus.ACCEPTED, meetingDate)));
+            couponRepository.save(ACCEPTED_COUPON.getCoupon(
+                sender, receiver, CouponType.COFFEE,
+                new CouponState(CouponStatus.READY, null)));
 
             List<CouponMeetingResponse> extract = couponService.findMeeting(sender.getId());
 


### PR DESCRIPTION
## 작업 내용

- 예약시간이 null인 경우에 대한 조건 추가로직에서 or 조건에 ()를 추가

  - 이전 PR에서 조건은 추가했지만, 제대로 쿼리가 작동하지 않는 문제가 있었음
  - 원인은 OR절에 () 가 생략되어서 발생한 문제


## 공유사항

없음

Resolves #418
