### PR TITLE
feat: 쿠폰 리스트 페이지, 메인 페이지, 토스트의 웹 접근성 고려

### DIFF
--- a/frontend/src/@components/@shared/Header/index.tsx
+++ b/frontend/src/@components/@shared/Header/index.tsx
@@ -49,24 +49,21 @@ const Header = (props: HeaderProps) => {
       </Styled.Logo>
       <Styled.Title>{!isMainPage && title}</Styled.Title>
       <Styled.Profile>
-        <Position
-          css={css`
-            display: flex;
-            align-items: center;
-          `}
-        >
-          {me && (
-            <Link to={PATH.USER_HISTORY}>
-              <Icon iconName='notification' size='26' color={'transparent'} />
-            </Link>
-          )}
-
-          {me && me?.unReadCount !== 0 && (
-            <Position position='absolute' top='0' right='0'>
-              <Styled.Bell />
-            </Position>
-          )}
-        </Position>
+        {me && (
+          <Link
+            to={PATH.USER_HISTORY}
+            css={css`
+              position: relative;
+            `}
+          >
+            <Icon iconName='notification' size='26' color={'transparent'} />
+            {me?.unReadCount !== 0 && (
+              <Position position='absolute' top='0' right='0'>
+                <Styled.Bell />
+              </Position>
+            )}
+          </Link>
+        )}
         <Link
           to={PATH.PROFILE}
           css={css`

--- a/frontend/src/@components/@shared/ListFilter/index.tsx
+++ b/frontend/src/@components/@shared/ListFilter/index.tsx
@@ -14,13 +14,14 @@ const ListFilter = <T extends string>(props: ListFilterProps<T>) => {
   return (
     <Styled.Root>
       {options.map(option => (
-        <Styled.FilterButton
-          key={option}
-          isFocus={status === option}
-          onClick={() => onClickFilterButton(option)}
-        >
-          {option}
-        </Styled.FilterButton>
+        <Styled.FilterList key={option}>
+          <Styled.FilterButton
+            isFocus={status === option}
+            onClick={() => onClickFilterButton(option)}
+          >
+            {option}
+          </Styled.FilterButton>
+        </Styled.FilterList>
       ))}
     </Styled.Root>
   );

--- a/frontend/src/@components/@shared/ListFilter/style.tsx
+++ b/frontend/src/@components/@shared/ListFilter/style.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 
-export const Root = styled.div`
+export const Root = styled.ul`
   display: flex;
   justify-content: center;
   flex-wrap: no-wrap;
@@ -11,14 +11,16 @@ export const Root = styled.div`
   gap: 10px;
 `;
 
-export const FilterButton = styled.button<{ isFocus?: boolean; horizontalScroll?: boolean }>`
+export const FilterList = styled.li`
   max-width: 120px;
-
   aspect-ratio: 1/1;
-
-  padding: 5px;
-
   flex: 1;
+`;
+
+export const FilterButton = styled.button<{ isFocus?: boolean; horizontalScroll?: boolean }>`
+  width: 100%;
+  height: 100%;
+  padding: 5px;
 
   border-radius: 20px;
 

--- a/frontend/src/@components/@shared/SelectInput/style.tsx
+++ b/frontend/src/@components/@shared/SelectInput/style.tsx
@@ -19,10 +19,7 @@ export const SelectContainer = styled.ul`
 
   display: flex;
   align-items: center;
-
-  & > li + li {
-    margin-left: 10px;
-  }
+  gap: 10px;
 
   & > li {
     cursor: pointer;

--- a/frontend/src/@components/@shared/ToastProvider/index.tsx
+++ b/frontend/src/@components/@shared/ToastProvider/index.tsx
@@ -91,7 +91,7 @@ const ToastProvider = (props: React.PropsWithChildren) => {
       {ReactDOM.createPortal(
         <>
           {isShow === true && (
-            <Styled.ShowUpRoot>
+            <Styled.ShowUpRoot role='status' aria-live='polite'>
               <ToastMessage message={message} isError={isError} onClickToast={onClickToast} />
             </Styled.ShowUpRoot>
           )}

--- a/frontend/src/@components/coupon/CouponCreateForm/index.tsx
+++ b/frontend/src/@components/coupon/CouponCreateForm/index.tsx
@@ -83,11 +83,13 @@ const CouponCreateForm = (props: CouponCreateFormProps) => {
       )}
 
       <SelectInput label='어떤 쿠폰인가요 ?'>
-        {couponTypeCollection.map(({ engType, koreanType }) => (
-          <Styled.TypeOption key={engType} isSelected={engType === currentCouponType}>
-            <button type='button' onClick={onSelectCouponType(engType)}>
-              <img src={THUMBNAIL[engType]} alt={koreanType} width={50} height={50} />
-            </button>
+        {couponTypeCollection.map(({ engType }) => (
+          <Styled.TypeOption
+            key={engType}
+            isSelected={engType === currentCouponType}
+            onClick={onSelectCouponType(engType)}
+          >
+            <img src={THUMBNAIL[engType].src} alt={THUMBNAIL[engType].alt} width={50} height={50} />
           </Styled.TypeOption>
         ))}
       </SelectInput>

--- a/frontend/src/@components/coupon/CouponCreateForm/index.tsx
+++ b/frontend/src/@components/coupon/CouponCreateForm/index.tsx
@@ -84,12 +84,15 @@ const CouponCreateForm = (props: CouponCreateFormProps) => {
 
       <SelectInput label='어떤 쿠폰인가요 ?'>
         {couponTypeCollection.map(({ engType }) => (
-          <Styled.TypeOption
-            key={engType}
-            isSelected={engType === currentCouponType}
-            onClick={onSelectCouponType(engType)}
-          >
-            <img src={THUMBNAIL[engType].src} alt={THUMBNAIL[engType].alt} width={50} height={50} />
+          <Styled.TypeOption key={engType} isSelected={engType === currentCouponType}>
+            <button type='button' onClick={onSelectCouponType(engType)}>
+              <img
+                src={THUMBNAIL[engType].src}
+                alt={THUMBNAIL[engType].alt}
+                width={50}
+                height={50}
+              />
+            </button>
           </Styled.TypeOption>
         ))}
       </SelectInput>

--- a/frontend/src/@components/coupon/CouponItem/big.style.tsx
+++ b/frontend/src/@components/coupon/CouponItem/big.style.tsx
@@ -41,6 +41,7 @@ export const Message = styled.p`
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  text-align: left;
 `;
 
 export const MeetingDate = styled.span<{ couponStatus: COUPON_STATUS }>`

--- a/frontend/src/@components/coupon/CouponItem/big.style.tsx
+++ b/frontend/src/@components/coupon/CouponItem/big.style.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 
 import { COUPON_STATUS } from '@/types/coupon/client';
 
-export const Root = styled.div<{ hasCursor?: boolean }>`
+export const Root = styled.div`
   width: 100%;
 
   max-width: 340px;
@@ -23,12 +23,6 @@ export const Root = styled.div<{ hasCursor?: boolean }>`
   ${({ theme }) => css`
     background-color: ${theme.colors.white_100};
   `}
-
-  ${({ hasCursor = true }) =>
-    hasCursor &&
-    css`
-      cursor: pointer;
-    `}
 `;
 
 export const Top = styled.div`

--- a/frontend/src/@components/coupon/CouponItem/big.tsx
+++ b/frontend/src/@components/coupon/CouponItem/big.tsx
@@ -28,7 +28,7 @@ const BigCouponItem = (props: BigCouponItemProps) => {
         <CouponStatus status={couponStatus} meetingDate={meetingDate} isSent={isSent} />
 
         <Styled.ImageInner>
-          <img src={thumbnail} alt='쿠폰' width={44} height={44} />
+          <img src={thumbnail.src} alt={thumbnail.alt} width={44} height={44} />
         </Styled.ImageInner>
       </Styled.CouponPropertyContainer>
       <Styled.TextContainer>

--- a/frontend/src/@components/coupon/CouponItem/big.tsx
+++ b/frontend/src/@components/coupon/CouponItem/big.tsx
@@ -22,8 +22,10 @@ const BigCouponItem = (props: BigCouponItemProps) => {
 
   const { isSent, member } = useCouponPartner(coupon);
 
+  const rootElementType = onClick && 'button';
+
   return (
-    <Styled.Root as={onClick && 'button'} className={className} onClick={onClick}>
+    <Styled.Root as={rootElementType} className={className} onClick={onClick}>
       <Styled.CouponPropertyContainer>
         <CouponStatus status={couponStatus} meetingDate={meetingDate} isSent={isSent} />
 

--- a/frontend/src/@components/coupon/CouponItem/big.tsx
+++ b/frontend/src/@components/coupon/CouponItem/big.tsx
@@ -23,7 +23,12 @@ const BigCouponItem = (props: BigCouponItemProps) => {
   const { isSent, member } = useCouponPartner(coupon);
 
   return (
-    <Styled.Root className={className} hasCursor={!!onClick} onClick={onClick}>
+    <Styled.Root
+      as={onClick && 'button'}
+      className={className}
+      hasCursor={!!onClick}
+      onClick={onClick}
+    >
       <Styled.CouponPropertyContainer>
         <CouponStatus status={couponStatus} meetingDate={meetingDate} isSent={isSent} />
 

--- a/frontend/src/@components/coupon/CouponItem/big.tsx
+++ b/frontend/src/@components/coupon/CouponItem/big.tsx
@@ -22,10 +22,10 @@ const BigCouponItem = (props: BigCouponItemProps) => {
 
   const { isSent, member } = useCouponPartner(coupon);
 
-  const rootElementType = onClick && 'button';
+  const rootElementTag = onClick && 'button';
 
   return (
-    <Styled.Root as={rootElementType} className={className} onClick={onClick}>
+    <Styled.Root as={rootElementTag} className={className} onClick={onClick}>
       <Styled.CouponPropertyContainer>
         <CouponStatus status={couponStatus} meetingDate={meetingDate} isSent={isSent} />
 

--- a/frontend/src/@components/coupon/CouponItem/big.tsx
+++ b/frontend/src/@components/coupon/CouponItem/big.tsx
@@ -38,7 +38,7 @@ const BigCouponItem = (props: BigCouponItemProps) => {
           </Styled.Member>
         </Styled.Top>
         <Styled.Message>{couponMessage}</Styled.Message>
-        <Styled.Hashtag>#{couponTag}</Styled.Hashtag>
+        <Styled.Hashtag aria-label={`hashtag ${couponTag}`}>#{couponTag}</Styled.Hashtag>
       </Styled.TextContainer>
     </Styled.Root>
   );

--- a/frontend/src/@components/coupon/CouponItem/big.tsx
+++ b/frontend/src/@components/coupon/CouponItem/big.tsx
@@ -23,12 +23,7 @@ const BigCouponItem = (props: BigCouponItemProps) => {
   const { isSent, member } = useCouponPartner(coupon);
 
   return (
-    <Styled.Root
-      as={onClick && 'button'}
-      className={className}
-      hasCursor={!!onClick}
-      onClick={onClick}
-    >
+    <Styled.Root as={onClick && 'button'} className={className} onClick={onClick}>
       <Styled.CouponPropertyContainer>
         <CouponStatus status={couponStatus} meetingDate={meetingDate} isSent={isSent} />
 

--- a/frontend/src/@components/coupon/CouponItem/small.style.tsx
+++ b/frontend/src/@components/coupon/CouponItem/small.style.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 
-export const Root = styled.button<{ hasCursor?: boolean }>`
+export const Root = styled.div`
   width: 140px;
   height: 132px;
 
@@ -16,12 +16,6 @@ export const Root = styled.button<{ hasCursor?: boolean }>`
   padding: 12px;
 
   gap: 10px;
-
-  ${({ hasCursor = true }) =>
-    hasCursor &&
-    css`
-      cursor: pointer;
-    `}
 `;
 
 export const TextContainer = styled.div`

--- a/frontend/src/@components/coupon/CouponItem/small.style.tsx
+++ b/frontend/src/@components/coupon/CouponItem/small.style.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 
-export const Root = styled.div<{ hasCursor?: boolean }>`
+export const Root = styled.button<{ hasCursor?: boolean }>`
   width: 140px;
   height: 132px;
 

--- a/frontend/src/@components/coupon/CouponItem/small.tsx
+++ b/frontend/src/@components/coupon/CouponItem/small.tsx
@@ -26,7 +26,7 @@ const SmallCouponItem = (props: SmallCouponItemProps) => {
     <Styled.Root hasCursor={!!onClick} onClick={onClick}>
       <CouponStatus status={couponStatus} meetingDate={meetingDate} isSent={isSent} />
 
-      <img src={thumbnail} alt='쿠폰' width={50} height={50} />
+      <img src={thumbnail.src} alt={thumbnail.alt} width={50} height={50} />
 
       <Styled.TextContainer>
         <Styled.Preposition>{isSent ? 'To.' : 'From.'} </Styled.Preposition>

--- a/frontend/src/@components/coupon/CouponItem/small.tsx
+++ b/frontend/src/@components/coupon/CouponItem/small.tsx
@@ -22,10 +22,10 @@ const SmallCouponItem = (props: SmallCouponItemProps) => {
 
   const { isSent, member } = useCouponPartner(coupon);
 
-  const rootElementType = onClick && 'button';
+  const rootElementTag = onClick && 'button';
 
   return (
-    <Styled.Root as={rootElementType} onClick={onClick}>
+    <Styled.Root as={rootElementTag} onClick={onClick}>
       <CouponStatus status={couponStatus} meetingDate={meetingDate} isSent={isSent} />
 
       <img src={thumbnail.src} alt={thumbnail.alt} width={50} height={50} />

--- a/frontend/src/@components/coupon/CouponItem/small.tsx
+++ b/frontend/src/@components/coupon/CouponItem/small.tsx
@@ -9,7 +9,7 @@ import * as Styled from './small.style';
 
 export interface SmallCouponItemProps extends Coupon {
   className?: string;
-  onClick?: MouseEventHandler<HTMLDivElement>;
+  onClick?: MouseEventHandler<HTMLButtonElement>;
 }
 
 const SmallCouponItem = (props: SmallCouponItemProps) => {
@@ -23,7 +23,7 @@ const SmallCouponItem = (props: SmallCouponItemProps) => {
   const { isSent, member } = useCouponPartner(coupon);
 
   return (
-    <Styled.Root hasCursor={!!onClick} onClick={onClick}>
+    <Styled.Root as={onClick ? undefined : 'div'} hasCursor={!!onClick} onClick={onClick}>
       <CouponStatus status={couponStatus} meetingDate={meetingDate} isSent={isSent} />
 
       <img src={thumbnail.src} alt={thumbnail.alt} width={50} height={50} />

--- a/frontend/src/@components/coupon/CouponItem/small.tsx
+++ b/frontend/src/@components/coupon/CouponItem/small.tsx
@@ -22,8 +22,10 @@ const SmallCouponItem = (props: SmallCouponItemProps) => {
 
   const { isSent, member } = useCouponPartner(coupon);
 
+  const rootElementType = onClick && 'button';
+
   return (
-    <Styled.Root as={onClick && 'button'} onClick={onClick}>
+    <Styled.Root as={rootElementType} onClick={onClick}>
       <CouponStatus status={couponStatus} meetingDate={meetingDate} isSent={isSent} />
 
       <img src={thumbnail.src} alt={thumbnail.alt} width={50} height={50} />

--- a/frontend/src/@components/coupon/CouponItem/small.tsx
+++ b/frontend/src/@components/coupon/CouponItem/small.tsx
@@ -9,7 +9,7 @@ import * as Styled from './small.style';
 
 export interface SmallCouponItemProps extends Coupon {
   className?: string;
-  onClick?: MouseEventHandler<HTMLButtonElement>;
+  onClick?: MouseEventHandler<HTMLDivElement>;
 }
 
 const SmallCouponItem = (props: SmallCouponItemProps) => {
@@ -23,7 +23,7 @@ const SmallCouponItem = (props: SmallCouponItemProps) => {
   const { isSent, member } = useCouponPartner(coupon);
 
   return (
-    <Styled.Root as={onClick ? undefined : 'div'} hasCursor={!!onClick} onClick={onClick}>
+    <Styled.Root as={onClick && 'button'} onClick={onClick}>
       <CouponStatus status={couponStatus} meetingDate={meetingDate} isSent={isSent} />
 
       <img src={thumbnail.src} alt={thumbnail.alt} width={50} height={50} />

--- a/frontend/src/@components/coupon/CouponList/vertical.style.tsx
+++ b/frontend/src/@components/coupon/CouponList/vertical.style.tsx
@@ -6,9 +6,7 @@ export const Root = styled.div`
   flex-direction: column;
   align-items: center;
 
-  & > * + * {
-    margin-top: 20px;
-  }
+  gap: 20px;
 `;
 
 export const TextContainer = styled.div<{ fontSize?: string }>`

--- a/frontend/src/@components/coupon/CouponList/vertical.style.tsx
+++ b/frontend/src/@components/coupon/CouponList/vertical.style.tsx
@@ -6,7 +6,7 @@ export const Root = styled.div`
   flex-direction: column;
   align-items: center;
 
-  & > div + div {
+  & > * + * {
     margin-top: 20px;
   }
 `;

--- a/frontend/src/@components/reservation/ReservationItem/index.tsx
+++ b/frontend/src/@components/reservation/ReservationItem/index.tsx
@@ -19,21 +19,19 @@ const ReservationItem = (props: ReservationItemProps) => {
   const { member } = useCouponPartner(reservatedCoupon);
 
   return (
-    <Position>
-      <Styled.Root>
-        <Styled.Bar />
-        <Styled.ImageContainer>
-          <img src={member.imageUrl} alt='프로필' width={40} height={40} />
-        </Styled.ImageContainer>
-        <Styled.TextContainer>{member.nickname}님과의 약속</Styled.TextContainer>
+    <Styled.Root>
+      <Styled.Bar />
+      <Styled.ImageContainer>
+        <img src={member.imageUrl} alt='프로필' width={40} height={40} />
+      </Styled.ImageContainer>
+      <Styled.TextContainer>{`${member.nickname}님과의 약속`}</Styled.TextContainer>
 
-        <Position position='absolute' right='10px'>
-          <Link to={DYNAMIC_PATH.COUPON_DETAIL(id)} css={Styled.LinkButton}>
-            쿠폰보기
-          </Link>
-        </Position>
-      </Styled.Root>
-    </Position>
+      <Position position='absolute' right='10px'>
+        <Link to={DYNAMIC_PATH.COUPON_DETAIL(id)} css={Styled.LinkButton}>
+          쿠폰보기
+        </Link>
+      </Position>
+    </Styled.Root>
   );
 };
 

--- a/frontend/src/@components/reservation/ReservationItem/style.tsx
+++ b/frontend/src/@components/reservation/ReservationItem/style.tsx
@@ -2,9 +2,10 @@ import type { Theme } from '@emotion/react';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 
-export const Root = styled.div`
-  display: flex;
+export const Root = styled.li`
+  position: relative;
 
+  display: flex;
   align-items: center;
   gap: 10px;
 

--- a/frontend/src/@components/reservation/ReservationList/style.tsx
+++ b/frontend/src/@components/reservation/ReservationList/style.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 
-export const Root = styled.div`
+export const Root = styled.ul`
   display: flex;
   flex-direction: column;
 

--- a/frontend/src/@components/reservation/ReservationSection/index.tsx
+++ b/frontend/src/@components/reservation/ReservationSection/index.tsx
@@ -19,8 +19,8 @@ const ReservationSection = (props: ReservationSectionProps) => {
     return (
       <Styled.NoneContentsContainer>
         <Icon iconName='hand' hasCursor={false} size='36' color={theme.colors.primary_400} />
-        <p>아직 예정된 약속이 없어요!</p>
-        <p>약속을 기다리는 사람에게 신청해볼까요 ?</p>
+        <Styled.NonContentsText1>아직 예정된 약속이 없어요!</Styled.NonContentsText1>
+        <Styled.NonContentsText2>약속을 기다리는 사람에게 신청해볼까요 ?</Styled.NonContentsText2>
       </Styled.NoneContentsContainer>
     );
   }

--- a/frontend/src/@components/reservation/ReservationSection/index.tsx
+++ b/frontend/src/@components/reservation/ReservationSection/index.tsx
@@ -19,8 +19,8 @@ const ReservationSection = (props: ReservationSectionProps) => {
     return (
       <Styled.NoneContentsContainer>
         <Icon iconName='hand' hasCursor={false} size='36' color={theme.colors.primary_400} />
-        <h3>아직 예정된 약속이 없어요!</h3>
-        <h4>약속을 기다리는 사람에게 신청해볼까요 ?</h4>
+        <p>아직 예정된 약속이 없어요!</p>
+        <p>약속을 기다리는 사람에게 신청해볼까요 ?</p>
       </Styled.NoneContentsContainer>
     );
   }
@@ -37,9 +37,7 @@ const ReservationSection = (props: ReservationSectionProps) => {
         return (
           <Styled.DateContainer key={meetingDate}>
             <Styled.DateTitle>
-              <div>
-                {dateText}({day})
-              </div>
+              <div>{`${dateText}(${day})`}</div>
               <div>{dDay > 0 ? `D-${dDay}` : 'D-Day'}</div>
             </Styled.DateTitle>
             <ReservationList reservatedCouponList={reservatedCouponList} />

--- a/frontend/src/@components/reservation/ReservationSection/style.tsx
+++ b/frontend/src/@components/reservation/ReservationSection/style.tsx
@@ -21,11 +21,7 @@ export const NoneContentsContainer = styled.div`
 
   gap: 10px;
 
-  & > h2 {
-    font-size: 50px;
-  }
-
-  & > h3 {
+  & > p:nth-of-type(1) {
     font-size: 18px;
 
     ${({ theme }) => css`
@@ -33,7 +29,7 @@ export const NoneContentsContainer = styled.div`
     `}
   }
 
-  & > h4 {
+  & > p:nth-of-type(2) {
     font-size: 14px;
 
     ${({ theme }) => css`

--- a/frontend/src/@components/reservation/ReservationSection/style.tsx
+++ b/frontend/src/@components/reservation/ReservationSection/style.tsx
@@ -20,22 +20,22 @@ export const NoneContentsContainer = styled.div`
   align-items: center;
 
   gap: 10px;
+`;
 
-  & > p:nth-of-type(1) {
-    font-size: 18px;
+export const NonContentsText1 = styled.p`
+  font-size: 18px;
 
-    ${({ theme }) => css`
-      color: ${theme.colors.dark_grey_200};
-    `}
-  }
+  ${({ theme }) => css`
+    color: ${theme.colors.dark_grey_200};
+  `}
+`;
 
-  & > p:nth-of-type(2) {
-    font-size: 14px;
+export const NonContentsText2 = styled.p`
+  font-size: 14px;
 
-    ${({ theme }) => css`
-      color: ${theme.colors.grey_100};
-    `}
-  }
+  ${({ theme }) => css`
+    color: ${theme.colors.grey_100};
+  `}
 `;
 
 export const DateContainer = styled.li`

--- a/frontend/src/@components/reservation/ReservationSection/style.tsx
+++ b/frontend/src/@components/reservation/ReservationSection/style.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 
-export const Root = styled.div`
+export const Root = styled.ul`
   display: flex;
 
   overflow-x: scroll;
@@ -42,7 +42,7 @@ export const NoneContentsContainer = styled.div`
   }
 `;
 
-export const DateContainer = styled.div`
+export const DateContainer = styled.li`
   width: 350px;
   height: 320px;
 

--- a/frontend/src/@components/unregistered-coupon/UnregisteredCouponCreateForm/index.tsx
+++ b/frontend/src/@components/unregistered-coupon/UnregisteredCouponCreateForm/index.tsx
@@ -64,7 +64,7 @@ const UnregisteredCouponCreateForm = (props: UnregisteredCouponCreateFormProps) 
             isSelected={engType === currentCouponType}
             onClick={onSelectCouponType(engType)}
           >
-            <img src={THUMBNAIL[engType]} alt='쿠폰 종류' width={50} height={50} />
+            <img src={THUMBNAIL[engType].src} alt={THUMBNAIL[engType].alt} width={50} height={50} />
           </Styled.TypeOption>
         ))}
       </SelectInput>

--- a/frontend/src/@components/unregistered-coupon/UnregisteredCouponItem/index.tsx
+++ b/frontend/src/@components/unregistered-coupon/UnregisteredCouponItem/index.tsx
@@ -42,7 +42,7 @@ const UnregisteredCouponItem = (props: UnregisteredCouponItemProps) => {
         <Styled.CouponPropertyContainer>
           <UnregisteredCouponStatus status={unregisteredCouponStatus} />
           <Styled.ImageInner>
-            <img src={thumbnail} alt='쿠폰' width={44} height={44} />
+            <img src={thumbnail.src} alt={thumbnail.alt} width={44} height={44} />
           </Styled.ImageInner>
         </Styled.CouponPropertyContainer>
         <Styled.TextContainer>

--- a/frontend/src/@pages/coupon-list/index.tsx
+++ b/frontend/src/@pages/coupon-list/index.tsx
@@ -104,7 +104,7 @@ export const Styled = {
     border-radius: 4px;
     padding: 20px 0;
   `,
-  ListFilterContainer: styled.div`
+  ListFilterContainer: styled.nav`
     padding: 0 20px;
   `,
   Container: styled.div`
@@ -124,7 +124,7 @@ export const Styled = {
       bottom: 16px;
     }
   `,
-  VerticalListContainer: styled.div`
+  VerticalListContainer: styled.section`
     padding: 20px 10px;
   `,
   HorizonListContainer: styled.div`

--- a/frontend/src/@pages/main/index.tsx
+++ b/frontend/src/@pages/main/index.tsx
@@ -55,11 +55,11 @@ const MainPage = () => {
     <PageTemplate.ExtendedStyleHeader title='꼭꼭'>
       <Styled.Root>
         <Styled.CreateCouponContainer>
-          <div>
+          <h3>
             <Styled.ExtraBold>꼭꼭</Styled.ExtraBold>으로
             <br />
             당신의 마음을 전달해보세요!
-          </div>
+          </h3>
 
           <Styled.AdditionalExplanation>
             시간을 보내고 싶어하는 사람들이 있을지 모릅니다.
@@ -91,7 +91,7 @@ const MainPage = () => {
 
         <Styled.FullListContainer>
           <Styled.FullListTitle>
-            <span>예정된 약속</span>
+            <h3>예정된 약속</h3>
           </Styled.FullListTitle>
 
           <CustomSuspense
@@ -103,9 +103,9 @@ const MainPage = () => {
         </Styled.FullListContainer>
 
         <Styled.ListContainer>
-          <div>
+          <section>
             <Styled.ListTitle>
-              <span>받은 쿠폰</span>
+              <h2>받은 쿠폰</h2>
               <Link
                 to={PATH.RECEIVED_COUPON_LIST}
                 css={Styled.ExtendedLink}
@@ -126,11 +126,11 @@ const MainPage = () => {
                 onClickCouponItem={onClickCouponItem}
               />
             </CustomSuspense>
-          </div>
+          </section>
 
-          <div>
+          <section>
             <Styled.ListTitle>
-              <span>보낸 쿠폰</span>
+              <h2>보낸 쿠폰</h2>
               <Link
                 to={PATH.SENT_COUPON_LIST}
                 css={Styled.ExtendedLink}
@@ -151,11 +151,11 @@ const MainPage = () => {
                 onClickCouponItem={onClickCouponItem}
               />
             </CustomSuspense>
-          </div>
+          </section>
 
           <Styled.UnRegisteredCouponSection>
             <Styled.ListTitle>
-              <span>미등록 쿠폰</span>
+              <h2>미등록 쿠폰</h2>
             </Styled.ListTitle>
             <Styled.UnRegisteredCouponSectionInner>
               <Link to={PATH.UNREGISTERED_COUPON_LIST}>

--- a/frontend/src/@pages/main/style.tsx
+++ b/frontend/src/@pages/main/style.tsx
@@ -7,7 +7,7 @@ export const Root = styled.div`
   border-radius: 4px;
 `;
 
-export const CreateCouponContainer = styled.div`
+export const CreateCouponContainer = styled.section`
   display: flex;
 
   flex-direction: column;
@@ -28,14 +28,14 @@ export const ExtraBold = styled.span`
   font-weight: 700;
 `;
 
-export const AdditionalExplanation = styled.div`
+export const AdditionalExplanation = styled.p`
   font-size: 12px;
   color: ${({ theme }) => theme.colors.primary_400};
 
   margin-top: 10px;
 `;
 
-export const FullListContainer = styled.div`
+export const FullListContainer = styled.section`
   padding: 32px 16px 16px 16px;
 
   display: flex;
@@ -64,7 +64,7 @@ export const ListTitle = styled.div`
   display: flex;
   justify-content: space-between;
 
-  & > span {
+  & > h2 {
     font-weight: 600;
   }
 `;

--- a/frontend/src/@pages/main/style.tsx
+++ b/frontend/src/@pages/main/style.tsx
@@ -24,8 +24,9 @@ export const CreateCouponContainer = styled.section`
   border-radius: 0 0 50px 50px;
 `;
 
-export const ExtraBold = styled.span`
+export const ExtraBold = styled.h1`
   font-weight: 700;
+  display: inline-block;
 `;
 
 export const AdditionalExplanation = styled.p`
@@ -47,7 +48,7 @@ export const FullListTitle = styled.div`
   display: flex;
   justify-content: space-between;
 
-  & > span {
+  & > h3 {
     font-weight: 600;
   }
 `;

--- a/frontend/src/styles/globalStyle.ts
+++ b/frontend/src/styles/globalStyle.ts
@@ -28,6 +28,10 @@ const globalStyle = css`
     list-style: none;
   }
 
+  li {
+    list-style: none;
+  }
+
   button {
     cursor: pointer;
     border: 0;

--- a/frontend/src/types/coupon/client.ts
+++ b/frontend/src/types/coupon/client.ts
@@ -27,10 +27,10 @@ export const couponHashtags = [
   '잘했어요!',
 ] as const;
 
-export const THUMBNAIL: { [x: string]: string } = {
-  COFFEE: coffeeImage,
-  DRINK: beerImage,
-  MEAL: mealImage,
+export const THUMBNAIL = {
+  COFFEE: { src: coffeeImage, alt: '커피 쿠폰' },
+  DRINK: { src: beerImage, alt: '술 쿠폰' },
+  MEAL: { src: mealImage, alt: '식사 쿠폰' },
 } as const;
 
 export type COUPON_ENG_TYPE = typeof couponTypeCollection[number]['engType'];


### PR DESCRIPTION
## 작업 내용

- main page의 시맨틱 tag를 준수했습니다. 
- coupon list page의 시맨틱 태그를 준수했습니다.
- THUMBNAIL에 alt를 추가했습니다.
- Toast를 screen reader가 읽을 수 있도록 설정했습니다.

## 공유사항

- Big, Small CouponItem에 @emotion의 as를 통해 동적으로 tag를 할당했습니다.

Resolves #489 
