### PR TITLE
fix: 약속이 확정된 쿠폰이 정상적으로 조회되지 않는 문제 해결

### DIFF
--- a/backend/src/main/java/com/woowacourse/kkogkkog/KkogKkogApplication.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/KkogKkogApplication.java
@@ -1,5 +1,7 @@
 package com.woowacourse.kkogkkog;
 
+import java.util.TimeZone;
+import javax.annotation.PostConstruct;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
@@ -8,5 +10,10 @@ public class KkogKkogApplication {
 
     public static void main(String[] args) {
         SpringApplication.run(KkogKkogApplication.class, args);
+    }
+
+    @PostConstruct
+    void started() {
+        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
     }
 }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/coupon/application/CouponService.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/coupon/application/CouponService.java
@@ -1,10 +1,8 @@
 package com.woowacourse.kkogkkog.coupon.application;
 
-import static java.time.LocalDateTime.now;
-
+import com.woowacourse.kkogkkog.coupon.application.dto.AcceptedCouponResponse;
 import com.woowacourse.kkogkkog.coupon.application.dto.CouponDetailResponse;
 import com.woowacourse.kkogkkog.coupon.application.dto.CouponMeetingData;
-import com.woowacourse.kkogkkog.coupon.application.dto.CouponMeetingResponse;
 import com.woowacourse.kkogkkog.coupon.application.dto.CouponResponse;
 import com.woowacourse.kkogkkog.coupon.application.dto.CouponSaveRequest;
 import com.woowacourse.kkogkkog.coupon.application.dto.CouponStatusRequest;
@@ -20,6 +18,7 @@ import com.woowacourse.kkogkkog.infrastructure.event.PushAlarmPublisher;
 import com.woowacourse.kkogkkog.member.domain.Member;
 import com.woowacourse.kkogkkog.member.domain.repository.MemberRepository;
 import com.woowacourse.kkogkkog.member.exception.MemberNotFoundException;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
@@ -86,7 +85,8 @@ public class CouponService {
     public List<CouponResponse> findAllByReceiver(Long memberId,
                                                   String couponStatus) {
         Member member = findMember(memberId);
-        return couponRepository.findAllByReceiver(member, CouponStatus.valueOf(couponStatus)).stream()
+        return couponRepository.findAllByReceiver(member, CouponStatus.valueOf(couponStatus))
+            .stream()
             .map(CouponResponse::of)
             .collect(Collectors.toList());
     }
@@ -109,15 +109,17 @@ public class CouponService {
         saveCouponHistory(CouponHistory.of(loginMember, coupon, event, request.getMessage()));
     }
 
-    public List<CouponMeetingResponse> findMeeting(Long memberId) {
+    @Transactional(readOnly = true)
+    public List<AcceptedCouponResponse> findAcceptedCoupons(Long memberId) {
         Member member = findMember(memberId);
         Map<LocalDateTime, List<CouponMeetingData>> collect = couponRepository
-            .findAllByMemberAndMeetingDate(member, now()).stream()
+            .findAllByMemberAndCouponStatusOrderByMeetingDate(member, LocalDate.now().atStartOfDay(), CouponStatus.ACCEPTED)
+            .stream()
             .map(CouponMeetingData::of)
             .collect(Collectors.groupingBy(CouponMeetingData::getMeetingDate));
 
         return collect.entrySet().stream()
-            .map(it -> CouponMeetingResponse.of(it.getKey(), it.getValue()))
+            .map(it -> AcceptedCouponResponse.of(it.getKey(), it.getValue()))
             .collect(Collectors.toList());
     }
 

--- a/backend/src/main/java/com/woowacourse/kkogkkog/coupon/application/dto/AcceptedCouponResponse.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/coupon/application/dto/AcceptedCouponResponse.java
@@ -8,19 +8,19 @@ import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class CouponMeetingResponse {
+public class AcceptedCouponResponse {
 
     private LocalDateTime meetingDate;
     private List<CouponMeetingData> coupons;
 
-    public CouponMeetingResponse(final LocalDateTime meetingDate,
-                                 final List<CouponMeetingData> couponMeetingData) {
+    public AcceptedCouponResponse(final LocalDateTime meetingDate,
+                                  final List<CouponMeetingData> couponMeetingData) {
         this.meetingDate = meetingDate;
         this.coupons = couponMeetingData;
     }
 
-    public static CouponMeetingResponse of(final LocalDateTime meetingDate,
-                                           final List<CouponMeetingData> value) {
-        return new CouponMeetingResponse(meetingDate, value);
+    public static AcceptedCouponResponse of(final LocalDateTime meetingDate,
+                                            final List<CouponMeetingData> value) {
+        return new AcceptedCouponResponse(meetingDate, value);
     }
 }

--- a/backend/src/main/java/com/woowacourse/kkogkkog/coupon/domain/repository/CouponRepository.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/coupon/domain/repository/CouponRepository.java
@@ -52,9 +52,11 @@ public interface CouponRepository extends JpaRepository<Coupon, Long> {
         + "WHERE (c.receiver = :member OR c.sender = :member) "
         + "AND c.couponState.meetingDate IS NOT NULL "
         + "AND c.couponState.meetingDate >= :nowDate "
+        + "AND c.couponState.couponStatus = :couponStatus "
         + "ORDER BY c.couponState.meetingDate DESC")
-    List<Coupon> findAllByMemberAndMeetingDate(@Param("member") Member member,
-                                               @Param("nowDate") LocalDateTime nowDate);
+    List<Coupon> findAllByMemberAndCouponStatusOrderByMeetingDate(@Param("member") Member member,
+                                                                  @Param("nowDate") LocalDateTime nowDate,
+                                                                  @Param("couponStatus") CouponStatus couponStatus);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT c FROM Coupon c where c.id = :id")

--- a/backend/src/main/java/com/woowacourse/kkogkkog/coupon/presentation/CouponController.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/coupon/presentation/CouponController.java
@@ -2,12 +2,12 @@ package com.woowacourse.kkogkkog.coupon.presentation;
 
 import com.woowacourse.kkogkkog.common.presentation.LoginMemberId;
 import com.woowacourse.kkogkkog.coupon.application.CouponService;
+import com.woowacourse.kkogkkog.coupon.application.dto.AcceptedCouponResponse;
 import com.woowacourse.kkogkkog.coupon.application.dto.CouponDetailResponse;
-import com.woowacourse.kkogkkog.coupon.application.dto.CouponMeetingResponse;
 import com.woowacourse.kkogkkog.coupon.application.dto.CouponResponse;
+import com.woowacourse.kkogkkog.coupon.presentation.dto.AcceptedCouponsResponse;
 import com.woowacourse.kkogkkog.coupon.presentation.dto.CouponCreateRequest;
 import com.woowacourse.kkogkkog.coupon.presentation.dto.CouponEventRequest;
-import com.woowacourse.kkogkkog.coupon.presentation.dto.CouponMeetingsResponse;
 import com.woowacourse.kkogkkog.coupon.presentation.dto.CouponsResponse;
 import java.util.List;
 import org.springframework.http.ResponseEntity;
@@ -64,9 +64,9 @@ public class CouponController {
     }
 
     @GetMapping("/accept")
-    public ResponseEntity<CouponMeetingsResponse> showMeetings(@LoginMemberId Long loginMemberId) {
-        List<CouponMeetingResponse> meetingsResponse = couponService.findMeeting(loginMemberId);
-        return ResponseEntity.ok(new CouponMeetingsResponse(meetingsResponse));
+    public ResponseEntity<AcceptedCouponsResponse> showAcceptedCoupons(@LoginMemberId Long loginMemberId) {
+        List<AcceptedCouponResponse> acceptedCouponResponses = couponService.findAcceptedCoupons(loginMemberId);
+        return ResponseEntity.ok(new AcceptedCouponsResponse(acceptedCouponResponses));
     }
 
     @PostMapping

--- a/backend/src/main/java/com/woowacourse/kkogkkog/coupon/presentation/dto/AcceptedCouponsResponse.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/coupon/presentation/dto/AcceptedCouponsResponse.java
@@ -1,6 +1,6 @@
 package com.woowacourse.kkogkkog.coupon.presentation.dto;
 
-import com.woowacourse.kkogkkog.coupon.application.dto.CouponMeetingResponse;
+import com.woowacourse.kkogkkog.coupon.application.dto.AcceptedCouponResponse;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -8,11 +8,11 @@ import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class CouponMeetingsResponse {
+public class AcceptedCouponsResponse {
 
-    private List<CouponMeetingResponse> data;
+    private List<AcceptedCouponResponse> data;
 
-    public CouponMeetingsResponse(final List<CouponMeetingResponse> data) {
+    public AcceptedCouponsResponse(final List<AcceptedCouponResponse> data) {
         this.data = data;
     }
 }

--- a/backend/src/test/java/com/woowacourse/kkogkkog/documentation/CouponDocumentTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/documentation/CouponDocumentTest.java
@@ -21,10 +21,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.woowacourse.kkogkkog.coupon.application.dto.CouponMeetingData;
-import com.woowacourse.kkogkkog.coupon.application.dto.CouponMeetingResponse;
+import com.woowacourse.kkogkkog.coupon.application.dto.AcceptedCouponResponse;
 import com.woowacourse.kkogkkog.coupon.application.dto.CouponMemberResponse;
 import com.woowacourse.kkogkkog.coupon.domain.CouponStatus;
-import com.woowacourse.kkogkkog.coupon.presentation.dto.CouponMeetingsResponse;
+import com.woowacourse.kkogkkog.coupon.presentation.dto.AcceptedCouponsResponse;
 import com.woowacourse.kkogkkog.coupon.presentation.dto.CouponsResponse;
 import com.woowacourse.kkogkkog.documentation.support.DocumentTest;
 import java.time.LocalDateTime;
@@ -210,7 +210,7 @@ class CouponDocumentTest extends DocumentTest {
     @Test
     void 미팅이_확정된_쿠폰_조회_API() throws Exception {
         given(jwtTokenProvider.getValidatedPayload(any())).willReturn("1");
-        given(couponService.findMeeting(any())).willReturn(List.of(CouponMeetingResponse.of(
+        given(couponService.findAcceptedCoupons(any())).willReturn(List.of(AcceptedCouponResponse.of(
             LocalDateTime.of(2022, 12, 12, 0, 0, 0),
             List.of(
                 new CouponMeetingData(
@@ -228,7 +228,7 @@ class CouponDocumentTest extends DocumentTest {
         perform.andExpect(status().isOk())
             .andExpect(
                 content().string(objectMapper.writeValueAsString(
-                    new CouponMeetingsResponse(List.of(CouponMeetingResponse.of(
+                    new AcceptedCouponsResponse(List.of(AcceptedCouponResponse.of(
                         LocalDateTime.of(2022, 12, 12, 0, 0, 0),
                         List.of(
                             new CouponMeetingData(

--- a/backend/src/test/java/com/woowacourse/kkogkkog/support/fixture/domain/CouponFixture.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/support/fixture/domain/CouponFixture.java
@@ -47,4 +47,8 @@ public enum CouponFixture {
             null, sender, receiver, couponMessage,
             couponTag, couponType, couponState);
     }
+
+    public Coupon getCoupon(Member sender, Member receiver, CouponState couponState) {
+        return new Coupon(null, sender, receiver, couponMessage, couponTag, couponType, couponState);
+    }
 }


### PR DESCRIPTION
## 작업 내용

- REQUESTED 상태의 쿠폰이 같이 조회되는 문제 해결
  - repository에 요청을 보낼 때 상태도 비교하도록 수정

- 약속 날짜 당일에 쿠폰이 보이지 않는 문제 해결
  - LocalDateTime.now() -> LocalDate.now().atStartOfDay() 비교하는 시간 수정

## 공유사항

Meeting으로 있었던 메서드와 Dto를 AcceptedCoupon으로 변경했습니다.
`CouponRepository.findAllByMemberAndCouponStatusOrderByMeetingDate()` 메서드 명이 너무 길어서 개선이 필요해 보입니다.
CouponFixture를 개선해야할 필요가 있습니다.

Resolves #449 
