### PR TITLE
feat: 미등록 쿠폰 등록 페이지에서 보일 시간 컴포넌트를 개발한다.

### DIFF
--- a/frontend/src/@components/@shared/DownCount/index.tsx
+++ b/frontend/src/@components/@shared/DownCount/index.tsx
@@ -1,0 +1,50 @@
+import { PropsWithChildren, useEffect, useRef, useState } from 'react';
+
+import { computeDayHourMinSecByMS } from '@/utils/time';
+
+interface DownCountProps {
+  className?: string;
+  start: number;
+  decreaseNumber: number;
+}
+
+const DownCount = (props: PropsWithChildren<DownCountProps>) => {
+  const { start, decreaseNumber, className, children } = props;
+
+  const [count, setCount] = useState(start);
+
+  const rAFId = useRef<number | null>(null);
+
+  useEffect(() => {
+    const remainingTimeSetter = (prevSecond: number, timestamp: number) => {
+      const currentSecond = Math.floor(timestamp / decreaseNumber);
+
+      if (prevSecond < currentSecond) {
+        setCount(prev => prev - 1000);
+      }
+
+      if (count > 0) {
+        requestAnimationFrame(timestamp => remainingTimeSetter(currentSecond, timestamp));
+      }
+    };
+
+    rAFId.current = requestAnimationFrame(timestamp => remainingTimeSetter(0, timestamp));
+  }, []);
+
+  useEffect(() => {
+    if (Math.floor(count) === 0 && rAFId.current) {
+      cancelAnimationFrame(rAFId.current);
+    }
+  }, [count, start]);
+
+  const { sec } = computeDayHourMinSecByMS(count);
+
+  return (
+    <div className={className}>
+      {Math.floor(sec)}
+      {children}
+    </div>
+  );
+};
+
+export default DownCount;

--- a/frontend/src/@components/@shared/Input/index.tsx
+++ b/frontend/src/@components/@shared/Input/index.tsx
@@ -35,9 +35,13 @@ Input.Counter = function CounterInput(props: CounterInputProps) {
       <label htmlFor={id}>{label}</label>
       {description && <Styled.Description>{description}</Styled.Description>}
       <Styled.CounterInputContainer>
-        <Styled.MinusCounterButton onClick={onClickMinusButton}>-</Styled.MinusCounterButton>
+        <Styled.MinusCounterButton type='button' onClick={onClickMinusButton}>
+          -
+        </Styled.MinusCounterButton>
         <Styled.Input id={id} type='number' value={value} disabled {...rest} />
-        <Styled.PlusCounterButton onClick={onClickPlusButton}>+</Styled.PlusCounterButton>
+        <Styled.PlusCounterButton type='button' onClick={onClickPlusButton}>
+          +
+        </Styled.PlusCounterButton>
       </Styled.CounterInputContainer>
     </Styled.Root>
   );

--- a/frontend/src/@components/@shared/UpCount/index.tsx
+++ b/frontend/src/@components/@shared/UpCount/index.tsx
@@ -13,7 +13,7 @@ const UpCount = (props: PropsWithChildren<UpCountProps>) => {
 
   const [count, setCount] = useState(0);
 
-  const reqId = useRef<number | null>(null);
+  const rAFId = useRef<number | null>(null);
 
   useEffect(() => {
     const animationHandler = (progress = 0) => {
@@ -24,12 +24,12 @@ const UpCount = (props: PropsWithChildren<UpCountProps>) => {
       }
     };
 
-    reqId.current = requestAnimationFrame(() => animationHandler(0));
+    rAFId.current = requestAnimationFrame(() => animationHandler(0));
   }, [duration, limit]);
 
   useEffect(() => {
-    if (Math.ceil(count) === limit && reqId.current) {
-      cancelAnimationFrame(reqId.current);
+    if (Math.ceil(count) === limit && rAFId.current) {
+      cancelAnimationFrame(rAFId.current);
     }
   }, [count, limit]);
 

--- a/frontend/src/@components/@shared/UpCount/index.tsx
+++ b/frontend/src/@components/@shared/UpCount/index.tsx
@@ -1,0 +1,44 @@
+import { PropsWithChildren, useEffect, useRef, useState } from 'react';
+
+import { easyOutExpo } from '@/utils/animation';
+
+interface UpCountProps {
+  className?: string;
+  limit: number;
+  duration: number;
+}
+
+const UpCount = (props: PropsWithChildren<UpCountProps>) => {
+  const { className, limit, duration, children } = props;
+
+  const [count, setCount] = useState(0);
+
+  const reqId = useRef<number | null>(null);
+
+  useEffect(() => {
+    const animationHandler = (progress = 0) => {
+      setCount(limit * easyOutExpo(progress));
+
+      if (progress <= 1) {
+        requestAnimationFrame(timestamp => animationHandler(timestamp / duration));
+      }
+    };
+
+    reqId.current = requestAnimationFrame(() => animationHandler(0));
+  }, [duration, limit]);
+
+  useEffect(() => {
+    if (Math.ceil(count) === limit && reqId.current) {
+      cancelAnimationFrame(reqId.current);
+    }
+  }, [count, limit]);
+
+  return (
+    <div className={className}>
+      {Math.ceil(count)}
+      {children}
+    </div>
+  );
+};
+
+export default UpCount;

--- a/frontend/src/@components/unregistered-coupon/UnregisteredCouponExpiredTime/index.tsx
+++ b/frontend/src/@components/unregistered-coupon/UnregisteredCouponExpiredTime/index.tsx
@@ -1,9 +1,10 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 
+import DownCount from '@/@components/@shared/DownCount';
 import UpCount from '@/@components/@shared/UpCount';
 import { EXPIRATION_PERIOD } from '@/constants/unregisteredCoupon';
 import { YYYYMMDDhhmmss } from '@/types/utils';
-import { computeDayHourMinSecByMS, computeExpiredTime } from '@/utils/time';
+import { computeDayHourMinSecByMS, computeExpiredTimeByPeriodMS } from '@/utils/time';
 
 import * as Styled from './style';
 
@@ -13,25 +14,11 @@ interface UnregisteredCouponExpiredTimeProps {
 const UnregisteredCouponExpiredTime = (props: UnregisteredCouponExpiredTimeProps) => {
   const { createdTime } = props;
 
-  const expiredTimeMS = computeExpiredTime(createdTime, EXPIRATION_PERIOD);
+  const expiredTimeMS = computeExpiredTimeByPeriodMS(createdTime, EXPIRATION_PERIOD);
 
-  const [remainingTime, setRemainingTime] = useState(expiredTimeMS - Date.now());
+  const [remainingTime] = useState(expiredTimeMS - Date.now());
 
-  useEffect(() => {
-    const remainingTimeSetter = (prevSecond: number, timestamp: number) => {
-      const currentSecond = Math.floor(timestamp / 1000);
-
-      if (prevSecond < currentSecond) {
-        setRemainingTime(prev => prev - 1000);
-      }
-
-      requestAnimationFrame(timestamp => remainingTimeSetter(currentSecond, timestamp));
-    };
-
-    requestAnimationFrame(timestamp => remainingTimeSetter(0, timestamp));
-  }, []);
-
-  const { day, hour, min, sec } = computeDayHourMinSecByMS(remainingTime);
+  const { day, hour, min } = computeDayHourMinSecByMS(remainingTime);
 
   return (
     <Styled.Root>
@@ -44,7 +31,9 @@ const UnregisteredCouponExpiredTime = (props: UnregisteredCouponExpiredTimeProps
       <UpCount limit={min} duration={3000}>
         분
       </UpCount>
-      <Styled.SecContainer>{sec}초</Styled.SecContainer>
+      <DownCount start={remainingTime} decreaseNumber={1000}>
+        초
+      </DownCount>
     </Styled.Root>
   );
 };

--- a/frontend/src/@components/unregistered-coupon/UnregisteredCouponExpiredTime/index.tsx
+++ b/frontend/src/@components/unregistered-coupon/UnregisteredCouponExpiredTime/index.tsx
@@ -1,0 +1,52 @@
+import { useEffect, useState } from 'react';
+
+import UpCount from '@/@components/@shared/UpCount';
+import { EXPIRATION_PERIOD } from '@/constants/unregisteredCoupon';
+import { YYYYMMDDhhmmss } from '@/types/utils';
+import { computeDayHourMinSecByMS, computeExpiredTime } from '@/utils/time';
+
+import * as Styled from './style';
+
+interface UnregisteredCouponExpiredTimeProps {
+  createdTime: YYYYMMDDhhmmss;
+}
+const UnregisteredCouponExpiredTime = (props: UnregisteredCouponExpiredTimeProps) => {
+  const { createdTime } = props;
+
+  const expiredTimeMS = computeExpiredTime(createdTime, EXPIRATION_PERIOD);
+
+  const [remainingTime, setRemainingTime] = useState(expiredTimeMS - Date.now());
+
+  useEffect(() => {
+    const remainingTimeSetter = (prevSecond: number, timestamp: number) => {
+      const currentSecond = Math.floor(timestamp / 1000);
+
+      if (prevSecond < currentSecond) {
+        setRemainingTime(prev => prev - 1000);
+      }
+
+      requestAnimationFrame(timestamp => remainingTimeSetter(currentSecond, timestamp));
+    };
+
+    requestAnimationFrame(timestamp => remainingTimeSetter(0, timestamp));
+  }, []);
+
+  const { day, hour, min, sec } = computeDayHourMinSecByMS(remainingTime);
+
+  return (
+    <Styled.Root>
+      <UpCount limit={day} duration={3000}>
+        일
+      </UpCount>
+      <UpCount limit={hour} duration={3000}>
+        시간
+      </UpCount>
+      <UpCount limit={min} duration={3000}>
+        분
+      </UpCount>
+      <Styled.SecContainer>{sec}초</Styled.SecContainer>
+    </Styled.Root>
+  );
+};
+
+export default UnregisteredCouponExpiredTime;

--- a/frontend/src/@components/unregistered-coupon/UnregisteredCouponExpiredTime/style.tsx
+++ b/frontend/src/@components/unregistered-coupon/UnregisteredCouponExpiredTime/style.tsx
@@ -1,0 +1,11 @@
+import styled from '@emotion/styled';
+
+export const Root = styled.div`
+  display: flex;
+
+  justify-content: center;
+  align-items: center;
+  gap: 10px;
+`;
+
+export const SecContainer = styled.div``;

--- a/frontend/src/@hooks/ui/unregistered-coupon/useUnregisteredForm.ts
+++ b/frontend/src/@hooks/ui/unregistered-coupon/useUnregisteredForm.ts
@@ -1,3 +1,4 @@
+import { r } from 'msw/lib/glossary-58eca5a8';
 import { FormEventHandler, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
@@ -29,7 +30,15 @@ export const useUnregisteredForm = () => {
       return;
     }
 
-    if (count < 1 || count > 5) {
+    if (count > 5) {
+      displayMessage('쿠폰의 수는 5개를 초과할 수 없어요', true);
+
+      return;
+    }
+
+    if (count < 1) {
+      displayMessage('쿠폰의 수는 1개보다 적을 수 없어요', true);
+
       return;
     }
 

--- a/frontend/src/@pages/unregistered-coupon-detail/index.tsx
+++ b/frontend/src/@pages/unregistered-coupon-detail/index.tsx
@@ -1,5 +1,5 @@
 import PageTemplate from '@/@components/@shared/PageTemplate';
-import Time from '@/@components/@shared/Time';
+import UnregisteredCouponExpiredTime from '@/@components/unregistered-coupon/UnregisteredCouponExpiredTime';
 import UnregisteredCouponItem from '@/@components/unregistered-coupon/UnregisteredCouponItem';
 import { useFetchUnregisteredCoupon } from '@/@hooks/@queries/unregistered-coupon';
 import { EXPIRATION_PERIOD } from '@/constants/unregisteredCoupon';
@@ -14,15 +14,15 @@ const UnregisteredCouponDetail = () => {
     return <div>hi</div>;
   }
 
-  const { couponType, couponMessage, couponCode, createdTime } = unregisteredCoupon;
+  // const { couponType, couponMessage, couponCode, createdTime } = unregisteredCoupon;
 
-  const expiredTimeSeconds = computeExpiredTime(createdTime, EXPIRATION_PERIOD);
+  // const expiredTimeSeconds = computeExpiredTime(createdTime, EXPIRATION_PERIOD);
 
   return (
-    <PageTemplate title='미등록 쿠폰 조회' extendedHeader>
-      <Styled.Root>
+    <PageTemplate title='미등록 쿠폰 조회'>
+      {/* <Styled.Root>
         <Styled.Top>
-          <Time expiredTimeSeconds={expiredTimeSeconds} />
+          <UnregisteredCouponExpiredTime createdTime={createdTime} />
         </Styled.Top>
         <Styled.Main>
           <Styled.CouponInner>
@@ -37,7 +37,7 @@ const UnregisteredCouponDetail = () => {
             <Styled.DescriptionContainer>{couponMessage}</Styled.DescriptionContainer>
           </Styled.SubSection>
         </Styled.Main>
-      </Styled.Root>
+      </Styled.Root> */}
     </PageTemplate>
   );
 };

--- a/frontend/src/@pages/unregistered-coupon-detail/index.tsx
+++ b/frontend/src/@pages/unregistered-coupon-detail/index.tsx
@@ -1,5 +1,45 @@
+import PageTemplate from '@/@components/@shared/PageTemplate';
+import Time from '@/@components/@shared/Time';
+import UnregisteredCouponItem from '@/@components/unregistered-coupon/UnregisteredCouponItem';
+import { useFetchUnregisteredCoupon } from '@/@hooks/@queries/unregistered-coupon';
+import { EXPIRATION_PERIOD } from '@/constants/unregisteredCoupon';
+import { computeExpiredTime } from '@/utils/time';
+
+import * as Styled from './style';
+
 const UnregisteredCouponDetail = () => {
-  return <div>UnregisteredCouponDetail</div>;
+  const { unregisteredCoupon } = useFetchUnregisteredCoupon(1);
+
+  if (!unregisteredCoupon) {
+    return <div>hi</div>;
+  }
+
+  const { couponType, couponMessage, couponCode, createdTime } = unregisteredCoupon;
+
+  const expiredTimeSeconds = computeExpiredTime(createdTime, EXPIRATION_PERIOD);
+
+  return (
+    <PageTemplate title='미등록 쿠폰 조회' extendedHeader>
+      <Styled.Root>
+        <Styled.Top>
+          <Time expiredTimeSeconds={expiredTimeSeconds} />
+        </Styled.Top>
+        <Styled.Main>
+          <Styled.CouponInner>
+            <UnregisteredCouponItem {...unregisteredCoupon} />
+          </Styled.CouponInner>
+          <Styled.SubSection>
+            <Styled.SubSectionTitle>미등록 쿠폰 코드</Styled.SubSectionTitle>
+            <Styled.CodeContainer>{couponCode}</Styled.CodeContainer>
+          </Styled.SubSection>
+          <Styled.SubSection>
+            <Styled.SubSectionTitle>쿠폰 메시지</Styled.SubSectionTitle>
+            <Styled.DescriptionContainer>{couponMessage}</Styled.DescriptionContainer>
+          </Styled.SubSection>
+        </Styled.Main>
+      </Styled.Root>
+    </PageTemplate>
+  );
 };
 
 export default UnregisteredCouponDetail;

--- a/frontend/src/@pages/unregistered-coupon-detail/style.tsx
+++ b/frontend/src/@pages/unregistered-coupon-detail/style.tsx
@@ -1,0 +1,134 @@
+import type { Theme } from '@emotion/react';
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+
+export const Root = styled.div`
+  display: flex;
+  flex-direction: column;
+  min-height: calc(var(--vh, 1vh) * 100);
+`;
+
+export const Top = styled.div`
+  width: 100%;
+  height: 200px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+
+  ${({ theme }) => css`
+    background-color: ${theme.colors.primary_400_opacity};
+  `}
+`;
+
+export const ProfileImage = styled.img`
+  border-radius: 50%;
+  margin-bottom: 24px;
+`;
+
+export const SummaryMessage = styled.span`
+  font-size: 16px;
+
+  strong {
+    font-weight: 600;
+  }
+`;
+
+export const Main = styled.main`
+  height: calc(100% - 100px);
+  padding: 30px 16px 40px;
+  border-radius: 20px 20px 0 0;
+  position: relative;
+  top: -20px;
+  background-color: white;
+
+  ${({ theme }) => css`
+    box-shadow: ${theme.shadow.top_1};
+  `}
+`;
+
+export const CouponInner = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: center;
+`;
+
+export const SubSection = styled.section`
+  margin-top: 40px;
+`;
+
+export const SubSectionTitle = styled.span`
+  font-weight: 600;
+  ${({ theme }) => css`
+    color: ${theme.colors.drak_grey_200};
+  `}
+`;
+
+export const CodeContainer = styled.div`
+  min-height: 150px;
+  margin-top: 10px;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  font-size: 14px;
+  border-radius: 20px;
+
+  ${({ theme }) => css`
+    background-color: ${theme.colors.background_3};
+  `}
+`;
+
+export const DescriptionContainer = styled.div`
+  min-height: 100px;
+
+  margin-top: 10px;
+
+  font-size: 14px;
+  border-radius: 20px;
+
+  padding: 15px;
+
+  line-height: 1.5;
+  word-break: break-all;
+
+  ${({ theme }) => css`
+    background-color: ${theme.colors.background_3};
+  `}
+`;
+
+export const FinishButtonInner = styled.div`
+  width: 100%;
+  text-align: right;
+  font-size: 12px;
+  margin-top: 16px;
+
+  ${({ theme }) => css`
+    color: ${theme.colors.grey_200};
+  `}
+
+  & > button {
+    text-decoration: underline;
+  }
+`;
+
+export const ExtendedButton = css`
+  height: 50px;
+  border-radius: 0;
+  flex: 1;
+`;
+
+export const ExtendedPosition = (theme: Theme) => css`
+  width: 100%;
+  max-width: 414px;
+
+  display: flex;
+
+  left: 50%;
+  transform: translateX(-50%);
+
+  & > button + button {
+    border-left: 1px solid ${theme.colors.grey_100};
+  }
+`;

--- a/frontend/src/constants/unregisteredCoupon.ts
+++ b/frontend/src/constants/unregisteredCoupon.ts
@@ -1,1 +1,1 @@
-export const EXPIRATION_PERIOD = 604800000;
+export const EXPIRATION_PERIOD = 60 * 60 * 24 * 7 * 1000;

--- a/frontend/src/constants/unregisteredCoupon.ts
+++ b/frontend/src/constants/unregisteredCoupon.ts
@@ -1,0 +1,1 @@
+export const EXPIRATION_PERIOD = 604800000;

--- a/frontend/src/mocks/fixtures/unregistered-coupon.ts
+++ b/frontend/src/mocks/fixtures/unregistered-coupon.ts
@@ -16,7 +16,7 @@ export default {
       couponMessage: '하하하',
       couponType: 'COFFEE',
       unregisteredCouponStatus: 'ISSUED',
-      createdTime: '2022-10-07T14:32:22',
+      createdTime: '2022-10-12T14:32:22',
     },
     {
       id: 2,
@@ -36,7 +36,7 @@ export default {
       couponMessage: '하하하',
       couponType: 'COFFEE',
       unregisteredCouponStatus: 'REGISTERED',
-      createdTime: '2022-10-07T14:32:22',
+      createdTime: '2022-10-12T14:32:22',
     },
     {
       id: 3,
@@ -52,7 +52,7 @@ export default {
       couponMessage: '하하하',
       couponType: 'COFFEE',
       unregisteredCouponStatus: 'EXPIRED',
-      createdTime: '2022-10-07T14:32:22',
+      createdTime: '2022-10-12T14:32:22',
     },
   ],
   findUnregisteredCouponListByStatus(status: UNREGISTERED_COUPON_STATUS) {
@@ -62,7 +62,6 @@ export default {
 
     return unregisteredCouponList;
   },
-
   findUnregisteredCoupon(unregisteredCouponId: number) {
     const coupon = this.current.find(({ id }) => id === unregisteredCouponId);
 

--- a/frontend/src/types/unregistered-coupon/remote.ts
+++ b/frontend/src/types/unregistered-coupon/remote.ts
@@ -15,7 +15,9 @@ export interface UnregisteredCouponListResponse {
 export interface UnregisteredCouponResponse {
   id: number;
   couponCode: string;
+  couponId: number | null;
   sender: Member;
+  receiver: Member | null;
   couponTag: COUPON_HASHTAGS;
   couponMessage: string;
   couponType: COUPON_ENG_TYPE;

--- a/frontend/src/utils/animation.ts
+++ b/frontend/src/utils/animation.ts
@@ -1,0 +1,1 @@
+export const easyOutExpo = (x: number) => (x >= 1 ? 1 : 1 - Math.pow(2, -10 * x));

--- a/frontend/src/utils/time.ts
+++ b/frontend/src/utils/time.ts
@@ -82,3 +82,22 @@ export const sortByTime = (targetDateA: string, targetDateB: string): number => 
 
   return Number(`${yearA}${monthA}${dayA}`) - Number(`${yearB}${monthB}${dayB}`);
 };
+
+export const computeExpiredTime = (startTime: YYYYMMDDhhmmss, expirationPeriodMS: number) => {
+  const startTimeMS = new Date(startTime).getTime();
+
+  const expiredTimeMS = startTimeMS + expirationPeriodMS;
+
+  return expiredTimeMS;
+};
+
+export const computeDayHourMinSecByMS = (ms: number) => {
+  const seconds = ms / 1000;
+
+  const day = Math.floor(seconds / 86400);
+  const hour = Math.floor((seconds % 86400) / 3600);
+  const min = Math.floor(((seconds % 86400) % 3600) / 60);
+  const sec = Math.floor(seconds % 60);
+
+  return { day, hour, min, sec };
+};

--- a/frontend/src/utils/time.ts
+++ b/frontend/src/utils/time.ts
@@ -83,7 +83,10 @@ export const sortByTime = (targetDateA: string, targetDateB: string): number => 
   return Number(`${yearA}${monthA}${dayA}`) - Number(`${yearB}${monthB}${dayB}`);
 };
 
-export const computeExpiredTime = (startTime: YYYYMMDDhhmmss, expirationPeriodMS: number) => {
+export const computeExpiredTimeByPeriodMS = (
+  startTime: YYYYMMDDhhmmss,
+  expirationPeriodMS: number
+) => {
   const startTimeMS = new Date(startTime).getTime();
 
   const expiredTimeMS = startTimeMS + expirationPeriodMS;


### PR DESCRIPTION
## 작업 내용

미등록 쿠폰 등록 페이지는 사용자의 쿠폰 등록 및 회원가입을 유도해야합니다. 이에 맞게 조금은 심미적인 UI를 디자인하고자 논의되었었고, 이에 맞게 `UI` 컴포넌트를 개발하였습니다. 

- [x] `UnregisteredCouponExpiredTime` 를 개발한다.

  - `requestAnimationFrame`을 활용하여 줄어드는 시간 데이터를 렌더링하였습니다.
  - 도메인에 귀속된 컴포넌트로 개발하였습니다.
     - 현재 사용되는 곳이 `UnregisteredCoupon` 영역 밖에 없다.
     - 다른 도메인에서 사용될 까? 의문이다. `YAGNI` 하지 않는다 👻

- [x] `UpCount` 컴포넌트 개발


  - 처음 렌더링 시 일, 시, 분 에 해당하는 숫자들이 카운트 업 되는 애니메이션을 트리거하는 컴포넌트를 개발하였습니다.
  - `requestAnimationFrame` 을 활용하였습니다.

## 공유사항

해당 작업 내용에 관한 부연 설명 및 및 향후 작업해야 할 내용 등에 대한 설명

Resolves #462 
