### PR TITLE
feat: 미등록 쿠폰 등록 과정 구현

### DIFF
--- a/frontend/src/@components/@shared/ErrorBoundary.tsx
+++ b/frontend/src/@components/@shared/ErrorBoundary.tsx
@@ -83,10 +83,9 @@ class ErrorBoundary extends Component<PropsWithChildren<ErrorBoundaryProps>, Err
 
     if (errorCase === 'get') {
       if (errorState instanceof CustomAxiosError) {
-        displayMessage(
-          errorState.response?.data.message || '알 수 없는 에러가 발생했습니다.',
-          true
-        );
+        const errorMessage = errorState.response?.data.message || '알 수 없는 에러가 발생했습니다.';
+
+        displayMessage(errorMessage, true);
 
         return;
       }

--- a/frontend/src/@components/@shared/ErrorBoundary.tsx
+++ b/frontend/src/@components/@shared/ErrorBoundary.tsx
@@ -1,3 +1,4 @@
+import { AxiosError } from 'axios';
 import React, { Component, ErrorInfo, PropsWithChildren } from 'react';
 import { useQueryClient } from 'react-query';
 import { Navigate } from 'react-router-dom';
@@ -23,7 +24,7 @@ type ErrorBoundaryState =
       errorCase: null;
     }
   | {
-      error: CustomAxiosError;
+      error: AxiosError;
       errorCase: 'unauthorized' | 'get';
     };
 
@@ -44,7 +45,7 @@ class ErrorBoundary extends Component<PropsWithChildren<ErrorBoundaryProps>, Err
   };
 
   static getDerivedStateFromError(error: Error): ErrorBoundaryState {
-    if (!(error instanceof CustomAxiosError)) {
+    if (!(error instanceof AxiosError)) {
       return { error, errorCase: null };
     }
 
@@ -81,7 +82,16 @@ class ErrorBoundary extends Component<PropsWithChildren<ErrorBoundaryProps>, Err
     }
 
     if (errorCase === 'get') {
-      displayMessage(errorState.response?.data.message || '알 수 없는 에러가 발생했습니다.', true);
+      if (errorState instanceof CustomAxiosError) {
+        displayMessage(
+          errorState.response?.data.message || '알 수 없는 에러가 발생했습니다.',
+          true
+        );
+
+        return;
+      }
+
+      displayMessage('알 수 없는 에러가 발생했습니다.', true);
 
       return;
     }

--- a/frontend/src/@components/coupon/CouponCreateForm/index.tsx
+++ b/frontend/src/@components/coupon/CouponCreateForm/index.tsx
@@ -66,9 +66,9 @@ const CouponCreateForm = (props: CouponCreateFormProps) => {
 
           <span>🔍</span>
         </Styled.FindUserInput>
-        {/* <Link to={PATH.UNREGISTERED_COUPON_CREATE} css={Styled.AnotherCouponCreatePageLink} replace>
+        <Link to={PATH.UNREGISTERED_COUPON_CREATE} css={Styled.AnotherCouponCreatePageLink} replace>
           미등록 쿠폰 생성하기
-        </Link> */}
+        </Link>
       </Styled.FindUserContainer>
 
       {isShowModal && (

--- a/frontend/src/@components/unregistered-coupon/UnregisteredCouponItem/index.tsx
+++ b/frontend/src/@components/unregistered-coupon/UnregisteredCouponItem/index.tsx
@@ -6,12 +6,12 @@ import UnregisteredCouponStatus from '@/@components/unregistered-coupon/Unregist
 import { useToast } from '@/@hooks/@common/useToast';
 import { DYNAMIC_PATH } from '@/Router';
 import { THUMBNAIL } from '@/types/coupon/client';
-import { UnregisteredCoupon } from '@/types/unregistered-coupon/client';
+import { UnregisteredCouponResponse } from '@/types/unregistered-coupon/remote';
 import clipboardCopy from '@/utils/clipboardCopy';
 
 import * as Styled from './style';
 
-export interface UnregisteredCouponItemProps extends UnregisteredCoupon {
+export interface UnregisteredCouponItemProps extends UnregisteredCouponResponse {
   className?: string;
   onClick?: MouseEventHandler<HTMLDivElement>;
 }
@@ -69,4 +69,36 @@ export default UnregisteredCouponItem;
 
 UnregisteredCouponItem.Skeleton = function Skeleton() {
   return <Placeholder aspectRatio='3/1' />;
+};
+
+UnregisteredCouponItem.Preview = function UnregisteredCouponItem(
+  props: UnregisteredCouponItemProps
+) {
+  const { ...coupon } = props;
+
+  const { receiver, couponTag, couponMessage, thumbnail } = {
+    ...coupon,
+    thumbnail: THUMBNAIL[coupon.couponType],
+  };
+
+  return (
+    <Styled.Root>
+      <Styled.Coupon hasCursor={false}>
+        <Styled.CouponPropertyContainer>
+          <Styled.ImageInner>
+            <img src={thumbnail} alt='쿠폰' width={44} height={44} />
+          </Styled.ImageInner>
+        </Styled.CouponPropertyContainer>
+        <Styled.TextContainer>
+          <Styled.Top>
+            <Styled.Member>
+              <Styled.English>To</Styled.English> {receiver?.nickname ?? '?'}
+            </Styled.Member>
+          </Styled.Top>
+          <Styled.Message>{couponMessage}</Styled.Message>
+          <Styled.Hashtag>#{couponTag}</Styled.Hashtag>
+        </Styled.TextContainer>
+      </Styled.Coupon>
+    </Styled.Root>
+  );
 };

--- a/frontend/src/@components/unregistered-coupon/UnregisteredCouponItem/style.tsx
+++ b/frontend/src/@components/unregistered-coupon/UnregisteredCouponItem/style.tsx
@@ -90,7 +90,8 @@ export const CouponPropertyContainer = styled.div`
 
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
+  justify-content: center;
+  gap: 10px;
   align-items: center;
   border-radius: 20px 0 0 20px;
   padding: 16px 0;

--- a/frontend/src/@components/unregistered-coupon/UnregisteredCouponListSection/ExpiredCouponListSection/index.tsx
+++ b/frontend/src/@components/unregistered-coupon/UnregisteredCouponListSection/ExpiredCouponListSection/index.tsx
@@ -1,12 +1,12 @@
 import VerticalCouponList from '@/@components/coupon/CouponList/vertical';
 import { useFetchUnregisteredCouponListByStatus } from '@/@hooks/@queries/unregistered-coupon';
 import { Styled } from '@/@pages/coupon-list';
-import { UnregisteredCoupon } from '@/types/unregistered-coupon/client';
+import { UnregisteredCouponResponse } from '@/types/unregistered-coupon/remote';
 
 import UnregisteredCouponItem from '../../UnregisteredCouponItem';
 
 interface ExpiredCouponListSectionProps {
-  onClickCouponItem: (coupon: UnregisteredCoupon) => void;
+  onClickCouponItem: (coupon: UnregisteredCouponResponse) => void;
 }
 
 const ExpiredCouponListSection = (props: ExpiredCouponListSectionProps) => {

--- a/frontend/src/@components/unregistered-coupon/UnregisteredCouponListSection/RegisteredCouponListSection/index.tsx
+++ b/frontend/src/@components/unregistered-coupon/UnregisteredCouponListSection/RegisteredCouponListSection/index.tsx
@@ -1,12 +1,12 @@
 import VerticalCouponList from '@/@components/coupon/CouponList/vertical';
 import { useFetchUnregisteredCouponListByStatus } from '@/@hooks/@queries/unregistered-coupon';
 import { Styled } from '@/@pages/coupon-list';
-import { UnregisteredCoupon } from '@/types/unregistered-coupon/client';
+import { UnregisteredCouponResponse } from '@/types/unregistered-coupon/remote';
 
 import UnregisteredCouponItem from '../../UnregisteredCouponItem';
 
 interface RegisteredCouponListSectionProps {
-  onClickCouponItem: (coupon: UnregisteredCoupon) => void;
+  onClickCouponItem: (coupon: UnregisteredCouponResponse) => void;
 }
 
 const RegisteredCouponListSection = (props: RegisteredCouponListSectionProps) => {

--- a/frontend/src/@components/unregistered-coupon/UnregisteredCouponListSection/UnregisteredCouponListSection/index.tsx
+++ b/frontend/src/@components/unregistered-coupon/UnregisteredCouponListSection/UnregisteredCouponListSection/index.tsx
@@ -1,12 +1,12 @@
 import VerticalCouponList from '@/@components/coupon/CouponList/vertical';
 import { useFetchUnregisteredCouponListByStatus } from '@/@hooks/@queries/unregistered-coupon';
 import { Styled } from '@/@pages/coupon-list';
-import { UnregisteredCoupon } from '@/types/unregistered-coupon/client';
+import { UnregisteredCouponResponse } from '@/types/unregistered-coupon/remote';
 
 import UnregisteredCouponItem from '../../UnregisteredCouponItem';
 
 interface UnregisteredCouponListSectionProps {
-  onClickCouponItem: (coupon: UnregisteredCoupon) => void;
+  onClickCouponItem: (coupon: UnregisteredCouponResponse) => void;
 }
 
 const UnregisteredCouponListSection = (props: UnregisteredCouponListSectionProps) => {

--- a/frontend/src/@hooks/@queries/unregistered-coupon.ts
+++ b/frontend/src/@hooks/@queries/unregistered-coupon.ts
@@ -1,20 +1,28 @@
-import {
-  getUnregisteredCoupon,
-  getUnregisteredCouponListByStatus,
-} from '@/apis/unregistered-coupon';
-import { UnregisteredCouponListByStatusRequest } from '@/types/unregistered-coupon/remote';
+import { useQueryClient } from 'react-query';
 
-import { useQuery } from './utils';
+import {
+  getUnregisteredCouponById,
+  getUnregisteredCouponListByStatus,
+  registerUnregisteredCoupon,
+} from '@/apis/unregistered-coupon';
+import {
+  RegisterUnregisteredCouponRequest,
+  UnregisteredCouponListByStatusRequest,
+} from '@/types/unregistered-coupon/remote';
+
+import { getUnregisteredCouponByCode } from '../../apis/unregistered-coupon';
+import { useLoading } from '../@common/useLoading';
+import { useMutation, useQuery } from './utils';
 
 const QUERY_KEY = {
   unregisteredCoupon: 'unregisteredCoupon',
   unregisteredCouponListByStatus: 'unregisteredCouponListByStatus',
 };
 
-export const useFetchUnregisteredCoupon = (id: number) => {
+export const useFetchUnregisteredCouponById = (id: number) => {
   const { data, isLoading } = useQuery(
     [QUERY_KEY.unregisteredCoupon, id],
-    () => getUnregisteredCoupon(id),
+    () => getUnregisteredCouponById(id),
     {
       staleTime: 10000,
     }
@@ -25,6 +33,22 @@ export const useFetchUnregisteredCoupon = (id: number) => {
     isLoading,
   };
 };
+
+export const useFetchUnregisteredCouponByCode = (couponCode: string) => {
+  const { data, isLoading } = useQuery(
+    [QUERY_KEY.unregisteredCoupon, couponCode],
+    () => getUnregisteredCouponByCode(couponCode),
+    {
+      staleTime: 10000,
+    }
+  );
+
+  return {
+    unregisteredCoupon: data,
+    isLoading,
+  };
+};
+
 export const useFetchUnregisteredCouponListByStatus = (
   body: UnregisteredCouponListByStatusRequest
 ) => {
@@ -40,4 +64,25 @@ export const useFetchUnregisteredCouponListByStatus = (
     unregisteredCouponListByStatus: data?.data ?? [],
     isLoading,
   };
+};
+
+/** Mutation */
+
+export const useRegisteredUnregisteredCouponMutation = ({
+  couponCode,
+}: RegisterUnregisteredCouponRequest) => {
+  const queryClient = useQueryClient();
+  const { showLoading, hideLoading } = useLoading();
+
+  return useMutation(registerUnregisteredCoupon, {
+    onSuccess() {
+      queryClient.invalidateQueries([QUERY_KEY.unregisteredCoupon, couponCode]);
+    },
+    onMutate() {
+      showLoading();
+    },
+    onSettled() {
+      hideLoading();
+    },
+  });
 };

--- a/frontend/src/@hooks/business/unregistered-coupon.ts
+++ b/frontend/src/@hooks/business/unregistered-coupon.ts
@@ -1,0 +1,19 @@
+import { RegisterUnregisteredCouponRequest } from '@/types/unregistered-coupon/remote';
+
+import { useRegisteredUnregisteredCouponMutation } from '../@queries/unregistered-coupon';
+
+export const useRegisteredUnregisteredCoupon = ({
+  couponCode,
+}: RegisterUnregisteredCouponRequest) => {
+  const { mutateAsync } = useRegisteredUnregisteredCouponMutation({
+    couponCode,
+  });
+
+  const registerUnregisteredCoupon = (body: RegisterUnregisteredCouponRequest) => {
+    return mutateAsync(body);
+  };
+
+  return {
+    registerUnregisteredCoupon,
+  };
+};

--- a/frontend/src/@hooks/ui/user/useAuthenticateForm.ts
+++ b/frontend/src/@hooks/ui/user/useAuthenticateForm.ts
@@ -62,7 +62,7 @@ export const useAuthenticateForm = (props: UseAuthenticateFormProps = {}) => {
       await googleSignup({ nickname, accessToken: signupToken });
     }
 
-    navigate(PATH.MAIN);
+    navigate(PATH.MAIN, { replace: true });
   };
 
   // const onSubmitLoginForm: FormEventHandler<HTMLFormElement> = async e => {

--- a/frontend/src/@pages/main/index.tsx
+++ b/frontend/src/@pages/main/index.tsx
@@ -46,7 +46,7 @@ const MainPage = () => {
         navigate(DYNAMIC_PATH.UNREGISTERED_COUPON_REGISTER(couponCode));
       }
 
-      unregisteredCouponCodeStorage.set('');
+      unregisteredCouponCodeStorage.remove();
     }
   }, [navigate]);
 

--- a/frontend/src/@pages/main/index.tsx
+++ b/frontend/src/@pages/main/index.tsx
@@ -51,7 +51,7 @@ const MainPage = () => {
             시간을 보내고 싶어하는 사람들이 있을지 모릅니다.
           </Styled.AdditionalExplanation>
           <Link
-            to={PATH.COUPON_CREATE}
+            to={PATH.COUPON_CREATE_SELECT}
             css={css`
               margin-top: 30px;
             `}
@@ -139,7 +139,7 @@ const MainPage = () => {
             </CustomSuspense>
           </div>
 
-          {/* <Styled.UnRegisteredCouponSection>
+          <Styled.UnRegisteredCouponSection>
             <Styled.ListTitle>
               <span>미등록 쿠폰</span>
             </Styled.ListTitle>
@@ -150,7 +150,7 @@ const MainPage = () => {
                 </Button>
               </Link>
             </Styled.UnRegisteredCouponSectionInner>
-          </Styled.UnRegisteredCouponSection> */}
+          </Styled.UnRegisteredCouponSection>
         </Styled.ListContainer>
       </Styled.Root>
     </PageTemplate.LandingPage>

--- a/frontend/src/@pages/main/index.tsx
+++ b/frontend/src/@pages/main/index.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/react';
+import { useEffect } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 
 import Button from '@/@components/@shared/Button';
@@ -11,7 +12,7 @@ import HorizontalCouponList from '@/@components/coupon/CouponList/horizontal';
 import ReservationSection from '@/@components/reservation/ReservationSection';
 import { useFetchCouponList, useFetchReservationList } from '@/@hooks/@queries/coupon';
 import { DYNAMIC_PATH, PATH } from '@/Router';
-import { filterOptionsSessionStorage } from '@/storage/session';
+import { filterOptionsSessionStorage, unregisteredCouponCodeStorage } from '@/storage/session';
 import { Coupon } from '@/types/coupon/client';
 
 import * as Styled from './style';
@@ -36,6 +37,18 @@ const MainPage = () => {
   const onClickViewMoreCoupon = () => {
     filterOptionsSessionStorage.set('전체');
   };
+
+  useEffect(() => {
+    const couponCode = unregisteredCouponCodeStorage.get();
+
+    if (couponCode) {
+      if (window.confirm('쿠폰을 받으러 갈까요?')) {
+        navigate(DYNAMIC_PATH.UNREGISTERED_COUPON_REGISTER(couponCode));
+      }
+
+      unregisteredCouponCodeStorage.set('');
+    }
+  }, [navigate]);
 
   return (
     <PageTemplate.LandingPage title='꼭꼭'>

--- a/frontend/src/@pages/profile/login/index.tsx
+++ b/frontend/src/@pages/profile/login/index.tsx
@@ -37,12 +37,12 @@ const LoginPage = () => {
             슬랙으로 로그인
           </Styled.SlackLink>
         )}
-        {/* <Styled.GoogleLink
+        <Styled.GoogleLink
           href={`https://accounts.google.com/o/oauth2/auth?client_id=722307223606-9hllknij10hdojacsmk53s1dcehd22uk.apps.googleusercontent.com&redirect_uri=${REDIRECT_URL}/login/google/redirect&response_type=code&scope=https://www.googleapis.com/auth/userinfo.profile https://www.googleapis.com/auth/userinfo.email&access_type=offline`}
         >
           <Icon iconName='google' size='20' />
           구글로 로그인
-        </Styled.GoogleLink> */}
+        </Styled.GoogleLink>
       </Styled.Root>
     </PageTemplate>
   );

--- a/frontend/src/@pages/unregistered-coupon-list/index.tsx
+++ b/frontend/src/@pages/unregistered-coupon-list/index.tsx
@@ -11,7 +11,7 @@ import UnregisteredCouponListSection from '@/@components/unregistered-coupon/Unr
 import { useStatus } from '@/@hooks/@common/useStatus';
 import { DYNAMIC_PATH } from '@/Router';
 import { unregisteredFilterOptionsSessionStorage } from '@/storage/session';
-import { UnregisteredCoupon } from '@/types/unregistered-coupon/client';
+import { UnregisteredCouponResponse } from '@/types/unregistered-coupon/remote';
 
 import * as Styled from './style';
 
@@ -31,11 +31,11 @@ const UnregisteredCouponList = () => {
     unregisteredFilterOptionsSessionStorage.set(status);
   };
 
-  const onClickUnregisteredCouponItem = ({ couponCode }: UnregisteredCoupon) => {
+  const onClickUnregisteredCouponItem = ({ couponCode }: UnregisteredCouponResponse) => {
     navigate(DYNAMIC_PATH.UNREGISTERED_COUPON_DETAIL(couponCode));
   };
 
-  const onClickRegisteredCouponItem = ({ couponId }: UnregisteredCoupon) => {
+  const onClickRegisteredCouponItem = ({ couponId }: UnregisteredCouponResponse) => {
     if (couponId === null) {
       return;
     }

--- a/frontend/src/@pages/unregistered-coupon-register/CouponCodePage.tsx
+++ b/frontend/src/@pages/unregistered-coupon-register/CouponCodePage.tsx
@@ -1,0 +1,40 @@
+import useGetSearchParam from '@/@hooks/@common/useGetSearchParams';
+import { useFetchUnregisteredCouponByCode } from '@/@hooks/@queries/unregistered-coupon';
+
+import NotFoundPage from '../404';
+import ExpiredRegisteredCouponPage from './ExpiredRegisteredCouponPage';
+import IssuedRegisteredCouponPage from './IssuedRegisteredCouponPage';
+import RegisteredRegisteredCouponPage from './RegisteredRegisteredCouponPage';
+
+const UnregisteredCouponCodePage = () => {
+  const couponCode = useGetSearchParam('couponCode');
+
+  // @TODO: null 처리
+  const { unregisteredCoupon } = useFetchUnregisteredCouponByCode(couponCode ?? '');
+
+  if (couponCode === null) {
+    return <NotFoundPage />;
+  }
+
+  if (unregisteredCoupon === undefined) {
+    return <NotFoundPage />;
+  }
+
+  if (unregisteredCoupon.unregisteredCouponStatus === 'ISSUED') {
+    return (
+      <IssuedRegisteredCouponPage unregisteredCoupon={unregisteredCoupon} couponCode={couponCode} />
+    );
+  }
+
+  if (unregisteredCoupon.unregisteredCouponStatus === 'REGISTERED') {
+    return <RegisteredRegisteredCouponPage />;
+  }
+
+  if (unregisteredCoupon.unregisteredCouponStatus === 'EXPIRED') {
+    return <ExpiredRegisteredCouponPage />;
+  }
+
+  return <NotFoundPage />;
+};
+
+export default UnregisteredCouponCodePage;

--- a/frontend/src/@pages/unregistered-coupon-register/CouponCodePage.tsx
+++ b/frontend/src/@pages/unregistered-coupon-register/CouponCodePage.tsx
@@ -4,7 +4,7 @@ import { useFetchUnregisteredCouponByCode } from '@/@hooks/@queries/unregistered
 import NotFoundPage from '../404';
 import ExpiredRegisteredCouponPage from './ExpiredRegisteredCouponPage';
 import IssuedRegisteredCouponPage from './IssuedRegisteredCouponPage';
-import RegisteredRegisteredCouponPage from './RegisteredRegisteredCouponPage';
+import RegisteredCouponPage from './RegisteredRegisteredCouponPage';
 
 const UnregisteredCouponCodePage = () => {
   const couponCode = useGetSearchParam('couponCode');
@@ -27,7 +27,7 @@ const UnregisteredCouponCodePage = () => {
   }
 
   if (unregisteredCoupon.unregisteredCouponStatus === 'REGISTERED') {
-    return <RegisteredRegisteredCouponPage />;
+    return <RegisteredCouponPage />;
   }
 
   if (unregisteredCoupon.unregisteredCouponStatus === 'EXPIRED') {

--- a/frontend/src/@pages/unregistered-coupon-register/ExpiredRegisteredCouponPage/index.tsx
+++ b/frontend/src/@pages/unregistered-coupon-register/ExpiredRegisteredCouponPage/index.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 
 import Button from '@/@components/@shared/Button';
 import PageTemplate from '@/@components/@shared/PageTemplate';
@@ -8,16 +8,14 @@ import { PATH } from '@/Router';
 import * as Styled from './style';
 
 const ExpiredUnregisteredCouponPage = () => {
-  const navigate = useNavigate();
-
   return (
     <PageTemplate title='꼭꼭' hasHeader={false}>
       <Styled.Root>
         <img src={landingLogoImage} alt='로고' width='86' />
         <Styled.Description>해당 쿠폰은 만료 기간(7일)이 지났습니다.</Styled.Description>
-        <Styled.ButtonInner>
-          <Button onClick={() => navigate(PATH.MAIN)}>홈으로 가기</Button>
-        </Styled.ButtonInner>
+        <Link to={PATH.MAIN} css={Styled.ExtendedLink}>
+          <Button>홈으로 가기</Button>
+        </Link>
       </Styled.Root>
     </PageTemplate>
   );

--- a/frontend/src/@pages/unregistered-coupon-register/ExpiredRegisteredCouponPage/index.tsx
+++ b/frontend/src/@pages/unregistered-coupon-register/ExpiredRegisteredCouponPage/index.tsx
@@ -1,0 +1,5 @@
+const ExpiredRegisteredCouponPage = () => {
+  return <div>만료 기간이 지나 쿠폰을 등록할 수 없습니다.</div>;
+};
+
+export default ExpiredRegisteredCouponPage;

--- a/frontend/src/@pages/unregistered-coupon-register/ExpiredRegisteredCouponPage/index.tsx
+++ b/frontend/src/@pages/unregistered-coupon-register/ExpiredRegisteredCouponPage/index.tsx
@@ -1,5 +1,26 @@
+import { useNavigate } from 'react-router-dom';
+
+import Button from '@/@components/@shared/Button';
+import PageTemplate from '@/@components/@shared/PageTemplate';
+import landingLogoImage from '@/assets/images/landing_logo.png';
+import { PATH } from '@/Router';
+
+import * as Styled from './style';
+
 const ExpiredRegisteredCouponPage = () => {
-  return <div>만료 기간이 지나 쿠폰을 등록할 수 없습니다.</div>;
+  const navigate = useNavigate();
+
+  return (
+    <PageTemplate title='꼭꼭' hasHeader={false}>
+      <Styled.Root>
+        <img src={landingLogoImage} alt='로고' width='86' />
+        <Styled.Description>해당 쿠폰은 만료 기간(7일)이 지났습니다.</Styled.Description>
+        <Styled.ButtonInner>
+          <Button onClick={() => navigate(PATH.MAIN)}>홈으로 가기</Button>
+        </Styled.ButtonInner>
+      </Styled.Root>
+    </PageTemplate>
+  );
 };
 
 export default ExpiredRegisteredCouponPage;

--- a/frontend/src/@pages/unregistered-coupon-register/ExpiredRegisteredCouponPage/index.tsx
+++ b/frontend/src/@pages/unregistered-coupon-register/ExpiredRegisteredCouponPage/index.tsx
@@ -7,7 +7,7 @@ import { PATH } from '@/Router';
 
 import * as Styled from './style';
 
-const ExpiredRegisteredCouponPage = () => {
+const ExpiredUnregisteredCouponPage = () => {
   const navigate = useNavigate();
 
   return (
@@ -23,4 +23,4 @@ const ExpiredRegisteredCouponPage = () => {
   );
 };
 
-export default ExpiredRegisteredCouponPage;
+export default ExpiredUnregisteredCouponPage;

--- a/frontend/src/@pages/unregistered-coupon-register/ExpiredRegisteredCouponPage/style.tsx
+++ b/frontend/src/@pages/unregistered-coupon-register/ExpiredRegisteredCouponPage/style.tsx
@@ -20,6 +20,6 @@ export const Description = styled.p`
   font-size: 20px;
 `;
 
-export const ButtonInner = styled.div`
+export const ExtendedLink = css`
   width: 50%;
 `;

--- a/frontend/src/@pages/unregistered-coupon-register/ExpiredRegisteredCouponPage/style.tsx
+++ b/frontend/src/@pages/unregistered-coupon-register/ExpiredRegisteredCouponPage/style.tsx
@@ -1,0 +1,25 @@
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+
+export const Root = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 20px;
+
+  height: calc(var(--vh, 1vh) * 100);
+
+  ${({ theme }) => css`
+    background-color: ${theme.colors.primary_400_opacity};
+  `}
+`;
+
+export const Description = styled.p`
+  font-family: 'BMHANNAProOTF';
+  font-size: 20px;
+`;
+
+export const ButtonInner = styled.div`
+  width: 50%;
+`;

--- a/frontend/src/@pages/unregistered-coupon-register/IssuedRegisteredCouponPage/index.tsx
+++ b/frontend/src/@pages/unregistered-coupon-register/IssuedRegisteredCouponPage/index.tsx
@@ -34,6 +34,7 @@ const IssuedRegisteredCouponPage = (props: IssuedRegisteredCouponPageProps) => {
   const onClickRegisterButton = () => {
     if (me) {
       registerUnregisteredCoupon({ couponCode });
+      navigate(PATH.MAIN);
     }
 
     if (window.confirm('쿠폰을 등록하려면 로그인이 필요합니다. 로그인하시겠아요?')) {

--- a/frontend/src/@pages/unregistered-coupon-register/IssuedRegisteredCouponPage/index.tsx
+++ b/frontend/src/@pages/unregistered-coupon-register/IssuedRegisteredCouponPage/index.tsx
@@ -5,8 +5,10 @@ import Icon from '@/@components/@shared/Icon';
 import PageTemplate from '@/@components/@shared/PageTemplate';
 import Position from '@/@components/@shared/Position';
 import UnregisteredCouponItem from '@/@components/unregistered-coupon/UnregisteredCouponItem';
+import { useFetchMe } from '@/@hooks/@queries/user';
 import { useRegisteredUnregisteredCoupon } from '@/@hooks/business/unregistered-coupon';
 import { couponTypeTextMapper } from '@/constants/coupon';
+import { PATH } from '@/Router';
 import theme from '@/styles/theme';
 import { UnregisteredCouponResponse } from '@/types/unregistered-coupon/remote';
 
@@ -24,10 +26,18 @@ const IssuedRegisteredCouponPage = (props: IssuedRegisteredCouponPageProps) => {
 
   const navigate = useNavigate();
 
+  const { me } = useFetchMe();
+
   const { registerUnregisteredCoupon } = useRegisteredUnregisteredCoupon({ couponCode });
 
   const onClickRegisterButton = () => {
-    registerUnregisteredCoupon({ couponCode });
+    if (me) {
+      registerUnregisteredCoupon({ couponCode });
+    }
+
+    if (window.confirm('쿠폰을 등록하려면 로그인이 필요합니다. 로그인하시겠아요?')) {
+      navigate(PATH.LOGIN);
+    }
   };
 
   return (

--- a/frontend/src/@pages/unregistered-coupon-register/IssuedRegisteredCouponPage/index.tsx
+++ b/frontend/src/@pages/unregistered-coupon-register/IssuedRegisteredCouponPage/index.tsx
@@ -1,0 +1,75 @@
+import { useNavigate } from 'react-router-dom';
+
+import Button from '@/@components/@shared/Button';
+import Icon from '@/@components/@shared/Icon';
+import PageTemplate from '@/@components/@shared/PageTemplate';
+import Position from '@/@components/@shared/Position';
+import UnregisteredCouponItem from '@/@components/unregistered-coupon/UnregisteredCouponItem';
+import { useRegisteredUnregisteredCoupon } from '@/@hooks/business/unregistered-coupon';
+import { couponTypeTextMapper } from '@/constants/coupon';
+import theme from '@/styles/theme';
+import { UnregisteredCouponResponse } from '@/types/unregistered-coupon/remote';
+
+import * as Styled from './style';
+
+interface IssuedRegisteredCouponPageProps {
+  unregisteredCoupon: UnregisteredCouponResponse;
+  couponCode: string;
+}
+
+const IssuedRegisteredCouponPage = (props: IssuedRegisteredCouponPageProps) => {
+  const { unregisteredCoupon, couponCode } = props;
+
+  const { sender, couponMessage, couponType } = unregisteredCoupon;
+
+  const navigate = useNavigate();
+
+  const { registerUnregisteredCoupon } = useRegisteredUnregisteredCoupon({ couponCode });
+
+  const onClickRegisterButton = () => {
+    registerUnregisteredCoupon({ couponCode });
+  };
+
+  return (
+    <PageTemplate title='쿠폰' hasHeader={false}>
+      <Styled.Root>
+        <Styled.Top>
+          <Position position='absolute' top='20px' left='20px'>
+            <Icon
+              iconName='arrow'
+              size='20'
+              color={theme.colors.primary_400}
+              onClick={() => navigate(-1)}
+            />
+          </Position>
+          <Styled.ProfileImage src={sender.imageUrl} alt='프로필' width={51} height={51} />
+          <Styled.SummaryMessage>
+            <strong>
+              {sender.nickname}
+              {'님이'} 보낸
+            </strong>
+            &nbsp;
+            {couponTypeTextMapper[couponType]} 쿠폰
+          </Styled.SummaryMessage>
+        </Styled.Top>
+        <Styled.Main>
+          <Styled.CouponInner>
+            <UnregisteredCouponItem.Preview {...unregisteredCoupon} />
+          </Styled.CouponInner>
+          <Styled.SubSection>
+            <Styled.SubSectionTitle>쿠폰 메시지</Styled.SubSectionTitle>
+            <Styled.DescriptionContainer>{couponMessage}</Styled.DescriptionContainer>
+          </Styled.SubSection>
+
+          <Position position='fixed' bottom='0' css={Styled.ExtendedPosition}>
+            <Button onClick={onClickRegisterButton} css={Styled.ExtendedButton}>
+              쿠폰 등록하기
+            </Button>
+          </Position>
+        </Styled.Main>
+      </Styled.Root>
+    </PageTemplate>
+  );
+};
+
+export default IssuedRegisteredCouponPage;

--- a/frontend/src/@pages/unregistered-coupon-register/IssuedRegisteredCouponPage/index.tsx
+++ b/frontend/src/@pages/unregistered-coupon-register/IssuedRegisteredCouponPage/index.tsx
@@ -9,6 +9,7 @@ import { useFetchMe } from '@/@hooks/@queries/user';
 import { useRegisteredUnregisteredCoupon } from '@/@hooks/business/unregistered-coupon';
 import { couponTypeTextMapper } from '@/constants/coupon';
 import { PATH } from '@/Router';
+import { unregisteredCouponCodeStorage } from '@/storage/session';
 import theme from '@/styles/theme';
 import { UnregisteredCouponResponse } from '@/types/unregistered-coupon/remote';
 
@@ -37,6 +38,7 @@ const IssuedRegisteredCouponPage = (props: IssuedRegisteredCouponPageProps) => {
 
     if (window.confirm('쿠폰을 등록하려면 로그인이 필요합니다. 로그인하시겠아요?')) {
       navigate(PATH.LOGIN);
+      unregisteredCouponCodeStorage.set(couponCode);
     }
   };
 

--- a/frontend/src/@pages/unregistered-coupon-register/IssuedRegisteredCouponPage/index.tsx
+++ b/frontend/src/@pages/unregistered-coupon-register/IssuedRegisteredCouponPage/index.tsx
@@ -15,12 +15,12 @@ import { UnregisteredCouponResponse } from '@/types/unregistered-coupon/remote';
 
 import * as Styled from './style';
 
-interface IssuedRegisteredCouponPageProps {
+interface IssuedUnregisteredCouponPageProps {
   unregisteredCoupon: UnregisteredCouponResponse;
   couponCode: string;
 }
 
-const IssuedRegisteredCouponPage = (props: IssuedRegisteredCouponPageProps) => {
+const IssuedUnregisteredCouponPage = (props: IssuedUnregisteredCouponPageProps) => {
   const { unregisteredCoupon, couponCode } = props;
 
   const { sender, couponMessage, couponType } = unregisteredCoupon;
@@ -47,14 +47,6 @@ const IssuedRegisteredCouponPage = (props: IssuedRegisteredCouponPageProps) => {
     <PageTemplate title='쿠폰' hasHeader={false}>
       <Styled.Root>
         <Styled.Top>
-          <Position position='absolute' top='20px' left='20px'>
-            <Icon
-              iconName='arrow'
-              size='20'
-              color={theme.colors.primary_400}
-              onClick={() => navigate(-1)}
-            />
-          </Position>
           <Styled.ProfileImage src={sender.imageUrl} alt='프로필' width={51} height={51} />
           <Styled.SummaryMessage>
             <strong>
@@ -85,4 +77,4 @@ const IssuedRegisteredCouponPage = (props: IssuedRegisteredCouponPageProps) => {
   );
 };
 
-export default IssuedRegisteredCouponPage;
+export default IssuedUnregisteredCouponPage;

--- a/frontend/src/@pages/unregistered-coupon-register/IssuedRegisteredCouponPage/style.tsx
+++ b/frontend/src/@pages/unregistered-coupon-register/IssuedRegisteredCouponPage/style.tsx
@@ -1,0 +1,103 @@
+import type { Theme } from '@emotion/react';
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+
+export const Root = styled.div`
+  display: flex;
+  flex-direction: column;
+  min-height: calc(var(--vh, 1vh) * 100);
+`;
+
+export const Top = styled.div`
+  width: 100%;
+  height: 200px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+
+  ${({ theme }) => css`
+    background-color: ${theme.colors.primary_400_opacity};
+  `}
+`;
+
+export const ProfileImage = styled.img`
+  border-radius: 50%;
+  margin-bottom: 24px;
+`;
+
+export const SummaryMessage = styled.span`
+  font-size: 16px;
+
+  strong {
+    font-weight: 600;
+  }
+`;
+
+export const Main = styled.main`
+  height: calc(100% - 100px);
+  padding: 30px 16px 40px;
+  border-radius: 20px 20px 0 0;
+  position: relative;
+  top: -20px;
+  background-color: white;
+
+  ${({ theme }) => css`
+    box-shadow: ${theme.shadow.top_1};
+  `}
+`;
+
+export const CouponInner = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: center;
+`;
+
+export const SubSection = styled.section`
+  margin-top: 40px;
+`;
+
+export const SubSectionTitle = styled.span`
+  font-weight: 600;
+  ${({ theme }) => css`
+    color: ${theme.colors.drak_grey_200};
+  `}
+`;
+
+export const DescriptionContainer = styled.div`
+  min-height: 100px;
+
+  margin-top: 10px;
+
+  font-size: 14px;
+  border-radius: 20px;
+
+  padding: 15px;
+
+  line-height: 1.5;
+  word-break: break-all;
+
+  ${({ theme }) => css`
+    background-color: ${theme.colors.background_3};
+  `}
+`;
+
+export const ExtendedButton = css`
+  height: 50px;
+  border-radius: 0;
+  flex: 1;
+`;
+
+export const ExtendedPosition = (theme: Theme) => css`
+  width: 100%;
+  max-width: 414px;
+
+  display: flex;
+
+  left: 50%;
+  transform: translateX(-50%);
+
+  & > button + button {
+    border-left: 1px solid ${theme.colors.grey_100};
+  }
+`;

--- a/frontend/src/@pages/unregistered-coupon-register/RegisteredRegisteredCouponPage/index.tsx
+++ b/frontend/src/@pages/unregistered-coupon-register/RegisteredRegisteredCouponPage/index.tsx
@@ -7,7 +7,7 @@ import { PATH } from '@/Router';
 
 import * as Styled from './style';
 
-const RegisteredRegisteredCouponPage = () => {
+const RegisteredCouponPage = () => {
   const navigate = useNavigate();
 
   return (
@@ -23,4 +23,4 @@ const RegisteredRegisteredCouponPage = () => {
   );
 };
 
-export default RegisteredRegisteredCouponPage;
+export default RegisteredCouponPage;

--- a/frontend/src/@pages/unregistered-coupon-register/RegisteredRegisteredCouponPage/index.tsx
+++ b/frontend/src/@pages/unregistered-coupon-register/RegisteredRegisteredCouponPage/index.tsx
@@ -1,5 +1,26 @@
+import { useNavigate } from 'react-router-dom';
+
+import Button from '@/@components/@shared/Button';
+import PageTemplate from '@/@components/@shared/PageTemplate';
+import landingLogoImage from '@/assets/images/landing_logo.png';
+import { PATH } from '@/Router';
+
+import * as Styled from './style';
+
 const RegisteredRegisteredCouponPage = () => {
-  return <div>이미 등록된 쿠폰입니다.</div>;
+  const navigate = useNavigate();
+
+  return (
+    <PageTemplate title='꼭꼭' hasHeader={false}>
+      <Styled.Root>
+        <img src={landingLogoImage} alt='로고' width='86' />
+        <Styled.Description>해당 쿠폰은 이미 등록되었습니다.</Styled.Description>
+        <Styled.ButtonInner>
+          <Button onClick={() => navigate(PATH.MAIN)}>홈으로 가기</Button>
+        </Styled.ButtonInner>
+      </Styled.Root>
+    </PageTemplate>
+  );
 };
 
 export default RegisteredRegisteredCouponPage;

--- a/frontend/src/@pages/unregistered-coupon-register/RegisteredRegisteredCouponPage/index.tsx
+++ b/frontend/src/@pages/unregistered-coupon-register/RegisteredRegisteredCouponPage/index.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 
 import Button from '@/@components/@shared/Button';
 import PageTemplate from '@/@components/@shared/PageTemplate';
@@ -8,16 +8,14 @@ import { PATH } from '@/Router';
 import * as Styled from './style';
 
 const RegisteredCouponPage = () => {
-  const navigate = useNavigate();
-
   return (
     <PageTemplate title='꼭꼭' hasHeader={false}>
       <Styled.Root>
         <img src={landingLogoImage} alt='로고' width='86' />
         <Styled.Description>해당 쿠폰은 이미 등록되었습니다.</Styled.Description>
-        <Styled.ButtonInner>
-          <Button onClick={() => navigate(PATH.MAIN)}>홈으로 가기</Button>
-        </Styled.ButtonInner>
+        <Link to={PATH.MAIN} css={Styled.ExtendedLink}>
+          <Button>홈으로 가기</Button>
+        </Link>
       </Styled.Root>
     </PageTemplate>
   );

--- a/frontend/src/@pages/unregistered-coupon-register/RegisteredRegisteredCouponPage/index.tsx
+++ b/frontend/src/@pages/unregistered-coupon-register/RegisteredRegisteredCouponPage/index.tsx
@@ -1,0 +1,5 @@
+const RegisteredRegisteredCouponPage = () => {
+  return <div>이미 등록된 쿠폰입니다.</div>;
+};
+
+export default RegisteredRegisteredCouponPage;

--- a/frontend/src/@pages/unregistered-coupon-register/RegisteredRegisteredCouponPage/style.tsx
+++ b/frontend/src/@pages/unregistered-coupon-register/RegisteredRegisteredCouponPage/style.tsx
@@ -20,6 +20,6 @@ export const Description = styled.p`
   font-size: 20px;
 `;
 
-export const ButtonInner = styled.div`
+export const ExtendedLink = css`
   width: 50%;
 `;

--- a/frontend/src/@pages/unregistered-coupon-register/RegisteredRegisteredCouponPage/style.tsx
+++ b/frontend/src/@pages/unregistered-coupon-register/RegisteredRegisteredCouponPage/style.tsx
@@ -1,0 +1,25 @@
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+
+export const Root = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 20px;
+
+  height: calc(var(--vh, 1vh) * 100);
+
+  ${({ theme }) => css`
+    background-color: ${theme.colors.primary_400_opacity};
+  `}
+`;
+
+export const Description = styled.p`
+  font-family: 'BMHANNAProOTF';
+  font-size: 20px;
+`;
+
+export const ButtonInner = styled.div`
+  width: 50%;
+`;

--- a/frontend/src/@pages/unregistered-coupon-register/UnregisteredCouponCodeProxyPage.tsx
+++ b/frontend/src/@pages/unregistered-coupon-register/UnregisteredCouponCodeProxyPage.tsx
@@ -7,10 +7,10 @@ import IssuedUnregisteredCouponPage from './IssuedRegisteredCouponPage';
 import RegisteredCouponPage from './RegisteredRegisteredCouponPage';
 
 const UnregisteredCouponCodeProxyPage = () => {
-  const couponCode = useGetSearchParam('couponCode');
+  const couponCode = useGetSearchParam('couponCode') ?? '';
 
   // @TODO: null 처리
-  const { unregisteredCoupon } = useFetchUnregisteredCouponByCode(couponCode ?? '');
+  const { unregisteredCoupon } = useFetchUnregisteredCouponByCode(couponCode);
 
   if (couponCode === null) {
     return <NotFoundPage />;

--- a/frontend/src/@pages/unregistered-coupon-register/UnregisteredCouponCodeProxyPage.tsx
+++ b/frontend/src/@pages/unregistered-coupon-register/UnregisteredCouponCodeProxyPage.tsx
@@ -2,11 +2,11 @@ import useGetSearchParam from '@/@hooks/@common/useGetSearchParams';
 import { useFetchUnregisteredCouponByCode } from '@/@hooks/@queries/unregistered-coupon';
 
 import NotFoundPage from '../404';
-import ExpiredRegisteredCouponPage from './ExpiredRegisteredCouponPage';
-import IssuedRegisteredCouponPage from './IssuedRegisteredCouponPage';
+import ExpiredUnregisteredCouponPage from './ExpiredRegisteredCouponPage';
+import IssuedUnregisteredCouponPage from './IssuedRegisteredCouponPage';
 import RegisteredCouponPage from './RegisteredRegisteredCouponPage';
 
-const UnregisteredCouponCodePage = () => {
+const UnregisteredCouponCodeProxyPage = () => {
   const couponCode = useGetSearchParam('couponCode');
 
   // @TODO: null 처리
@@ -20,21 +20,26 @@ const UnregisteredCouponCodePage = () => {
     return <NotFoundPage />;
   }
 
-  if (unregisteredCoupon.unregisteredCouponStatus === 'ISSUED') {
+  const { unregisteredCouponStatus } = unregisteredCoupon;
+
+  if (unregisteredCouponStatus === 'ISSUED') {
     return (
-      <IssuedRegisteredCouponPage unregisteredCoupon={unregisteredCoupon} couponCode={couponCode} />
+      <IssuedUnregisteredCouponPage
+        unregisteredCoupon={unregisteredCoupon}
+        couponCode={couponCode}
+      />
     );
   }
 
-  if (unregisteredCoupon.unregisteredCouponStatus === 'REGISTERED') {
+  if (unregisteredCouponStatus === 'REGISTERED') {
     return <RegisteredCouponPage />;
   }
 
-  if (unregisteredCoupon.unregisteredCouponStatus === 'EXPIRED') {
-    return <ExpiredRegisteredCouponPage />;
+  if (unregisteredCouponStatus === 'EXPIRED') {
+    return <ExpiredUnregisteredCouponPage />;
   }
 
   return <NotFoundPage />;
 };
 
-export default UnregisteredCouponCodePage;
+export default UnregisteredCouponCodeProxyPage;

--- a/frontend/src/@pages/unregistered-coupon-register/index.tsx
+++ b/frontend/src/@pages/unregistered-coupon-register/index.tsx
@@ -12,34 +12,24 @@ const UnregisteredCouponCodeProxyPage = () => {
   // @TODO: null 처리
   const { unregisteredCoupon } = useFetchUnregisteredCouponByCode(couponCode);
 
-  if (couponCode === null) {
+  if (!unregisteredCoupon) {
     return <NotFoundPage />;
   }
 
-  if (unregisteredCoupon === undefined) {
-    return <NotFoundPage />;
-  }
-
-  const { unregisteredCouponStatus } = unregisteredCoupon;
-
-  if (unregisteredCouponStatus === 'ISSUED') {
-    return (
-      <IssuedUnregisteredCouponPage
-        unregisteredCoupon={unregisteredCoupon}
-        couponCode={couponCode}
-      />
-    );
-  }
-
-  if (unregisteredCouponStatus === 'REGISTERED') {
-    return <RegisteredCouponPage />;
-  }
-
-  if (unregisteredCouponStatus === 'EXPIRED') {
-    return <ExpiredUnregisteredCouponPage />;
-  }
-
-  return <NotFoundPage />;
+  return (
+    <>
+      {unregisteredCoupon.unregisteredCouponStatus === 'ISSUED' && (
+        <IssuedUnregisteredCouponPage
+          unregisteredCoupon={unregisteredCoupon}
+          couponCode={couponCode}
+        />
+      )}
+      {unregisteredCoupon.unregisteredCouponStatus === 'REGISTERED' && <RegisteredCouponPage />}
+      {unregisteredCoupon.unregisteredCouponStatus === 'EXPIRED' && (
+        <ExpiredUnregisteredCouponPage />
+      )}
+    </>
+  );
 };
 
 export default UnregisteredCouponCodeProxyPage;

--- a/frontend/src/@pages/unregistered-coupon-register/index.tsx
+++ b/frontend/src/@pages/unregistered-coupon-register/index.tsx
@@ -9,7 +9,6 @@ import RegisteredCouponPage from './RegisteredRegisteredCouponPage';
 const UnregisteredCouponCodeProxyPage = () => {
   const couponCode = useGetSearchParam('couponCode') ?? '';
 
-  // @TODO: null 처리
   const { unregisteredCoupon } = useFetchUnregisteredCouponByCode(couponCode);
 
   if (!unregisteredCoupon) {

--- a/frontend/src/Router.tsx
+++ b/frontend/src/Router.tsx
@@ -86,6 +86,15 @@ const Router = () => {
       <Routes>
         <Route path={PATH.LANDING} element={<LandingPage />} />
         <Route path={PATH.UNREGISTERED_COUPON_DETAIL} element={<UnregisteredCouponDetail />} />
+        <Route
+          path={PATH.UNREGISTERED_COUPON_REGISTER}
+          element={
+            // get 실패 이후에, reset 기능이 필요없는 fallback 에러가 필요함.
+            <ErrorBoundaryWithHooks fallback={NotFoundPage}>
+              <UnregisteredCouponCodePage />
+            </ErrorBoundaryWithHooks>
+          }
+        />
         <Route element={<PublicRoute />}>
           <Route path={PATH.LOGIN} element={<LoginPage />} />
           <Route path={PATH.SIGNUP} element={<JoinPage />} />

--- a/frontend/src/Router.tsx
+++ b/frontend/src/Router.tsx
@@ -6,13 +6,17 @@ import Loading from '@/@components/@shared/Loading';
 import OnlyNumberDynamicRouting from '@/@components/@shared/OnlyNumberDynamicRouting';
 import UnregisteredCouponCreate from '@/@pages/unregistered-coupon-list/create';
 
+import ErrorBoundaryWithHooks from './@components/@shared/ErrorBoundary';
 import { useFetchMe } from './@hooks/@queries/user';
 
 const NotFoundPage = lazy(() => import('@/@pages/404'));
 const CouponListPage = lazy(() => import('@/@pages/coupon-list'));
 const CouponCreatePage = lazy(() => import('@/@pages/coupon-list/create'));
-// const UnRegisteredCouponList = lazy(() => import('@/@pages/unregistered-coupon-list'));
-// const UnregisteredCouponDetail = lazy(() => import('@/@pages/unregistered-coupon-detail'));
+const UnRegisteredCouponList = lazy(() => import('@/@pages/unregistered-coupon-list'));
+const UnregisteredCouponDetail = lazy(() => import('@/@pages/unregistered-coupon-detail'));
+const UnregisteredCouponCodePage = lazy(
+  () => import('@/@pages/unregistered-coupon-register/CouponCodePage')
+);
 const UserHistoryPage = lazy(() => import('@/@pages/history'));
 const JoinPage = lazy(() => import('@/@pages/join'));
 const LandingPage = lazy(() => import('@/@pages/landing'));
@@ -27,7 +31,7 @@ const LoginPage = lazy(() => import('@/@pages/profile/login'));
 const ProfileEditPage = lazy(() => import('@/@pages/profile/edit'));
 const OAuthRedirect = lazy(() => import('@/@pages/oauth-redirect'));
 const SlackDownloadRedirect = lazy(() => import('@/@pages/slack-download-redirect'));
-// const CouponCreateSelectPage = lazy(() => import('@/@pages/coupon-create-select'));
+const CouponCreateSelectPage = lazy(() => import('@/@pages/coupon-create-select'));
 
 export const PATH = {
   MAIN: '/',
@@ -39,7 +43,7 @@ export const PATH = {
   UNREGISTERED_COUPON_CREATE: '/unregistered-coupon-list/create',
   UNREGISTERED_COUPON_LIST: '/unregistered-coupon-list',
   UNREGISTERED_COUPON_DETAIL: '/unregistered-coupon-list/:unregisteredCouponId',
-  UNREGISTERED_COUPON_REGISTER: '/unregistered-coupon-list/register/:couponCode',
+  UNREGISTERED_COUPON_REGISTER: '/unregistered-coupon-list/register',
   COUPON_CREATE_SELECT: '/coupon-create-select',
   LOGIN: '/login',
   SLACK_LOGIN_REDIRECT: '/login/redirect',
@@ -81,7 +85,7 @@ const Router = () => {
     <Suspense fallback={<Loading />}>
       <Routes>
         <Route path={PATH.LANDING} element={<LandingPage />} />
-        {/* <Route path={PATH.UNREGISTERED_COUPON_DETAIL} element={<UnregisteredCouponDetail />} /> */}
+        <Route path={PATH.UNREGISTERED_COUPON_DETAIL} element={<UnregisteredCouponDetail />} />
         <Route element={<PublicRoute />}>
           <Route path={PATH.LOGIN} element={<LoginPage />} />
           <Route path={PATH.SIGNUP} element={<JoinPage />} />
@@ -94,10 +98,10 @@ const Router = () => {
           <Route path={PATH.MAIN} element={<MainPage />} />
           <Route path={PATH.SENT_COUPON_LIST} element={<CouponListPage />} />
           <Route path={PATH.RECEIVED_COUPON_LIST} element={<CouponListPage />} />
-          {/* <Route path={PATH.COUPON_CREATE_SELECT} element={<CouponCreateSelectPage />} /> */}
+          <Route path={PATH.COUPON_CREATE_SELECT} element={<CouponCreateSelectPage />} />
           <Route path={PATH.COUPON_CREATE} element={<CouponCreatePage />} />
           <Route path={PATH.UNREGISTERED_COUPON_CREATE} element={<UnregisteredCouponCreate />} />
-          {/* <Route path={PATH.UNREGISTERED_COUPON_LIST} element={<UnRegisteredCouponList />} /> */}
+          <Route path={PATH.UNREGISTERED_COUPON_LIST} element={<UnRegisteredCouponList />} />
           {/* @TODO: Skeleton */}
           <Route
             path={PATH.COUPON_DETAIL}

--- a/frontend/src/Router.tsx
+++ b/frontend/src/Router.tsx
@@ -14,9 +14,7 @@ const CouponListPage = lazy(() => import('@/@pages/coupon-list'));
 const CouponCreatePage = lazy(() => import('@/@pages/coupon-list/create'));
 const UnRegisteredCouponList = lazy(() => import('@/@pages/unregistered-coupon-list'));
 const UnregisteredCouponDetail = lazy(() => import('@/@pages/unregistered-coupon-detail'));
-const UnregisteredCouponCodeProxyPage = lazy(
-  () => import('@/@pages/unregistered-coupon-register/UnregisteredCouponCodeProxyPage')
-);
+const UnregisteredCouponCodeProxyPage = lazy(() => import('@/@pages/unregistered-coupon-register'));
 const UserHistoryPage = lazy(() => import('@/@pages/history'));
 const JoinPage = lazy(() => import('@/@pages/join'));
 const LandingPage = lazy(() => import('@/@pages/landing'));

--- a/frontend/src/Router.tsx
+++ b/frontend/src/Router.tsx
@@ -14,8 +14,8 @@ const CouponListPage = lazy(() => import('@/@pages/coupon-list'));
 const CouponCreatePage = lazy(() => import('@/@pages/coupon-list/create'));
 const UnRegisteredCouponList = lazy(() => import('@/@pages/unregistered-coupon-list'));
 const UnregisteredCouponDetail = lazy(() => import('@/@pages/unregistered-coupon-detail'));
-const UnregisteredCouponCodePage = lazy(
-  () => import('@/@pages/unregistered-coupon-register/CouponCodePage')
+const UnregisteredCouponCodeProxyPage = lazy(
+  () => import('@/@pages/unregistered-coupon-register/UnregisteredCouponCodeProxyPage')
 );
 const UserHistoryPage = lazy(() => import('@/@pages/history'));
 const JoinPage = lazy(() => import('@/@pages/join'));
@@ -94,7 +94,7 @@ const Router = () => {
           element={
             // get 실패 이후에, reset 기능이 필요없는 fallback 에러가 필요함.
             <ErrorBoundaryWithHooks fallback={NotFoundPage}>
-              <UnregisteredCouponCodePage />
+              <UnregisteredCouponCodeProxyPage />
             </ErrorBoundaryWithHooks>
           }
         />

--- a/frontend/src/Router.tsx
+++ b/frontend/src/Router.tsx
@@ -78,6 +78,9 @@ export const DYNAMIC_PATH = {
   UNREGISTERED_COUPON_DETAIL(couponCode: string): string {
     return `${PATH.UNREGISTERED_COUPON_LIST}/${couponCode}`;
   },
+  UNREGISTERED_COUPON_REGISTER(couponCode: string): string {
+    return `${PATH.UNREGISTERED_COUPON_REGISTER}?couponCode=${couponCode}`;
+  },
 };
 
 const Router = () => {

--- a/frontend/src/apis/unregistered-coupon.ts
+++ b/frontend/src/apis/unregistered-coupon.ts
@@ -1,4 +1,5 @@
 import {
+  RegisterUnregisteredCouponRequest,
   UnregisteredCouponListByStatusRequest,
   UnregisteredCouponListResponse,
   UnregisteredCouponResponse,
@@ -16,8 +17,22 @@ export const getUnregisteredCouponListByStatus = async ({
   return data;
 };
 
-export const getUnregisteredCoupon = async (id: number) => {
+export const getUnregisteredCouponById = async (id: number) => {
   const { data } = await client.get<UnregisteredCouponResponse>(`/coupons/unregistered/${id}`);
+
+  return data;
+};
+
+export const getUnregisteredCouponByCode = async (couponCode: string) => {
+  const { data } = await client.get<UnregisteredCouponResponse>(
+    `/coupons/unregistered?couponCode=${couponCode}`
+  );
+
+  return data;
+};
+
+export const registerUnregisteredCoupon = async (body: RegisterUnregisteredCouponRequest) => {
+  const { data } = await client.post<UnregisteredCouponResponse>('coupons/code', body);
 
   return data;
 };

--- a/frontend/src/mocks/fixtures/unregistered-coupon.ts
+++ b/frontend/src/mocks/fixtures/unregistered-coupon.ts
@@ -20,7 +20,7 @@ export default {
     },
     {
       id: 2,
-      couponCode: 'asdfghjkqwertyui',
+      couponCode: 'rkfkfjgmdoemdldk',
       couponId: 1,
       sender: {
         id: 1,
@@ -40,7 +40,7 @@ export default {
     },
     {
       id: 3,
-      couponCode: 'asdfghjkqwertyui',
+      couponCode: 'dlfoekermldodeoe',
       couponId: null,
       sender: {
         id: 1,
@@ -65,6 +65,16 @@ export default {
 
   findUnregisteredCoupon(unregisteredCouponId: number) {
     const coupon = this.current.find(({ id }) => id === unregisteredCouponId);
+
+    if (!coupon) {
+      throw new Error('쿠폰이 없습니다.');
+    }
+
+    return coupon;
+  },
+
+  findUnregisteredCouponByCode(couponCode: string) {
+    const coupon = this.current.find(coupon => coupon.couponCode === couponCode);
 
     if (!coupon) {
       throw new Error('쿠폰이 없습니다.');

--- a/frontend/src/mocks/handlers/unregistered-coupon.ts
+++ b/frontend/src/mocks/handlers/unregistered-coupon.ts
@@ -2,6 +2,7 @@ import { rest } from 'msw';
 
 import { BASE_URL } from '@/apis';
 import { UNREGISTERED_COUPON_STATUS } from '@/types/unregistered-coupon/client';
+import { RegisterUnregisteredCouponRequest } from '@/types/unregistered-coupon/remote';
 
 import unregisteredCouponMock from '../fixtures/unregistered-coupon';
 
@@ -22,6 +23,47 @@ export const unregisteredCouponHandler = [
 
     try {
       const coupon = unregisteredCouponMock.findUnregisteredCoupon(Number(unregisteredCouponId));
+
+      return res(ctx.status(200), ctx.json(coupon));
+    } catch ({ message }) {
+      return res(ctx.status(400), ctx.json({ message }));
+    }
+  }),
+
+  // @TODO: coupon/:couponId 가 먼저 인식되는 현상 해결
+  rest.get(`${BASE_URL}/coupons/unregistered`, (req, res, ctx) => {
+    const couponCode = req.url.searchParams.get('couponCode');
+
+    if (!couponCode) {
+      return res(ctx.status(400), ctx.json({ message: '해당 쿠폰이 없습니다.' }));
+    }
+
+    try {
+      const coupon = unregisteredCouponMock.findUnregisteredCouponByCode(couponCode);
+
+      return res(ctx.status(200), ctx.json(coupon));
+    } catch ({ message }) {
+      return res(ctx.status(400), ctx.json({ message }));
+    }
+  }),
+
+  rest.post<RegisterUnregisteredCouponRequest>(`${BASE_URL}/coupons/code`, (req, res, ctx) => {
+    const {
+      body: { couponCode },
+    } = req;
+
+    try {
+      const coupon = unregisteredCouponMock.findUnregisteredCouponByCode(couponCode);
+
+      if (coupon.unregisteredCouponStatus !== 'ISSUED') {
+        throw new Error('유효하지 않은 쿠폰입니다.');
+      }
+
+      unregisteredCouponMock.current = unregisteredCouponMock.current.map(coupon =>
+        coupon.unregisteredCouponStatus === 'ISSUED'
+          ? { ...coupon, unregisteredCouponStatus: 'REGISTERED' }
+          : coupon
+      );
 
       return res(ctx.status(200), ctx.json(coupon));
     } catch ({ message }) {

--- a/frontend/src/mocks/handlers/unregistered-coupon.ts
+++ b/frontend/src/mocks/handlers/unregistered-coupon.ts
@@ -56,7 +56,7 @@ export const unregisteredCouponHandler = [
       const coupon = unregisteredCouponMock.findUnregisteredCouponByCode(couponCode);
 
       if (coupon.unregisteredCouponStatus !== 'ISSUED') {
-        throw new Error('유효하지 않은 쿠폰입니다.');
+        return res(ctx.status(400), ctx.json({ message: '유효하지 않은 쿠폰입니다.' }));
       }
 
       unregisteredCouponMock.current = unregisteredCouponMock.current.map(coupon =>
@@ -67,7 +67,7 @@ export const unregisteredCouponHandler = [
 
       return res(ctx.status(200), ctx.json(coupon));
     } catch ({ message }) {
-      return res(ctx.status(400), ctx.json({ error: message }));
+      return res(ctx.status(400), ctx.json({ message }));
     }
   }),
 ];

--- a/frontend/src/storage/session/index.ts
+++ b/frontend/src/storage/session/index.ts
@@ -20,6 +20,10 @@ class SessionStorage<T extends string> {
   set(value: T) {
     sessionStorage.setItem(this.key, value);
   }
+
+  remove() {
+    sessionStorage.removeItem(this.key);
+  }
 }
 
 export const filterOptionsSessionStorage = new SessionStorage<FilterOption>(

--- a/frontend/src/storage/session/index.ts
+++ b/frontend/src/storage/session/index.ts
@@ -5,6 +5,7 @@ const SESSION_KEY = {
   filterOptions: 'filterOptions',
   unregisteredFilterOptions: 'unregisteredFilterOptions',
   prevUrl: 'prevUrl',
+  unregisteredCouponCode: 'unregisteredCouponCode',
 };
 
 class SessionStorage<T extends string> {
@@ -30,3 +31,5 @@ export const unregisteredFilterOptionsSessionStorage = new SessionStorage<Unregi
 );
 
 export const prevUrlSessionStorage = new SessionStorage(SESSION_KEY.prevUrl);
+
+export const unregisteredCouponCodeStorage = new SessionStorage(SESSION_KEY.unregisteredCouponCode);

--- a/frontend/src/types/unregistered-coupon/client.ts
+++ b/frontend/src/types/unregistered-coupon/client.ts
@@ -1,20 +1,5 @@
-import { COUPON_ENG_TYPE, COUPON_HASHTAGS } from '../coupon/client';
-import { Member } from '../user/client';
-import { Valueof, YYYYMMDDhhmmss } from '../utils';
+import { Valueof } from '../utils';
 
 export const unregisteredCouponStatus = ['ISSUED', 'REGISTERED', 'EXPIRED'] as const;
 
 export type UNREGISTERED_COUPON_STATUS = Valueof<typeof unregisteredCouponStatus>;
-
-export interface UnregisteredCoupon {
-  id: number;
-  couponCode: string;
-  couponId: number | null;
-  sender: Member;
-  receiver: Member | null;
-  couponTag: COUPON_HASHTAGS;
-  couponMessage: string;
-  couponType: COUPON_ENG_TYPE;
-  unregisteredCouponStatus: UNREGISTERED_COUPON_STATUS;
-  createdTime: YYYYMMDDhhmmss;
-}

--- a/frontend/src/types/unregistered-coupon/remote.ts
+++ b/frontend/src/types/unregistered-coupon/remote.ts
@@ -2,23 +2,29 @@ import { COUPON_ENG_TYPE, COUPON_HASHTAGS } from '@/types/coupon/client';
 import { Member } from '@/types/user/client';
 import { YYYYMMDDhhmmss } from '@/types/utils';
 
-import { UNREGISTERED_COUPON_STATUS, UnregisteredCoupon } from './client';
+import { UNREGISTERED_COUPON_STATUS } from './client';
 
 export interface UnregisteredCouponListByStatusRequest {
   type: UNREGISTERED_COUPON_STATUS;
 }
 
 export interface UnregisteredCouponListResponse {
-  data: UnregisteredCoupon[];
+  data: UnregisteredCouponResponse[];
 }
 
 export interface UnregisteredCouponResponse {
   id: number;
   couponCode: string;
+  couponId: number | null;
   sender: Member;
+  receiver: Member | null;
   couponTag: COUPON_HASHTAGS;
   couponMessage: string;
   couponType: COUPON_ENG_TYPE;
   unregisteredCouponStatus: UNREGISTERED_COUPON_STATUS;
   createdTime: YYYYMMDDhhmmss;
+}
+
+export interface RegisterUnregisteredCouponRequest {
+  couponCode: string;
 }


### PR DESCRIPTION
## 작업 내용

- 미등록 페이지 쿠폰 등록 과정 구현
  - 아직 등록되지 않은 미등록 쿠폰 페이지
  - 등록 완료된 미등록 쿠폰 페이지
  - 기간이 만료된 미등록 쿠폰 페이지
- 쿠폰을 등록하려 할 때 로그인 되어있지 않으면, 로그인 페이지로 라우팅 합니다. 이때 sessionStorage에 couponCode를 저장해두어, 인증 완료 후 메인페이지로 돌아왔을 때 쿠폰 등록 페이지로 돌아갈 수 있도록 유도합니다.

<img width="300" alt="image" src="https://user-images.githubusercontent.com/24906022/195357083-fb38c114-c9c8-4e46-aea4-208b2ddaca5b.png">

<img width="300" alt="image" src="https://user-images.githubusercontent.com/24906022/195357032-abdbac0f-a1a4-462a-b885-41e6a473147a.png">


## 공유사항

에러바운더리 코드 아주 조금 수정했습니다. AxiosError의 response.data에 message를 담고있는지 확인하기 위해 CustomAxiosError를 만들어서 내로잉 하고 있었습니다. 그러다보니 CustomAxiosError가 아닌 AxiosError가 get 메서드일 때, 에러가 잘 포착되지 않고, 계속 children을 보여주며 에러가 반복되어 앱이 터졌습니다. 그래서 CustomAxiosError 내로잉을 제거했습니다.

Resolves #448
