### PR TITLE
fix: 서버의 시간 동기화 및 미팅 확정 조회 날짜 값을 변경

### DIFF
--- a/backend/src/main/java/com/woowacourse/kkogkkog/KkogKkogApplication.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/KkogKkogApplication.java
@@ -1,5 +1,7 @@
 package com.woowacourse.kkogkkog;
 
+import java.util.TimeZone;
+import javax.annotation.PostConstruct;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
@@ -8,5 +10,10 @@ public class KkogKkogApplication {
 
     public static void main(String[] args) {
         SpringApplication.run(KkogKkogApplication.class, args);
+    }
+
+    @PostConstruct
+    void started() {
+        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
     }
 }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/coupon/application/CouponService.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/coupon/application/CouponService.java
@@ -112,13 +112,19 @@ public class CouponService {
     public List<CouponMeetingResponse> findMeeting(Long memberId) {
         Member member = findMember(memberId);
         Map<LocalDateTime, List<CouponMeetingData>> collect = couponRepository
-            .findAllByMemberAndMeetingDate(member, now()).stream()
+            .findAllByMemberAndMeetingDate(member, getNowDateTime())
+            .stream()
             .map(CouponMeetingData::of)
             .collect(Collectors.groupingBy(CouponMeetingData::getMeetingDate));
 
         return collect.entrySet().stream()
             .map(it -> CouponMeetingResponse.of(it.getKey(), it.getValue()))
             .collect(Collectors.toList());
+    }
+
+    private LocalDateTime getNowDateTime() {
+        return LocalDateTime.now()
+            .withHour(0).withMinute(0).withSecond(0).withNano(0);
     }
 
     private Coupon findCoupon(Long couponId) {


### PR DESCRIPTION
## 작업 내용

- 서버의 시간 동기화

  - TimeZone Asia/Seoul 설정

- 쿠폰의 미팅 확정 조회 날짜 변경

  - 시, 분, 초를 0의 값으로 설정되도록 변경

Resolves #442
