### PR TITLE
feat: 몸이 불편한 사용자도 키보드만으로 쿠폰 생성을 할 수 있다.

### DIFF
--- a/frontend/src/@components/@shared/Modal/index.tsx
+++ b/frontend/src/@components/@shared/Modal/index.tsx
@@ -23,7 +23,7 @@ function Modal(props: PropsWithChildren<ModalProps>) {
   };
 
   return ReactDOM.createPortal(
-    <Dimmed position={position} onClick={onClickDimmed}>
+    <Dimmed role='dialog' position={position} onClick={onClickDimmed}>
       <Styled.Root position={position} animation={animation}>
         {children}
       </Styled.Root>

--- a/frontend/src/@components/@shared/SelectInput/index.tsx
+++ b/frontend/src/@components/@shared/SelectInput/index.tsx
@@ -12,7 +12,7 @@ const SelectInput = (props: PropsWithChildren<SelectInputProps>) => {
   return (
     <Styled.Root>
       <label>{label}</label>
-      <Styled.SelectContainer>{children}</Styled.SelectContainer>
+      <Styled.SelectContainer tabIndex={0}>{children}</Styled.SelectContainer>
     </Styled.Root>
   );
 };
@@ -23,7 +23,7 @@ SelectInput.VerticalView = function VerticalView(props: PropsWithChildren<Select
   return (
     <Styled.Root>
       <label>{label}</label>
-      <Styled.SelectVerticalContainer>{children}</Styled.SelectVerticalContainer>
+      <Styled.SelectVerticalContainer tabIndex={0}>{children}</Styled.SelectVerticalContainer>
     </Styled.Root>
   );
 };

--- a/frontend/src/@components/@shared/SelectInput/style.tsx
+++ b/frontend/src/@components/@shared/SelectInput/style.tsx
@@ -12,7 +12,7 @@ export const Root = styled.div`
   }
 `;
 
-export const SelectContainer = styled.section`
+export const SelectContainer = styled.ul`
   overflow-x: scroll;
 
   padding: 10px;
@@ -35,7 +35,7 @@ export const SelectContainer = styled.section`
   }
 `;
 
-export const SelectVerticalContainer = styled.section`
+export const SelectVerticalContainer = styled.ul`
   padding: 10px;
 
   display: flex;

--- a/frontend/src/@components/@shared/SelectInput/style.tsx
+++ b/frontend/src/@components/@shared/SelectInput/style.tsx
@@ -12,7 +12,7 @@ export const Root = styled.div`
   }
 `;
 
-export const SelectContainer = styled.ul`
+export const SelectContainer = styled.section`
   overflow-x: scroll;
 
   padding: 10px;
@@ -35,7 +35,7 @@ export const SelectContainer = styled.ul`
   }
 `;
 
-export const SelectVerticalContainer = styled.ul`
+export const SelectVerticalContainer = styled.section`
   padding: 10px;
 
   display: flex;

--- a/frontend/src/@components/coupon/CouponCreateForm/index.tsx
+++ b/frontend/src/@components/coupon/CouponCreateForm/index.tsx
@@ -1,4 +1,4 @@
-import { ChangeEventHandler, FormEventHandler, MouseEventHandler } from 'react';
+import { ChangeEventHandler, FormEventHandler, KeyboardEvent, MouseEventHandler } from 'react';
 import { Link } from 'react-router-dom';
 
 import Button from '@/@components/@shared/Button';
@@ -23,9 +23,9 @@ interface CouponCreateFormProps {
   currentCouponType: COUPON_ENG_TYPE;
   currentCouponTag: COUPON_HASHTAGS;
   currentCouponMessage: string;
-  onSelectReceiver: (user: UserResponse) => MouseEventHandler<HTMLDivElement>;
-  onSelectCouponType: (type: COUPON_ENG_TYPE) => MouseEventHandler<HTMLLIElement>;
-  onSelectCouponTag: (hashtag: COUPON_HASHTAGS) => MouseEventHandler<HTMLLIElement>;
+  onSelectReceiver: (user: UserResponse) => MouseEventHandler<HTMLButtonElement>;
+  onSelectCouponType: (type: COUPON_ENG_TYPE) => MouseEventHandler<HTMLButtonElement>;
+  onSelectCouponTag: (hashtag: COUPON_HASHTAGS) => MouseEventHandler<HTMLButtonElement>;
   onChangeCouponMessage: ChangeEventHandler<HTMLTextAreaElement>;
   onSubmitCouponCreateForm: FormEventHandler<HTMLFormElement>;
 }
@@ -49,9 +49,12 @@ const CouponCreateForm = (props: CouponCreateFormProps) => {
 
   return (
     <Styled.FormRoot onSubmit={onSubmitCouponCreateForm}>
-      <Styled.FindUserContainer>
-        <div>누구에게 보내시나요 ?</div>
-        <Styled.FindUserInput onClick={openModal}>
+      <Styled.FindUserContainer
+        aria-label='유저 검색 섹션. 활성화하려면 엔터를 눌러주세요'
+        tabIndex={0}
+      >
+        <label htmlFor='find-user-input'>누구에게 보내시나요 ?</label>
+        <Styled.FindUserInput id='find-user-input' type='button' onClick={openModal}>
           {currentReceiverList.length === 0 && <span>유저를 찾아보세요</span>}
 
           {currentReceiverList.length !== 0 && (
@@ -80,25 +83,21 @@ const CouponCreateForm = (props: CouponCreateFormProps) => {
       )}
 
       <SelectInput label='어떤 쿠폰인가요 ?'>
-        {couponTypeCollection.map(({ engType }) => (
-          <Styled.TypeOption
-            key={engType}
-            isSelected={engType === currentCouponType}
-            onClick={onSelectCouponType(engType)}
-          >
-            <img src={THUMBNAIL[engType]} alt='쿠폰 종류' width={50} height={50} />
+        {couponTypeCollection.map(({ engType, koreanType }) => (
+          <Styled.TypeOption key={engType} isSelected={engType === currentCouponType}>
+            <button type='button' onClick={onSelectCouponType(engType)}>
+              <img src={THUMBNAIL[engType]} alt={koreanType} width={50} height={50} />
+            </button>
           </Styled.TypeOption>
         ))}
       </SelectInput>
 
       <SelectInput.VerticalView label='당신의 마음을 선택해주세요 !'>
         {couponHashtags.map(hashtag => (
-          <Styled.FeelOption
-            key={hashtag}
-            isSelected={hashtag === currentCouponTag}
-            onClick={onSelectCouponTag(hashtag)}
-          >
-            #{hashtag}
+          <Styled.FeelOption key={hashtag} isSelected={hashtag === currentCouponTag}>
+            <button type='button' onClick={onSelectCouponTag(hashtag)}>
+              #{hashtag}
+            </button>
           </Styled.FeelOption>
         ))}
       </SelectInput.VerticalView>

--- a/frontend/src/@components/coupon/CouponCreateForm/index.tsx
+++ b/frontend/src/@components/coupon/CouponCreateForm/index.tsx
@@ -1,4 +1,4 @@
-import { ChangeEventHandler, FormEventHandler, KeyboardEvent, MouseEventHandler } from 'react';
+import { ChangeEventHandler, FormEventHandler, MouseEventHandler } from 'react';
 import { Link } from 'react-router-dom';
 
 import Button from '@/@components/@shared/Button';
@@ -60,8 +60,8 @@ const CouponCreateForm = (props: CouponCreateFormProps) => {
           {currentReceiverList.length !== 0 && (
             <Styled.SelectedUserListContainer>
               {currentReceiverList.map(receiver => (
-                <Styled.SelectedUserContainer key={receiver.id}>
-                  <span>{receiver.nickname}</span>
+                <Styled.SelectedUserContainer key={receiver.id} tabIndex={0}>
+                  {receiver.nickname}
                 </Styled.SelectedUserContainer>
               ))}
             </Styled.SelectedUserListContainer>
@@ -95,7 +95,11 @@ const CouponCreateForm = (props: CouponCreateFormProps) => {
       <SelectInput.VerticalView label='당신의 마음을 선택해주세요 !'>
         {couponHashtags.map(hashtag => (
           <Styled.FeelOption key={hashtag} isSelected={hashtag === currentCouponTag}>
-            <button type='button' onClick={onSelectCouponTag(hashtag)}>
+            <button
+              type='button'
+              onClick={onSelectCouponTag(hashtag)}
+              aria-label={`해시태그${hashtag}`}
+            >
               #{hashtag}
             </button>
           </Styled.FeelOption>

--- a/frontend/src/@components/coupon/CouponCreateForm/style.tsx
+++ b/frontend/src/@components/coupon/CouponCreateForm/style.tsx
@@ -11,10 +11,10 @@ export const FormRoot = styled.form`
   }
 `;
 
-export const FindUserContainer = styled.div`
+export const FindUserContainer = styled.section`
   position: relative;
 
-  & > div:first-of-type {
+  & > label {
     font-size: 14px;
     font-weight: 600;
 
@@ -35,7 +35,7 @@ export const AnotherCouponCreatePageLink = (theme: Theme) => css`
   cursor: pointer;
 `;
 
-export const FindUserInput = styled.div`
+export const FindUserInput = styled.button`
   width: 100%;
   min-height: 50px;
 
@@ -59,7 +59,7 @@ export const FindUserInput = styled.div`
   `}
 `;
 
-export const SelectedUserListContainer = styled.div`
+export const SelectedUserListContainer = styled.ul`
   flex: 1;
 
   display: flex;
@@ -73,7 +73,7 @@ export const SelectedUserListContainer = styled.div`
   `}
 `;
 
-export const SelectedUserContainer = styled.div`
+export const SelectedUserContainer = styled.li`
   margin-right: 10px;
 
   padding: 6px 9px;

--- a/frontend/src/@components/user/UserSearchForm/index.tsx
+++ b/frontend/src/@components/user/UserSearchForm/index.tsx
@@ -43,13 +43,11 @@ const UserSearchForm = (props: UserSearchFormProps) => {
         autoFocus={true}
       />
 
-      <Styled.SearchContainer>
-        <UserSearchResult
-          searchedUserList={searchedUserList}
-          currentReceiverList={currentReceiverList}
-          onSelectReceiver={onSelectReceiver}
-        />
-      </Styled.SearchContainer>
+      <UserSearchResult
+        searchedUserList={searchedUserList}
+        currentReceiverList={currentReceiverList}
+        onSelectReceiver={onSelectReceiver}
+      />
     </Styled.Root>
   );
 };
@@ -72,19 +70,28 @@ const UserSearchResult = (props: UserSearchResultProps) => {
   }
 
   return (
-    <>
-      {searchedUserList.map(user => (
-        <Styled.SearchedUser
-          key={user.id}
-          isSelected={currentReceiverList.some(receiver => receiver.id === user.id)}
-          onClick={onSelectReceiver(user)}
-        >
-          <Styled.ProfileImage src={user.imageUrl} width='24' alt='프사' />
-          <span>{user.nickname}&nbsp;</span>
-          <Styled.Email>({user.email})</Styled.Email>
-        </Styled.SearchedUser>
-      ))}
-    </>
+    <Styled.SearchedUserContainer>
+      {searchedUserList.map(user => {
+        const isSelected = currentReceiverList.some(receiver => receiver.id === user.id);
+
+        const ariaLabel = isSelected
+          ? '이미 선택되어 있는 유저입니다. 클릭하여 선택을 해제할 수 있습니다.'
+          : '선택되지 않은 유저입니다. 클릭하여 선택할 수 있습니다.';
+
+        return (
+          <Styled.SearchedUser
+            key={user.id}
+            isSelected={isSelected}
+            onClick={onSelectReceiver(user)}
+            aria-label={ariaLabel}
+          >
+            <Styled.ProfileImage src={user.imageUrl} width='24' alt='프사' />
+            <span>{user.nickname}&nbsp;</span>
+            <Styled.Email>({user.email})</Styled.Email>
+          </Styled.SearchedUser>
+        );
+      })}
+    </Styled.SearchedUserContainer>
   );
 };
 

--- a/frontend/src/@components/user/UserSearchForm/index.tsx
+++ b/frontend/src/@components/user/UserSearchForm/index.tsx
@@ -74,9 +74,7 @@ const UserSearchResult = (props: UserSearchResultProps) => {
       {searchedUserList.map(user => {
         const isSelected = currentReceiverList.some(receiver => receiver.id === user.id);
 
-        const ariaLabel = isSelected
-          ? '이미 선택되어 있는 유저입니다. 클릭하여 선택을 해제할 수 있습니다.'
-          : '선택되지 않은 유저입니다. 클릭하여 선택할 수 있습니다.';
+        const ariaLabel = isSelected ? `${user.nickname} 선택 해제` : `${user.nickname} 선택`;
 
         return (
           <Styled.SearchedUser

--- a/frontend/src/@components/user/UserSearchForm/index.tsx
+++ b/frontend/src/@components/user/UserSearchForm/index.tsx
@@ -8,7 +8,7 @@ import * as Styled from './style';
 
 interface UserSearchFormProps {
   currentReceiverList: UserResponse[];
-  onSelectReceiver: (user: UserResponse) => MouseEventHandler<HTMLDivElement>;
+  onSelectReceiver: (user: UserResponse) => MouseEventHandler<HTMLButtonElement>;
 }
 
 const UserSearchForm = (props: UserSearchFormProps) => {
@@ -40,6 +40,7 @@ const UserSearchForm = (props: UserSearchFormProps) => {
         label='누구에게 주고 싶나요?'
         placeholder='🔍 유저 검색'
         onChange={onChangeSearchInput}
+        autoFocus={true}
       />
 
       <Styled.SearchContainer>
@@ -56,7 +57,7 @@ const UserSearchForm = (props: UserSearchFormProps) => {
 interface UserSearchResultProps {
   searchedUserList: UserResponse[] | undefined;
   currentReceiverList: UserResponse[];
-  onSelectReceiver: (user: UserResponse) => MouseEventHandler<HTMLDivElement>;
+  onSelectReceiver: (user: UserResponse) => MouseEventHandler<HTMLButtonElement>;
 }
 
 const UserSearchResult = (props: UserSearchResultProps) => {

--- a/frontend/src/@components/user/UserSearchForm/style.tsx
+++ b/frontend/src/@components/user/UserSearchForm/style.tsx
@@ -3,6 +3,8 @@ import styled from '@emotion/styled';
 
 export const Root = styled.div`
   min-height: 250px;
+
+  padding: 8px 0;
 `;
 
 export const SelectedUserListContainer = styled.div`

--- a/frontend/src/@components/user/UserSearchForm/style.tsx
+++ b/frontend/src/@components/user/UserSearchForm/style.tsx
@@ -99,7 +99,9 @@ export const TextContainer = styled.div`
   `}
 `;
 
-export const SearchedUser = styled.div<{ isSelected: boolean }>`
+export const SearchedUser = styled.button<{ isSelected: boolean }>`
+  width: 100%;
+
   display: flex;
   align-items: center;
 

--- a/frontend/src/@components/user/UserSearchForm/style.tsx
+++ b/frontend/src/@components/user/UserSearchForm/style.tsx
@@ -58,7 +58,7 @@ export const CloseButton = styled.div`
   cursor: pointer;
 `;
 
-export const SearchContainer = styled.div`
+export const SearchedUserContainer = styled.div`
   width: 100%;
 
   height: fit-content;

--- a/frontend/src/@components/user/UserSearchModal/index.tsx
+++ b/frontend/src/@components/user/UserSearchModal/index.tsx
@@ -8,7 +8,7 @@ import UserSearchForm from '../UserSearchForm';
 
 interface UserSearchModalProps {
   currentReceiverList: UserResponse[];
-  onSelectReceiver: (user: UserResponse) => MouseEventHandler<HTMLDivElement>;
+  onSelectReceiver: (user: UserResponse) => MouseEventHandler<HTMLButtonElement>;
   closeModal: () => void;
 }
 

--- a/frontend/src/@components/user/UserSearchModal/index.tsx
+++ b/frontend/src/@components/user/UserSearchModal/index.tsx
@@ -1,10 +1,13 @@
 import { MouseEventHandler, useState } from 'react';
 
+import Icon from '@/@components/@shared/Icon';
 import Modal from '@/@components/@shared/Modal';
 import { ANIMATION_DURATION } from '@/constants/animation';
+import theme from '@/styles/theme';
 import { UserResponse } from '@/types/user/remote';
 
 import UserSearchForm from '../UserSearchForm';
+import * as Styled from './style';
 
 interface UserSearchModalProps {
   currentReceiverList: UserResponse[];
@@ -24,7 +27,15 @@ const UserSearchModal = (props: UserSearchModalProps) => {
   };
 
   return (
-    <Modal position='bottom' animation={animation} closeModal={onCloseModal}>
+    <Modal
+      position='bottom'
+      animation={animation}
+      closeModal={onCloseModal}
+      css={Styled.UserSearchModal}
+    >
+      <Styled.CloseButton type='button' onClick={onCloseModal}>
+        <Icon iconName='close' size='18' color={theme.colors.drak_grey_200} />
+      </Styled.CloseButton>
       <UserSearchForm
         currentReceiverList={currentReceiverList}
         onSelectReceiver={onSelectReceiver}

--- a/frontend/src/@components/user/UserSearchModal/style.tsx
+++ b/frontend/src/@components/user/UserSearchModal/style.tsx
@@ -1,0 +1,14 @@
+import { css, Theme } from '@emotion/react';
+import styled from '@emotion/styled';
+
+export const UserSearchModal = (theme: Theme) => css`
+  position: relative;
+`;
+
+export const CloseButton = styled.button`
+  position: absolute;
+  top: 5px;
+  right: 5px;
+
+  border-radius: 20px;
+`;

--- a/frontend/src/@components/user/UserSearchModal/style.tsx
+++ b/frontend/src/@components/user/UserSearchModal/style.tsx
@@ -7,8 +7,8 @@ export const UserSearchModal = (theme: Theme) => css`
 
 export const CloseButton = styled.button`
   position: absolute;
-  top: 5px;
-  right: 5px;
+  top: 10px;
+  right: 10px;
 
   border-radius: 20px;
 `;


### PR DESCRIPTION
## 작업 내용

- 키보드만으로 쿠폰 생성을 가능하게 한다.

  - [x] 기존의 focus가 불가능하던 섹션에 대해 `tabIndex=0`를 부여
  - [x] `tabIndex=0`을 부여하여 `focusable`하도록 구현
  - [x] `selectInput`의 `option`을 버튼으로 구성하여 탭 키로 전환, 엔터키로 선택이 가능하도록 구현
  - [x] `FindUserInput` 역시 클릭하면 모달을 띄운다라는 역할에 맞게 `button` 태그로 구성한다.
  - [x] `Modal`은 `role="dialog"`이다.
  - [x] `UserSearchModal` 내부의 옵션들을 버튼 태그로 만들어 탭 키로 전환, 엔터 키로 선택 가능 하도록 구현
  - [x] `UserSearchModal` 내부의 옵션들은 선택 된 것인지 아닌지에 대한 피드백을 사용자에게 전달한다.
  - [x] `Modal`의 종료 버튼이 있어야한다.


## 공유사항

해당 작업 내용에 관한 부연 설명 및 및 향후 작업해야 할 내용 등에 대한 설명

Resolves #487
