### PR TITLE
fix: 구글로만 회원가입한 유저 나의 정보 조회 NPE 발생

### DIFF
--- a/backend/src/main/java/com/woowacourse/kkogkkog/member/application/MemberService.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/member/application/MemberService.java
@@ -103,7 +103,7 @@ public class MemberService {
         Long unreadHistoryCount = memberHistoryRepository
             .countByHostMemberAndIsReadFalse(findMember);
 
-        if (findMember.getWorkspace() == null) {
+        if (findMember.getUserId() == null) {
             return MyProfileResponse.withNoWorkspace(findMember, unreadHistoryCount);
         }
         return MyProfileResponse.of(findMember, unreadHistoryCount);


### PR DESCRIPTION
## 작업 내용
프록시 객체 null 확인 코드에서 문제 발생 추정

- member의 userId를 비교하게 수정

- 이슈
Resolves #493
