### PR TITLE
feat: Suspense로 인한 네트워크 병목 해결 및 Skeleton UI 수정

### DIFF
--- a/frontend/src/@components/@shared/Placeholder/index.tsx
+++ b/frontend/src/@components/@shared/Placeholder/index.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { CSSProperties } from 'react';
 
-type PlaceholderProps = Pick<CSSProperties, 'width' | 'height' | 'aspectRatio'>;
+type PlaceholderProps = Pick<CSSProperties, 'width' | 'height' | 'aspectRatio' | 'maxWidth'>;
 
 const Placeholder = styled.div<PlaceholderProps>`
   border-radius: 20px;
@@ -19,8 +19,9 @@ const Placeholder = styled.div<PlaceholderProps>`
     }
   }
 
-  ${({ width = '100%', height = '100%', aspectRatio }) => css`
+  ${({ width = '100%', height = '100%', aspectRatio, maxWidth }) => css`
     width: ${width};
+    max-width: ${maxWidth};
     height: ${height};
 
     aspect-ratio: ${aspectRatio};

--- a/frontend/src/@components/coupon/CouponItem/big.tsx
+++ b/frontend/src/@components/coupon/CouponItem/big.tsx
@@ -75,7 +75,7 @@ BigCouponItem.Preview = function Preview(props: BigCouponItemPreviewProps) {
 };
 
 BigCouponItem.Skeleton = function Skeleton() {
-  return <Placeholder aspectRatio='3/1' />;
+  return <Placeholder width='100%' maxWidth='340px' height='120px' />;
 };
 
 export default BigCouponItem;

--- a/frontend/src/@components/coupon/CouponItem/small.style.tsx
+++ b/frontend/src/@components/coupon/CouponItem/small.style.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 
 export const Root = styled.div<{ hasCursor?: boolean }>`
   width: 140px;
+  height: 132px;
 
   display: flex;
   justify-content: center;

--- a/frontend/src/@components/coupon/CouponItem/small.tsx
+++ b/frontend/src/@components/coupon/CouponItem/small.tsx
@@ -39,5 +39,5 @@ const SmallCouponItem = (props: SmallCouponItemProps) => {
 export default SmallCouponItem;
 
 SmallCouponItem.Skeleton = function Skeleton() {
-  return <Placeholder width='140px' height='117px' />;
+  return <Placeholder width='140px' height='132px' />;
 };

--- a/frontend/src/@components/coupon/CouponItem/small.tsx
+++ b/frontend/src/@components/coupon/CouponItem/small.tsx
@@ -39,5 +39,5 @@ const SmallCouponItem = (props: SmallCouponItemProps) => {
 export default SmallCouponItem;
 
 SmallCouponItem.Skeleton = function Skeleton() {
-  return <Placeholder width='100px' height='200px' />;
+  return <Placeholder width='140px' height='117px' />;
 };

--- a/frontend/src/@components/coupon/CouponList/horizontal.style.tsx
+++ b/frontend/src/@components/coupon/CouponList/horizontal.style.tsx
@@ -14,6 +14,7 @@ export const SlideRoot = styled.div`
 
 export const TextContainer = styled.div<{ fontSize?: string }>`
   width: 100%;
+  height: 132px; // 쿠폰이 있는 상황과 height가 동일해야 한다.
 
   display: flex;
   flex-direction: column;

--- a/frontend/src/@components/coupon/CouponListSection/AcceptedCouponListSection/index.tsx
+++ b/frontend/src/@components/coupon/CouponListSection/AcceptedCouponListSection/index.tsx
@@ -1,3 +1,4 @@
+import CustomSuspense from '@/@components/@shared/CustomSuspense';
 import BigCouponItem from '@/@components/coupon/CouponItem/big';
 import VerticalCouponList from '@/@components/coupon/CouponList/vertical';
 import { useFetchCouponListByStatus } from '@/@hooks/@queries/coupon';
@@ -12,18 +13,24 @@ interface AcceptedCouponListSectionProps {
 const AcceptedCouponListSection = (props: AcceptedCouponListSectionProps) => {
   const { couponListType, onClickCouponItem } = props;
 
-  const { couponListByStatus: acceptedCouponList } = useFetchCouponListByStatus({
-    couponListType,
-    body: { type: 'ACCEPTED' },
-  });
+  const { couponListByStatus: acceptedCouponList, isLoading: isAcceptedCouponListLoading } =
+    useFetchCouponListByStatus({
+      couponListType,
+      body: { type: 'ACCEPTED' },
+    });
 
   return (
     <Styled.VerticalListContainer>
-      <VerticalCouponList
-        couponList={acceptedCouponList}
-        CouponItem={BigCouponItem}
-        onClickCouponItem={onClickCouponItem}
-      />
+      <CustomSuspense
+        isLoading={isAcceptedCouponListLoading}
+        fallback={<VerticalCouponList.Skeleton CouponItemSkeleton={BigCouponItem.Skeleton} />}
+      >
+        <VerticalCouponList
+          couponList={acceptedCouponList}
+          CouponItem={BigCouponItem}
+          onClickCouponItem={onClickCouponItem}
+        />
+      </CustomSuspense>
     </Styled.VerticalListContainer>
   );
 };

--- a/frontend/src/@components/coupon/CouponListSection/AllCouponListSection/index.tsx
+++ b/frontend/src/@components/coupon/CouponListSection/AllCouponListSection/index.tsx
@@ -1,3 +1,4 @@
+import CustomSuspense from '@/@components/@shared/CustomSuspense';
 import SmallCouponItem from '@/@components/coupon/CouponItem/small';
 import HorizontalCouponList from '@/@components/coupon/CouponList/horizontal';
 import { useFetchCouponListByStatus } from '@/@hooks/@queries/coupon';
@@ -12,48 +13,67 @@ interface AllCouponListSectionProps {
 const AllCouponListSection = (props: AllCouponListSectionProps) => {
   const { couponListType, onClickCouponItem } = props;
 
-  const { couponListByStatus: readyCouponList } = useFetchCouponListByStatus({
-    couponListType,
-    body: { type: 'READY' },
-  });
-  const { couponListByStatus: requestedCouponList } = useFetchCouponListByStatus({
-    couponListType,
-    body: { type: 'REQUESTED' },
-  });
-  const { couponListByStatus: acceptedCouponList } = useFetchCouponListByStatus({
-    couponListType,
-    body: { type: 'ACCEPTED' },
-  });
-  const { couponListByStatus: finishedCouponList } = useFetchCouponListByStatus({
-    couponListType,
-    body: { type: 'FINISHED' },
-  });
+  const { couponListByStatus: readyCouponList, isLoading: isReadyCouponListLoading } =
+    useFetchCouponListByStatus({
+      couponListType,
+      body: { type: 'READY' },
+    });
+  const { couponListByStatus: requestedCouponList, isLoading: isRequestedCouponListLoading } =
+    useFetchCouponListByStatus({
+      couponListType,
+      body: { type: 'REQUESTED' },
+    });
+  const { couponListByStatus: acceptedCouponList, isLoading: isAcceptedCouponListLoading } =
+    useFetchCouponListByStatus({
+      couponListType,
+      body: { type: 'ACCEPTED' },
+    });
+  const { couponListByStatus: finishedCouponList, isLoading: isFinishedCouponListLoading } =
+    useFetchCouponListByStatus({
+      couponListType,
+      body: { type: 'FINISHED' },
+    });
 
   return (
     <Styled.HorizonListContainer>
       <section>
         <h2>기다리고 있어요!</h2>
-        <HorizontalCouponList
-          couponList={[...readyCouponList, ...requestedCouponList]}
-          CouponItem={SmallCouponItem}
-          onClickCouponItem={onClickCouponItem}
-        />
+        <CustomSuspense
+          isLoading={isReadyCouponListLoading || isRequestedCouponListLoading}
+          fallback={<HorizontalCouponList.Skeleton CouponItemSkeleton={SmallCouponItem.Skeleton} />}
+        >
+          <HorizontalCouponList
+            couponList={[...readyCouponList, ...requestedCouponList]}
+            CouponItem={SmallCouponItem}
+            onClickCouponItem={onClickCouponItem}
+          />
+        </CustomSuspense>
       </section>
       <section>
         <h2>잡은 약속</h2>
-        <HorizontalCouponList
-          couponList={acceptedCouponList}
-          CouponItem={SmallCouponItem}
-          onClickCouponItem={onClickCouponItem}
-        />
+        <CustomSuspense
+          isLoading={isAcceptedCouponListLoading}
+          fallback={<HorizontalCouponList.Skeleton CouponItemSkeleton={SmallCouponItem.Skeleton} />}
+        >
+          <HorizontalCouponList
+            couponList={acceptedCouponList}
+            CouponItem={SmallCouponItem}
+            onClickCouponItem={onClickCouponItem}
+          />
+        </CustomSuspense>
       </section>
       <section>
         <h2>지난 약속</h2>
-        <HorizontalCouponList
-          couponList={finishedCouponList}
-          CouponItem={SmallCouponItem}
-          onClickCouponItem={onClickCouponItem}
-        />
+        <CustomSuspense
+          isLoading={isFinishedCouponListLoading}
+          fallback={<HorizontalCouponList.Skeleton CouponItemSkeleton={SmallCouponItem.Skeleton} />}
+        >
+          <HorizontalCouponList
+            couponList={finishedCouponList}
+            CouponItem={SmallCouponItem}
+            onClickCouponItem={onClickCouponItem}
+          />
+        </CustomSuspense>
       </section>
     </Styled.HorizonListContainer>
   );

--- a/frontend/src/@components/coupon/CouponListSection/FinishedCouponListSection/index.tsx
+++ b/frontend/src/@components/coupon/CouponListSection/FinishedCouponListSection/index.tsx
@@ -1,3 +1,4 @@
+import CustomSuspense from '@/@components/@shared/CustomSuspense';
 import BigCouponItem from '@/@components/coupon/CouponItem/big';
 import VerticalCouponList from '@/@components/coupon/CouponList/vertical';
 import { useFetchCouponListByStatus } from '@/@hooks/@queries/coupon';
@@ -12,18 +13,24 @@ interface FinishedCouponListSectionProps {
 const FinishedCouponListSection = (props: FinishedCouponListSectionProps) => {
   const { couponListType, onClickCouponItem } = props;
 
-  const { couponListByStatus: finishedCouponList } = useFetchCouponListByStatus({
-    couponListType,
-    body: { type: 'FINISHED' },
-  });
+  const { couponListByStatus: finishedCouponList, isLoading: isFinishedCouponListLoading } =
+    useFetchCouponListByStatus({
+      couponListType,
+      body: { type: 'FINISHED' },
+    });
 
   return (
     <Styled.VerticalListContainer>
-      <VerticalCouponList
-        couponList={finishedCouponList}
-        CouponItem={BigCouponItem}
-        onClickCouponItem={onClickCouponItem}
-      />
+      <CustomSuspense
+        isLoading={isFinishedCouponListLoading}
+        fallback={<VerticalCouponList.Skeleton CouponItemSkeleton={BigCouponItem.Skeleton} />}
+      >
+        <VerticalCouponList
+          couponList={finishedCouponList}
+          CouponItem={BigCouponItem}
+          onClickCouponItem={onClickCouponItem}
+        />
+      </CustomSuspense>
     </Styled.VerticalListContainer>
   );
 };

--- a/frontend/src/@components/coupon/CouponListSection/WaitingCouponListSection/index.tsx
+++ b/frontend/src/@components/coupon/CouponListSection/WaitingCouponListSection/index.tsx
@@ -1,3 +1,4 @@
+import CustomSuspense from '@/@components/@shared/CustomSuspense';
 import BigCouponItem from '@/@components/coupon/CouponItem/big';
 import VerticalCouponList from '@/@components/coupon/CouponList/vertical';
 import { useFetchCouponListByStatus } from '@/@hooks/@queries/coupon';
@@ -12,22 +13,29 @@ interface WaitingCouponListSectionProps {
 const WaitingCouponListSection = (props: WaitingCouponListSectionProps) => {
   const { couponListType, onClickCouponItem } = props;
 
-  const { couponListByStatus: readyCouponList } = useFetchCouponListByStatus({
-    couponListType,
-    body: { type: 'READY' },
-  });
-  const { couponListByStatus: requestedCouponList } = useFetchCouponListByStatus({
-    couponListType,
-    body: { type: 'REQUESTED' },
-  });
+  const { couponListByStatus: readyCouponList, isLoading: isReadyCouponListLoading } =
+    useFetchCouponListByStatus({
+      couponListType,
+      body: { type: 'READY' },
+    });
+  const { couponListByStatus: requestedCouponList, isLoading: isRequestedCouponListLoading } =
+    useFetchCouponListByStatus({
+      couponListType,
+      body: { type: 'REQUESTED' },
+    });
 
   return (
     <Styled.VerticalListContainer>
-      <VerticalCouponList
-        couponList={[...readyCouponList, ...requestedCouponList]}
-        CouponItem={BigCouponItem}
-        onClickCouponItem={onClickCouponItem}
-      />
+      <CustomSuspense
+        isLoading={isReadyCouponListLoading || isRequestedCouponListLoading}
+        fallback={<VerticalCouponList.Skeleton CouponItemSkeleton={BigCouponItem.Skeleton} />}
+      >
+        <VerticalCouponList
+          couponList={[...readyCouponList, ...requestedCouponList]}
+          CouponItem={BigCouponItem}
+          onClickCouponItem={onClickCouponItem}
+        />
+      </CustomSuspense>
     </Styled.VerticalListContainer>
   );
 };

--- a/frontend/src/@components/reservation/ReservationSection/style.tsx
+++ b/frontend/src/@components/reservation/ReservationSection/style.tsx
@@ -12,7 +12,7 @@ export const Root = styled.div`
 
 export const NoneContentsContainer = styled.div`
   width: 100%;
-  height: 200px;
+  height: 320px;
 
   display: flex;
   flex-direction: column;

--- a/frontend/src/@hooks/@queries/coupon.ts
+++ b/frontend/src/@hooks/@queries/coupon.ts
@@ -85,6 +85,7 @@ export const useFetchCouponListByStatus = ({
     () => fetcher(body),
     {
       staleTime: 10000,
+      suspense: false,
     }
   );
 

--- a/frontend/src/@hooks/@queries/coupon.ts
+++ b/frontend/src/@hooks/@queries/coupon.ts
@@ -42,6 +42,7 @@ export const useFetchCoupon = (id: number) => {
 export const useFetchReservationList = () => {
   const { data, isLoading } = useQuery([QUERY_KEY.reservationList], () => getReservationList(), {
     staleTime: 10000,
+    suspense: false,
   });
 
   return {
@@ -55,6 +56,7 @@ export const useFetchCouponList = ({ couponListType }: { couponListType: COUPON_
 
   const { data, isLoading } = useQuery([QUERY_KEY.couponList, couponListType], () => fetcher(), {
     staleTime: 10000,
+    suspense: false,
   });
 
   const openCouponList = (data?.data ?? []).filter(

--- a/frontend/src/@pages/coupon-list/index.tsx
+++ b/frontend/src/@pages/coupon-list/index.tsx
@@ -52,34 +52,34 @@ const CouponListPage = () => {
             onClickFilterButton={onClickFilterButton}
           />
         </Styled.ListFilterContainer>
-        <Suspense fallback={<CouponListPageFallback />}>
-          <Styled.Container>
-            {status === '전체' && (
-              <AllCouponListSection
-                couponListType={couponListType}
-                onClickCouponItem={onClickCouponItem}
-              />
-            )}
-            {status === '대기' && (
-              <WaitingCouponListSection
-                couponListType={couponListType}
-                onClickCouponItem={onClickCouponItem}
-              />
-            )}
-            {status === '확정' && (
-              <AcceptedCouponListSection
-                couponListType={couponListType}
-                onClickCouponItem={onClickCouponItem}
-              />
-            )}
-            {status === '완료' && (
-              <FinishedCouponListSection
-                couponListType={couponListType}
-                onClickCouponItem={onClickCouponItem}
-              />
-            )}
-          </Styled.Container>
-        </Suspense>
+
+        <Styled.Container>
+          {status === '전체' && (
+            <AllCouponListSection
+              couponListType={couponListType}
+              onClickCouponItem={onClickCouponItem}
+            />
+          )}
+          {status === '대기' && (
+            <WaitingCouponListSection
+              couponListType={couponListType}
+              onClickCouponItem={onClickCouponItem}
+            />
+          )}
+          {status === '확정' && (
+            <AcceptedCouponListSection
+              couponListType={couponListType}
+              onClickCouponItem={onClickCouponItem}
+            />
+          )}
+          {status === '완료' && (
+            <FinishedCouponListSection
+              couponListType={couponListType}
+              onClickCouponItem={onClickCouponItem}
+            />
+          )}
+        </Styled.Container>
+
         <Styled.LinkInner>
           <Link to={PATH.COUPON_CREATE}>
             <Icon iconName='plus' size='37' color={theme.colors.primary_400} />

--- a/frontend/src/@pages/unregistered-coupon-register/IssuedRegisteredCouponPage/index.tsx
+++ b/frontend/src/@pages/unregistered-coupon-register/IssuedRegisteredCouponPage/index.tsx
@@ -1,7 +1,6 @@
 import { useNavigate } from 'react-router-dom';
 
 import Button from '@/@components/@shared/Button';
-import Icon from '@/@components/@shared/Icon';
 import PageTemplate from '@/@components/@shared/PageTemplate';
 import Position from '@/@components/@shared/Position';
 import UnregisteredCouponItem from '@/@components/unregistered-coupon/UnregisteredCouponItem';
@@ -10,7 +9,6 @@ import { useRegisteredUnregisteredCoupon } from '@/@hooks/business/unregistered-
 import { couponTypeTextMapper } from '@/constants/coupon';
 import { PATH } from '@/Router';
 import { unregisteredCouponCodeStorage } from '@/storage/session';
-import theme from '@/styles/theme';
 import { UnregisteredCouponResponse } from '@/types/unregistered-coupon/remote';
 
 import * as Styled from './style';


### PR DESCRIPTION
## 작업 내용

### Suspense 제거
Suspense는 하나의 요청에서 throw한 것을 catch하여 loading을 보여주는 것으로, 네트워크 병목을 만듭니다.
Main 페이지 및 coupon list 페이지에서 3~4개의 요청을 한번에 하는데, 이때 Suspense가 병목을 만들어 로딩이 길고, 사용자 경험을 악화시켰습니다.
이를 해결하기 위해, suspense를 끄고, isLoading으로 로딩을 처리했습니다.

### Skeleton UI 수정
- 쿠없뷰, 쿠있뷰, Skeleton의 height가 달라서 layout shift가 생기는 현상 + 유저 경험이 나빠지는 현상이 있었습니다. 이를 해결하기 위해 3개의 height를 통일했습니다. 앞으로도 3개의 height를 통일하는 식으로 디자인해야 할 것 같습니다.


**변경전**
<img width="1386" alt="Untitled (12)" src="https://user-images.githubusercontent.com/24906022/195795543-fd035f80-d4cf-4790-8c9a-e29bd1481dce.png">

**변경후**
<img width="1281" alt="Untitled (13)" src="https://user-images.githubusercontent.com/24906022/195795559-3925f1a2-feee-4c48-804f-738b9b7b8a1c.png">

Resolves #472 
