### PR TITLE
feat: 사이트 내에 뒤로가기 버튼은 필요하지 않다.

### DIFF
--- a/frontend/src/@components/@shared/Header/index.tsx
+++ b/frontend/src/@components/@shared/Header/index.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { Link, useLocation, useNavigate } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 
 import Icon from '@/@components/@shared/Icon';
 import Position from '@/@components/@shared/Position';
@@ -18,34 +18,16 @@ interface HeaderProps {
 const Header = (props: HeaderProps) => {
   const { title = '', className } = props;
 
-  const navigate = useNavigate();
-
   const isMainPage = useLocation().pathname === PATH.MAIN;
 
   const { me } = useFetchMe();
 
-  const onClickGoBack = () => {
-    navigate(-1);
-  };
-
   return (
     <Styled.Root className={className}>
       <Styled.Logo>
-        {isMainPage ? (
-          <Link to={PATH.LANDING}>
-            <img src={logoImage} alt='로고' width={36} height={36} />
-          </Link>
-        ) : (
-          <Icon
-            iconName='arrow'
-            size='30'
-            color={theme.colors.primary_400}
-            onClick={onClickGoBack}
-            css={css`
-              padding: 5px;
-            `}
-          />
-        )}
+        <Link to={PATH.MAIN}>
+          <img src={logoImage} alt='로고' width={36} height={36} />
+        </Link>
       </Styled.Logo>
       <Styled.Title>{!isMainPage && title}</Styled.Title>
       <Styled.Profile>


### PR DESCRIPTION
## 작업 내용

모바일 브라우저, 데스크탑 브라우저는 모두 뒤로가기 기능을 제공합니다. 우리 서비스에서 또 제공할 필요는 없다고 생각합니다. 따라서 탈출 루트를 `Main`으로 변경합니다.

- 헤더의 뒤로가기 버튼, 로직을 제거하고 홈 버튼을 추가한다.


## 공유사항

해당 작업 내용에 관한 부연 설명 및 및 향후 작업해야 할 내용 등에 대한 설명

Resolves #466
