### PR TITLE
fix: CouponResponse와 MemberHistoryResponse Dto의 형식 변경

### DIFF
--- a/backend/src/main/java/com/woowacourse/kkogkkog/coupon/application/dto/CouponResponse.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/coupon/application/dto/CouponResponse.java
@@ -51,7 +51,7 @@ public class CouponResponse {
             new CouponMemberResponse(receiver.getId(), receiver.getNickname(), receiver.getImageUrl()),
             coupon.getCouponTag(),
             coupon.getCouponMessage(),
-            coupon.getCouponType().getDisplayName(),
+            coupon.getCouponType().name(),
             coupon.getCouponState().getCouponStatus().name(),
             coupon.getCouponState().getMeetingDate(),
             coupon.getCreatedTime());

--- a/backend/src/main/java/com/woowacourse/kkogkkog/member/application/dto/MemberHistoryResponse.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/member/application/dto/MemberHistoryResponse.java
@@ -1,7 +1,5 @@
 package com.woowacourse.kkogkkog.member.application.dto;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
-import com.fasterxml.jackson.annotation.JsonFormat.Shape;
 import com.woowacourse.kkogkkog.coupon.domain.Coupon;
 import com.woowacourse.kkogkkog.coupon.domain.CouponHistory;
 import java.time.LocalDateTime;
@@ -19,10 +17,8 @@ public class MemberHistoryResponse {
     private Long couponId;
     private String couponType;
     private String couponEvent;
-    @JsonFormat(shape = Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime meetingDate;
     private Boolean isRead;
-    @JsonFormat(shape = Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime createdTime;
 
     public MemberHistoryResponse(Long id,


### PR DESCRIPTION
## 작업 내용
CouponDetailResponse에서는 enum 값을 반환하는데,
Coupon 목록으로 조회할 때는 DisplayName을 반환하고 있어서 수정합니다.

커피 -> COFFEE

추가로)
MemberHistoryResponse 반환 시 LocalDateTime이 다른 이슈가 있어서 같이 처리했습니다.
@JsonFormat이 필수인지 알았는데 스프링부트에서 디폴트로 LocalDateTime을 처리하도록 설정을 해놔서 생략해도 되더라구요.
이렇게 "2022-10-07T15:24:16.142161"
