### PR TITLE
fix: CouponNotFoundException 상속 변경, CouponHistoryResponse 시간 형태 변경

### DIFF
--- a/backend/src/main/java/com/woowacourse/kkogkkog/coupon/application/dto/CouponHistoryResponse.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/coupon/application/dto/CouponHistoryResponse.java
@@ -20,10 +20,8 @@ public class CouponHistoryResponse {
     private String imageUrl;
     private String couponType;
     private String couponEvent;
-    @JsonFormat(shape = Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime meetingDate;
     private String meetingMessage;
-    @JsonFormat(shape = Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime createdTime;
 
     public CouponHistoryResponse(Long id,

--- a/backend/src/main/java/com/woowacourse/kkogkkog/coupon/exception/CouponNotFoundException.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/coupon/exception/CouponNotFoundException.java
@@ -1,6 +1,8 @@
 package com.woowacourse.kkogkkog.coupon.exception;
 
-public class CouponNotFoundException extends RuntimeException {
+import com.woowacourse.kkogkkog.common.exception.NotFoundException;
+
+public class CouponNotFoundException extends NotFoundException {
 
     public CouponNotFoundException() {
         super("존재하지 않는 쿠폰입니다.");


### PR DESCRIPTION
## 작업 내용

CouponNotFoundException이 500을 던지는 문제 해결
몇개 Exception이 RuntimeException을 상속받고 있는 것 같은데 내일까지 찾아보고 머지합시다.

추가 사항1.
CouponHistoryResponse에서 시간 반환 타입을 변경했습니다.
기존에 년월일 과 시분초 사이에 T가 없었는데 생성합니다.
