### PR TITLE
fix: 통합 알림봇에서 email이 null로 오는 경우 NPE 발생하는 문제 해결

### DIFF
--- a/backend/src/main/java/com/woowacourse/kkogkkog/infrastructure/domain/WoowacourseUserRepositoryImpl.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/infrastructure/domain/WoowacourseUserRepositoryImpl.java
@@ -23,8 +23,11 @@ public class WoowacourseUserRepositoryImpl implements WoowacourseUserRepository 
         Map<String, String> responseMap = new ConcurrentHashMap<>();
         WoowacourseUsersResponse response = woowacoursePushAlarmClient.requestUsers();
         for (WoowacourseUserResponse member : response.getMembers()) {
-            String email = member.getProfile().getEmail();
             String userId = member.getId();
+            String email = member.getProfile().getEmail();
+            if (email == null) {
+                continue;
+            }
             responseMap.put(email, userId);
         }
         cache = responseMap;


### PR DESCRIPTION
## 작업 내용

통합 알림봇에서 userId만 있고 email이 null인 경우 NPE가 터지는 문제 해결했습니다.

## 공유사항

코드가 지저분합니다..ㅠㅠ

Resolves #없음
