### PR TITLE
refactor: Header 및 PageTemplate 컴포넌트 개선작업

### DIFF
--- a/frontend/src/@components/@shared/ErrorFallback/index.tsx
+++ b/frontend/src/@components/@shared/ErrorFallback/index.tsx
@@ -14,7 +14,7 @@ export interface ErrorFallbackProps {
 
 const ErrorFallback = ({ error, resetErrorBoundary }: ErrorFallbackProps) => {
   return (
-    <PageTemplate title='꼭꼭' hasHeader={false}>
+    <PageTemplate.ExtendedStyleHeader title='문제가 발생했어요'>
       <Styled.Root>
         <img src={landingLogoImage} alt='로고' width='86' />
         <Styled.ResetSection onClick={resetErrorBoundary}>
@@ -22,7 +22,7 @@ const ErrorFallback = ({ error, resetErrorBoundary }: ErrorFallbackProps) => {
           <button>다시 불러오기</button>
         </Styled.ResetSection>
       </Styled.Root>
-    </PageTemplate>
+    </PageTemplate.ExtendedStyleHeader>
   );
 };
 

--- a/frontend/src/@components/@shared/Header/index.tsx
+++ b/frontend/src/@components/@shared/Header/index.tsx
@@ -47,7 +47,7 @@ const Header = (props: HeaderProps) => {
           />
         )}
       </Styled.Logo>
-      <Styled.Title>{title}</Styled.Title>
+      <Styled.Title>{!isMainPage && title}</Styled.Title>
       <Styled.Profile>
         <Position
           css={css`

--- a/frontend/src/@components/@shared/PageTemplate/index.tsx
+++ b/frontend/src/@components/@shared/PageTemplate/index.tsx
@@ -29,20 +29,20 @@ const PageTemplate = (props: PropsWithChildren<PageTemplateProps>) => {
   );
 };
 
-PageTemplate.LandingPage = function LandingPageTemplate(
+PageTemplate.ExtendedStyleHeader = function LandingPageTemplate(
   props: PropsWithChildren<PageTemplateProps>
 ) {
-  const { hasHeader = true, children } = props;
+  const { title, hasHeader = true, children } = props;
 
   useEffect(() => {
-    document.title = '꼭꼭 | 쿠폰으로 전하는 약속, 꼭꼭으로 간편하게';
-  }, []);
+    document.title = `${title || '꼭꼭'} | 쿠폰으로 전하는 약속, 꼭꼭으로 간편하게`;
+  }, [title]);
 
   return (
     <PrevPathMemoization>
       <Styled.Root>
         <Styled.Container>
-          {hasHeader && <Header css={Styled.ExtendedHeader} />}
+          {hasHeader && <Header title={title} css={Styled.ExtendedHeader} />}
           {children}
         </Styled.Container>
       </Styled.Root>

--- a/frontend/src/@components/@shared/PageTemplate/index.tsx
+++ b/frontend/src/@components/@shared/PageTemplate/index.tsx
@@ -29,7 +29,7 @@ const PageTemplate = (props: PropsWithChildren<PageTemplateProps>) => {
   );
 };
 
-PageTemplate.ExtendedStyleHeader = function LandingPageTemplate(
+PageTemplate.ExtendedStyleHeader = function ExtendedPageTemplate(
   props: PropsWithChildren<PageTemplateProps>
 ) {
   const { title, hasHeader = true, children } = props;

--- a/frontend/src/@pages/coupon-list/coupon-detail/accept/index.tsx
+++ b/frontend/src/@pages/coupon-list/coupon-detail/accept/index.tsx
@@ -64,7 +64,7 @@ const CouponAcceptPage = () => {
   };
 
   return (
-    <PageTemplate title='쿠폰' hasHeader={false}>
+    <PageTemplate.ExtendedStyleHeader title='쿠폰 확정하기'>
       <Styled.Root>
         <Styled.Top>
           <Position position='absolute' top='20px' left='20px'>
@@ -110,7 +110,7 @@ const CouponAcceptPage = () => {
           </Position>
         </Styled.Main>
       </Styled.Root>
-    </PageTemplate>
+    </PageTemplate.ExtendedStyleHeader>
   );
 };
 

--- a/frontend/src/@pages/coupon-list/coupon-detail/accept/index.tsx
+++ b/frontend/src/@pages/coupon-list/coupon-detail/accept/index.tsx
@@ -67,14 +67,6 @@ const CouponAcceptPage = () => {
     <PageTemplate.ExtendedStyleHeader title='쿠폰 확정하기'>
       <Styled.Root>
         <Styled.Top>
-          <Position position='absolute' top='20px' left='20px'>
-            <Icon
-              iconName='arrow'
-              size='20'
-              color={theme.colors.primary_400}
-              onClick={() => navigate(-1)}
-            />
-          </Position>
           <Styled.ProfileImage src={member?.imageUrl} alt='프로필' width={51} height={51} />
           <Styled.SummaryMessage>
             <strong>

--- a/frontend/src/@pages/coupon-list/coupon-detail/decline/index.tsx
+++ b/frontend/src/@pages/coupon-list/coupon-detail/decline/index.tsx
@@ -65,17 +65,9 @@ const CouponDeclinePage = () => {
   };
 
   return (
-    <PageTemplate title='쿠폰' hasHeader={false}>
+    <PageTemplate.ExtendedStyleHeader title='쿠폰 거절하기'>
       <Styled.Root>
         <Styled.Top>
-          <Position position='absolute' top='20px' left='20px'>
-            <Icon
-              iconName='arrow'
-              size='20'
-              color={theme.colors.primary_400}
-              onClick={() => navigate(-1)}
-            />
-          </Position>
           <Styled.ProfileImage src={member.imageUrl} alt='프로필' width={51} height={51} />
           <Styled.SummaryMessage>
             <strong>
@@ -110,7 +102,7 @@ const CouponDeclinePage = () => {
           </Position>
         </Styled.Main>
       </Styled.Root>
-    </PageTemplate>
+    </PageTemplate.ExtendedStyleHeader>
   );
 };
 

--- a/frontend/src/@pages/coupon-list/coupon-detail/index.tsx
+++ b/frontend/src/@pages/coupon-list/coupon-detail/index.tsx
@@ -2,7 +2,6 @@ import { Fragment } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 
 import Button from '@/@components/@shared/Button';
-import Icon from '@/@components/@shared/Icon';
 import PageTemplate from '@/@components/@shared/PageTemplate';
 import Position from '@/@components/@shared/Position';
 import CouponHistoryList from '@/@components/coupon/CouponHistoryList';
@@ -13,7 +12,6 @@ import useCouponPartner from '@/@hooks/ui/coupon/useCouponPartner';
 import NotFoundPage from '@/@pages/404';
 import { couponTypeTextMapper } from '@/constants/coupon';
 import { DYNAMIC_PATH } from '@/Router';
-import theme from '@/styles/theme';
 import { COUPON_STATUS } from '@/types/coupon/client';
 
 import * as Styled from './style';
@@ -100,17 +98,9 @@ const CouponDetailPage = () => {
   };
 
   return (
-    <PageTemplate title='쿠폰' hasHeader={false}>
+    <PageTemplate.ExtendedStyleHeader title='쿠폰 자세히 보기'>
       <Styled.Root>
         <Styled.Top>
-          <Position position='absolute' top='20px' left='20px'>
-            <Icon
-              iconName='arrow'
-              size='20'
-              color={theme.colors.primary_400}
-              onClick={() => navigate(-1)}
-            />
-          </Position>
           <Styled.ProfileImage src={member.imageUrl} alt='프로필' width={51} height={51} />
           <Styled.SummaryMessage>
             <strong>
@@ -171,7 +161,7 @@ const CouponDetailPage = () => {
           </Position>
         </Styled.Main>
       </Styled.Root>
-    </PageTemplate>
+    </PageTemplate.ExtendedStyleHeader>
   );
 };
 

--- a/frontend/src/@pages/coupon-list/coupon-detail/request/index.tsx
+++ b/frontend/src/@pages/coupon-list/coupon-detail/request/index.tsx
@@ -1,7 +1,6 @@
 import { Navigate, useNavigate, useParams } from 'react-router-dom';
 
 import Button from '@/@components/@shared/Button';
-import Icon from '@/@components/@shared/Icon';
 import PageTemplate from '@/@components/@shared/PageTemplate';
 import Position from '@/@components/@shared/Position';
 import useInput from '@/@hooks/@common/useInput';
@@ -12,7 +11,6 @@ import { useChangeCouponStatus } from '@/@hooks/business/coupon';
 import useCouponPartner from '@/@hooks/ui/coupon/useCouponPartner';
 import NotFoundPage from '@/@pages/404';
 import { couponTypeTextMapper } from '@/constants/coupon';
-import theme from '@/styles/theme';
 import { YYYYMMDD } from '@/types/utils';
 import { getTodayDate, isBeforeToday } from '@/utils/time';
 import { isOverMaxLength } from '@/utils/validations';
@@ -73,17 +71,9 @@ const CouponRequestPage = () => {
   };
 
   return (
-    <PageTemplate title='쿠폰' hasHeader={false}>
+    <PageTemplate.ExtendedStyleHeader title='쿠폰 요청하기'>
       <Styled.Root>
         <Styled.Top>
-          <Position position='absolute' top='20px' left='20px'>
-            <Icon
-              iconName='arrow'
-              size='20'
-              color={theme.colors.primary_400}
-              onClick={() => navigate(-1)}
-            />
-          </Position>
           <Styled.ProfileImage src={member.imageUrl} alt='프로필' width={51} height={51} />
           <Styled.SummaryMessage>
             <strong>
@@ -125,7 +115,7 @@ const CouponRequestPage = () => {
           </Position>
         </Styled.Main>
       </Styled.Root>
-    </PageTemplate>
+    </PageTemplate.ExtendedStyleHeader>
   );
 };
 

--- a/frontend/src/@pages/main/index.tsx
+++ b/frontend/src/@pages/main/index.tsx
@@ -38,7 +38,7 @@ const MainPage = () => {
   };
 
   return (
-    <PageTemplate.LandingPage title='꼭꼭'>
+    <PageTemplate.ExtendedStyleHeader title='꼭꼭'>
       <Styled.Root>
         <Styled.CreateCouponContainer>
           <div>
@@ -153,7 +153,7 @@ const MainPage = () => {
           </Styled.UnRegisteredCouponSection> */}
         </Styled.ListContainer>
       </Styled.Root>
-    </PageTemplate.LandingPage>
+    </PageTemplate.ExtendedStyleHeader>
   );
 };
 


### PR DESCRIPTION
## 작업 내용

기존의 PageTemplate은 페이지 단위로 개발되었습니다. 이러다보니 다른 페이지에서 사용하고자 할 때 의미가 모호해지는 경향이 있어 네이밍과 동작을 조금 수정하였습니다. 또한 쿠폰 상세 페이지에서도 헤더를 사용하기 위해 `PageTemplate, Header` 컴포넌트를 일부 수정합니다.

- `PageTemplate` 수정


- `Header` 수정


## 공유사항

해당 작업 내용에 관한 부연 설명 및 및 향후 작업해야 할 내용 등에 대한 설명

Resolves #464 
