### PR TITLE
feat: 미등록 쿠폰 삭제 기능 추가 (Endpoint 수정 사항 반영)

### DIFF
--- a/frontend/src/@hooks/@queries/unregistered-coupon.ts
+++ b/frontend/src/@hooks/@queries/unregistered-coupon.ts
@@ -2,6 +2,7 @@ import { useQueryClient } from 'react-query';
 
 import {
   createUnregisteredCoupon,
+  deleteUnregisteredCoupon,
   getUnregisteredCouponById,
   getUnregisteredCouponListByStatus,
   registerUnregisteredCoupon,
@@ -94,6 +95,24 @@ export const useRegisterUnregisteredCouponMutation = () => {
   return useMutation(registerUnregisteredCoupon, {
     onSuccess() {
       queryClient.invalidateQueries([QUERY_KEY.unregisteredCoupon]);
+    },
+    onMutate() {
+      showLoading();
+    },
+    onSettled() {
+      hideLoading();
+    },
+  });
+};
+
+export const useDeleteUnregisteredCouponMutation = () => {
+  const queryClient = useQueryClient();
+  const { showLoading, hideLoading } = useLoading();
+
+  return useMutation(deleteUnregisteredCoupon, {
+    onSuccess() {
+      queryClient.invalidateQueries([QUERY_KEY.unregisteredCouponListByStatus, QUERY_KEY.ISSUED]);
+      queryClient.removeQueries([QUERY_KEY.unregisteredCoupon]);
     },
     onMutate() {
       showLoading();

--- a/frontend/src/@hooks/@queries/unregistered-coupon.ts
+++ b/frontend/src/@hooks/@queries/unregistered-coupon.ts
@@ -105,14 +105,14 @@ export const useRegisterUnregisteredCouponMutation = () => {
   });
 };
 
-export const useDeleteUnregisteredCouponMutation = () => {
+export const useDeleteUnregisteredCouponMutation = (id: number) => {
   const queryClient = useQueryClient();
   const { showLoading, hideLoading } = useLoading();
 
   return useMutation(deleteUnregisteredCoupon, {
     onSuccess() {
       queryClient.invalidateQueries([QUERY_KEY.unregisteredCouponListByStatus, QUERY_KEY.ISSUED]);
-      queryClient.removeQueries([QUERY_KEY.unregisteredCoupon]);
+      queryClient.removeQueries([QUERY_KEY.unregisteredCoupon, id]);
     },
     onMutate() {
       showLoading();

--- a/frontend/src/@hooks/business/unregistered-coupon.ts
+++ b/frontend/src/@hooks/business/unregistered-coupon.ts
@@ -45,11 +45,11 @@ export const useRegisterUnregisteredCoupon = () => {
   };
 };
 
-export const useDeleteUnregisteredCoupon = () => {
+export const useDeleteUnregisteredCoupon = (id: number) => {
   const { displayMessage } = useToast();
-  const { mutateAsync } = useDeleteUnregisteredCouponMutation();
+  const { mutateAsync } = useDeleteUnregisteredCouponMutation(id);
 
-  const deleteUnregisteredCoupon = (id: number) => {
+  const deleteUnregisteredCoupon = () => {
     return mutateAsync(id, {
       onSuccess() {
         displayMessage('쿠폰이 삭제되었습니다.', false);

--- a/frontend/src/@hooks/business/unregistered-coupon.ts
+++ b/frontend/src/@hooks/business/unregistered-coupon.ts
@@ -6,6 +6,7 @@ import {
 import { useToast } from '../@common/useToast';
 import {
   useCreateUnregisteredCouponMutation,
+  useDeleteUnregisteredCouponMutation,
   useRegisterUnregisteredCouponMutation,
 } from '../@queries/unregistered-coupon';
 
@@ -41,5 +42,22 @@ export const useRegisterUnregisteredCoupon = () => {
 
   return {
     registerUnregisteredCoupon,
+  };
+};
+
+export const useDeleteUnregisteredCoupon = () => {
+  const { displayMessage } = useToast();
+  const { mutateAsync } = useDeleteUnregisteredCouponMutation();
+
+  const deleteUnregisteredCoupon = (id: number) => {
+    return mutateAsync(id, {
+      onSuccess() {
+        displayMessage('쿠폰이 삭제되었습니다.', false);
+      },
+    });
+  };
+
+  return {
+    deleteUnregisteredCoupon,
   };
 };

--- a/frontend/src/@pages/unregistered-coupon-detail/index.tsx
+++ b/frontend/src/@pages/unregistered-coupon-detail/index.tsx
@@ -1,23 +1,46 @@
-import { useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 
+import Button from '@/@components/@shared/Button';
 import PageTemplate from '@/@components/@shared/PageTemplate';
+import Position from '@/@components/@shared/Position';
 import UnregisteredCouponExpiredTime from '@/@components/unregistered-coupon/UnregisteredCouponExpiredTime';
 import UnregisteredCouponItem from '@/@components/unregistered-coupon/UnregisteredCouponItem';
 import { useFetchUnregisteredCouponById } from '@/@hooks/@queries/unregistered-coupon';
+import { useDeleteUnregisteredCoupon } from '@/@hooks/business/unregistered-coupon';
 import NotFoundPage from '@/@pages/404';
+import { PATH } from '@/Router';
+import { unregisteredFilterOptionsSessionStorage } from '@/storage/session';
 
 import * as Styled from './style';
 
 const UnregisteredCouponDetail = () => {
+  const navigate = useNavigate();
+
   const { unregisteredCouponId } = useParams();
 
   const { unregisteredCoupon } = useFetchUnregisteredCouponById(Number(unregisteredCouponId));
+
+  const { deleteUnregisteredCoupon } = useDeleteUnregisteredCoupon();
 
   if (!unregisteredCoupon) {
     return <NotFoundPage />;
   }
 
   const { couponMessage, createdTime } = unregisteredCoupon;
+
+  const onClickDeleteButton = async () => {
+    if (!window.confirm('쿠폰을 삭제하시겠습니까?')) {
+      return;
+    }
+
+    const unregisteredCouponIdAsNumber = Number(unregisteredCouponId);
+
+    await deleteUnregisteredCoupon(unregisteredCouponIdAsNumber);
+
+    navigate(PATH.UNREGISTERED_COUPON_LIST);
+
+    unregisteredFilterOptionsSessionStorage.set('미등록');
+  };
 
   return (
     <PageTemplate.ExtendedStyleHeader title='미등록 쿠폰'>
@@ -34,6 +57,12 @@ const UnregisteredCouponDetail = () => {
             <Styled.DescriptionContainer>{couponMessage}</Styled.DescriptionContainer>
           </Styled.SubSection>
         </Styled.Main>
+
+        <Position position='fixed' bottom='0' right='0' css={Styled.ExtendedPosition}>
+          <Button onClick={onClickDeleteButton} css={Styled.ExtendedButton}>
+            쿠폰 삭제하기
+          </Button>
+        </Position>
       </Styled.Root>
     </PageTemplate.ExtendedStyleHeader>
   );

--- a/frontend/src/@pages/unregistered-coupon-detail/index.tsx
+++ b/frontend/src/@pages/unregistered-coupon-detail/index.tsx
@@ -1,8 +1,6 @@
 import { useNavigate, useParams } from 'react-router-dom';
 
-import Button from '@/@components/@shared/Button';
 import PageTemplate from '@/@components/@shared/PageTemplate';
-import Position from '@/@components/@shared/Position';
 import UnregisteredCouponExpiredTime from '@/@components/unregistered-coupon/UnregisteredCouponExpiredTime';
 import UnregisteredCouponItem from '@/@components/unregistered-coupon/UnregisteredCouponItem';
 import { useFetchUnregisteredCouponById } from '@/@hooks/@queries/unregistered-coupon';
@@ -54,13 +52,10 @@ const UnregisteredCouponDetail = () => {
             <Styled.SubSectionTitle>쿠폰 메시지</Styled.SubSectionTitle>
             <Styled.DescriptionContainer>{couponMessage}</Styled.DescriptionContainer>
           </Styled.SubSection>
+          <Styled.FinishButtonInner>
+            <button onClick={onClickDeleteButton}>쿠폰을 삭제하시겠습니까?</button>
+          </Styled.FinishButtonInner>
         </Styled.Main>
-
-        <Position position='fixed' bottom='0' right='0' css={Styled.ExtendedPosition}>
-          <Button onClick={onClickDeleteButton} css={Styled.ExtendedButton}>
-            쿠폰 삭제하기
-          </Button>
-        </Position>
       </Styled.Root>
     </PageTemplate.ExtendedStyleHeader>
   );

--- a/frontend/src/@pages/unregistered-coupon-detail/index.tsx
+++ b/frontend/src/@pages/unregistered-coupon-detail/index.tsx
@@ -37,7 +37,7 @@ const UnregisteredCouponDetail = () => {
 
     await deleteUnregisteredCoupon(unregisteredCouponIdAsNumber);
 
-    navigate(PATH.UNREGISTERED_COUPON_LIST);
+    navigate(PATH.UNREGISTERED_COUPON_LIST, { replace: true });
 
     unregisteredFilterOptionsSessionStorage.set('미등록');
   };

--- a/frontend/src/@pages/unregistered-coupon-detail/index.tsx
+++ b/frontend/src/@pages/unregistered-coupon-detail/index.tsx
@@ -20,7 +20,7 @@ const UnregisteredCouponDetail = () => {
 
   const { unregisteredCoupon } = useFetchUnregisteredCouponById(Number(unregisteredCouponId));
 
-  const { deleteUnregisteredCoupon } = useDeleteUnregisteredCoupon();
+  const { deleteUnregisteredCoupon } = useDeleteUnregisteredCoupon(Number(unregisteredCouponId));
 
   if (!unregisteredCoupon) {
     return <NotFoundPage />;
@@ -33,9 +33,7 @@ const UnregisteredCouponDetail = () => {
       return;
     }
 
-    const unregisteredCouponIdAsNumber = Number(unregisteredCouponId);
-
-    await deleteUnregisteredCoupon(unregisteredCouponIdAsNumber);
+    await deleteUnregisteredCoupon();
 
     navigate(PATH.UNREGISTERED_COUPON_LIST, { replace: true });
 

--- a/frontend/src/@pages/unregistered-coupon-detail/style.tsx
+++ b/frontend/src/@pages/unregistered-coupon-detail/style.tsx
@@ -82,6 +82,21 @@ export const DescriptionContainer = styled.div`
   `}
 `;
 
+export const FinishButtonInner = styled.div`
+  width: 100%;
+  text-align: right;
+  font-size: 12px;
+  margin-top: 16px;
+
+  ${({ theme }) => css`
+    color: ${theme.colors.grey_200};
+  `}
+
+  & > button {
+    text-decoration: underline;
+  }
+`;
+
 export const ExtendedButton = css`
   height: 50px;
   border-radius: 0;

--- a/frontend/src/@pages/unregistered-coupon-list/index.tsx
+++ b/frontend/src/@pages/unregistered-coupon-list/index.tsx
@@ -28,6 +28,7 @@ const UnregisteredCouponList = () => {
 
   const onClickFilterButton = (status: UnregisteredFilterOption) => {
     changeStatus(status);
+
     unregisteredFilterOptionsSessionStorage.set(status);
   };
 

--- a/frontend/src/@pages/unregistered-coupon-register/IssuedRegisteredCouponPage/index.tsx
+++ b/frontend/src/@pages/unregistered-coupon-register/IssuedRegisteredCouponPage/index.tsx
@@ -29,9 +29,10 @@ const IssuedUnregisteredCouponPage = (props: IssuedUnregisteredCouponPageProps) 
 
   const { registerUnregisteredCoupon } = useRegisterUnregisteredCoupon();
 
-  const onClickRegisterButton = () => {
+  const onClickRegisterButton = async () => {
     if (me) {
-      registerUnregisteredCoupon({ couponCode });
+      await registerUnregisteredCoupon({ couponCode });
+
       navigate(PATH.MAIN);
 
       return;

--- a/frontend/src/apis/unregistered-coupon.ts
+++ b/frontend/src/apis/unregistered-coupon.ts
@@ -12,34 +12,40 @@ export const getUnregisteredCouponListByStatus = async ({
   type,
 }: UnregisteredCouponListByStatusRequest) => {
   const { data } = await client.get<UnregisteredCouponListResponse>(
-    `/coupons/unregistered/status?type=${type}`
+    `/lazy-coupons/status?type=${type}`
   );
 
   return data;
 };
 
 export const getUnregisteredCouponById = async (id: number) => {
-  const { data } = await client.get<UnregisteredCouponResponse>(`/coupons/unregistered/${id}`);
+  const { data } = await client.get<UnregisteredCouponResponse>(`/lazy-coupons/${id}`);
 
   return data;
 };
 
 export const createUnregisteredCoupon = async (body: CreateUnregisteredCouponRequest) => {
-  const { data } = await client.post<UnregisteredCouponListResponse>('/coupons/unregistered', body);
+  const { data } = await client.post<UnregisteredCouponListResponse>('/lazy-coupons', body);
 
   return data;
 };
 
 export const getUnregisteredCouponByCode = async (couponCode: string) => {
   const { data } = await client.get<UnregisteredCouponResponse>(
-    `/coupons/unregistered/code?couponCode=${couponCode}`
+    `/lazy-coupons/code?couponCode=${couponCode}`
   );
 
   return data;
 };
 
 export const registerUnregisteredCoupon = async (body: RegisterUnregisteredCouponRequest) => {
-  const { data } = await client.post<UnregisteredCouponResponse>('/coupons/code', body);
+  const { data } = await client.post<UnregisteredCouponResponse>('/lazy-coupons/register', body);
+
+  return data;
+};
+
+export const deleteUnregisteredCoupon = async (id: number) => {
+  const { data } = await client.delete<UnregisteredCouponResponse>(`/lazy-coupons/${id}`);
 
   return data;
 };

--- a/frontend/src/mocks/fixtures/unregistered-coupon.ts
+++ b/frontend/src/mocks/fixtures/unregistered-coupon.ts
@@ -62,6 +62,7 @@ export default {
 
     return unregisteredCouponList;
   },
+
   findUnregisteredCoupon(unregisteredCouponId: number) {
     const coupon = this.current.find(({ id }) => id === unregisteredCouponId);
 
@@ -80,5 +81,11 @@ export default {
     }
 
     return coupon;
+  },
+
+  deleteUnregisteredCoupon(unregisteredCouponId: number) {
+    const newUnregisteredCouponList = this.current.filter(({ id }) => id !== unregisteredCouponId);
+
+    this.current = newUnregisteredCouponList;
   },
 };


### PR DESCRIPTION
## 작업 내용

- 미동록 쿠폰 삭제 기능을 추가한다.

  - Ajax Request 요청을 보내는 함수 개발
  - useMutation 기반의 커스텀 훅 제작
  - 비즈니스 로직 개발

- `mock API` 개발

  - mocked API 를 개발합니다.


- `endpoint` 수정 사항 반영

  - `/coupons/unregistered` -> `/lazy-coupons` 로 변경합니다.


- `IssuedUnregisteredCouponPage`의 프로미스를 핸들링하여 오류를 수정합니다.

  - `mutateAsync`는 Promise를 반환합니다. 따라서 비동기 동작을 제어하고 싶다면 `async await` 키워드를 작성하거나, `then`이나 `catch`절에서 제어 이후의 작업을 기술해주어야합니다. 이전에는 그것이 제대로 되어 있지 않았기에 수정합니다.

## 공유사항

Resolves #502
