### PR TITLE
feat: 미등록 쿠폰 생성 이 후 라우팅 로직을 수정 & `UnregisteredCoupon.Preview` 컴포넌트 & UnregisteredCoupon Type 구조 개선

### DIFF
--- a/frontend/src/@components/coupon/CouponStatus/index.tsx
+++ b/frontend/src/@components/coupon/CouponStatus/index.tsx
@@ -23,7 +23,7 @@ const couponStatusMapper = (
 
 interface CouponStatusProps {
   status: 'REQUESTED' | 'READY' | 'ACCEPTED' | 'FINISHED';
-  meetingDate?: COUPON_MEETING_DATE;
+  meetingDate: COUPON_MEETING_DATE | null;
   isSent: boolean;
 }
 

--- a/frontend/src/@components/unregistered-coupon/UnregisteredCouponItem/index.tsx
+++ b/frontend/src/@components/unregistered-coupon/UnregisteredCouponItem/index.tsx
@@ -6,12 +6,12 @@ import UnregisteredCouponStatus from '@/@components/unregistered-coupon/Unregist
 import { useToast } from '@/@hooks/@common/useToast';
 import { DYNAMIC_PATH } from '@/Router';
 import { THUMBNAIL } from '@/types/coupon/client';
-import { UnregisteredCouponResponse } from '@/types/unregistered-coupon/remote';
+import { UnregisteredCoupon } from '@/types/unregistered-coupon/client';
 import clipboardCopy from '@/utils/clipboardCopy';
 
 import * as Styled from './style';
 
-export interface UnregisteredCouponItemProps extends UnregisteredCouponResponse {
+export interface UnregisteredCouponItemProps extends UnregisteredCoupon {
   className?: string;
   onClick?: MouseEventHandler<HTMLDivElement>;
 }
@@ -72,7 +72,7 @@ UnregisteredCouponItem.Skeleton = function Skeleton() {
 };
 
 interface UnregisteredCouponItemPreviewProps
-  extends Pick<UnregisteredCouponResponse, 'couponTag' | 'couponMessage' | 'couponType'> {
+  extends Pick<UnregisteredCoupon, 'couponTag' | 'couponMessage' | 'couponType'> {
   className?: string;
 }
 

--- a/frontend/src/@components/unregistered-coupon/UnregisteredCouponItem/index.tsx
+++ b/frontend/src/@components/unregistered-coupon/UnregisteredCouponItem/index.tsx
@@ -71,12 +71,17 @@ UnregisteredCouponItem.Skeleton = function Skeleton() {
   return <Placeholder aspectRatio='3/1' />;
 };
 
+interface UnregisteredCouponItemPreviewProps
+  extends Pick<UnregisteredCouponResponse, 'couponTag' | 'couponMessage' | 'couponType'> {
+  className?: string;
+}
+
 UnregisteredCouponItem.Preview = function UnregisteredCouponItem(
-  props: UnregisteredCouponItemProps
+  props: UnregisteredCouponItemPreviewProps
 ) {
   const { ...coupon } = props;
 
-  const { receiver, couponTag, couponMessage, thumbnail } = {
+  const { couponTag, couponMessage, thumbnail } = {
     ...coupon,
     thumbnail: THUMBNAIL[coupon.couponType],
   };
@@ -92,7 +97,7 @@ UnregisteredCouponItem.Preview = function UnregisteredCouponItem(
         <Styled.TextContainer>
           <Styled.Top>
             <Styled.Member>
-              <Styled.English>To</Styled.English> {receiver?.nickname ?? '?'}
+              <Styled.English>To</Styled.English> ?
             </Styled.Member>
           </Styled.Top>
           <Styled.Message>{couponMessage}</Styled.Message>

--- a/frontend/src/@components/unregistered-coupon/UnregisteredCouponListSection/ExpiredCouponListSection/index.tsx
+++ b/frontend/src/@components/unregistered-coupon/UnregisteredCouponListSection/ExpiredCouponListSection/index.tsx
@@ -1,12 +1,12 @@
 import VerticalCouponList from '@/@components/coupon/CouponList/vertical';
 import { useFetchUnregisteredCouponListByStatus } from '@/@hooks/@queries/unregistered-coupon';
 import { Styled } from '@/@pages/coupon-list';
-import { UnregisteredCouponResponse } from '@/types/unregistered-coupon/remote';
+import { UnregisteredCoupon } from '@/types/unregistered-coupon/client';
 
 import UnregisteredCouponItem from '../../UnregisteredCouponItem';
 
 interface ExpiredCouponListSectionProps {
-  onClickCouponItem: (coupon: UnregisteredCouponResponse) => void;
+  onClickCouponItem: (coupon: UnregisteredCoupon) => void;
 }
 
 const ExpiredCouponListSection = (props: ExpiredCouponListSectionProps) => {

--- a/frontend/src/@components/unregistered-coupon/UnregisteredCouponListSection/RegisteredCouponListSection/index.tsx
+++ b/frontend/src/@components/unregistered-coupon/UnregisteredCouponListSection/RegisteredCouponListSection/index.tsx
@@ -1,12 +1,12 @@
 import VerticalCouponList from '@/@components/coupon/CouponList/vertical';
 import { useFetchUnregisteredCouponListByStatus } from '@/@hooks/@queries/unregistered-coupon';
 import { Styled } from '@/@pages/coupon-list';
-import { UnregisteredCouponResponse } from '@/types/unregistered-coupon/remote';
+import { UnregisteredCoupon } from '@/types/unregistered-coupon/client';
 
 import UnregisteredCouponItem from '../../UnregisteredCouponItem';
 
 interface RegisteredCouponListSectionProps {
-  onClickCouponItem: (coupon: UnregisteredCouponResponse) => void;
+  onClickCouponItem: (coupon: UnregisteredCoupon) => void;
 }
 
 const RegisteredCouponListSection = (props: RegisteredCouponListSectionProps) => {

--- a/frontend/src/@components/unregistered-coupon/UnregisteredCouponListSection/UnregisteredCouponListSection/index.tsx
+++ b/frontend/src/@components/unregistered-coupon/UnregisteredCouponListSection/UnregisteredCouponListSection/index.tsx
@@ -1,12 +1,12 @@
 import VerticalCouponList from '@/@components/coupon/CouponList/vertical';
 import { useFetchUnregisteredCouponListByStatus } from '@/@hooks/@queries/unregistered-coupon';
 import { Styled } from '@/@pages/coupon-list';
-import { UnregisteredCouponResponse } from '@/types/unregistered-coupon/remote';
+import { UnregisteredCoupon } from '@/types/unregistered-coupon/client';
 
 import UnregisteredCouponItem from '../../UnregisteredCouponItem';
 
 interface UnregisteredCouponListSectionProps {
-  onClickCouponItem: (coupon: UnregisteredCouponResponse) => void;
+  onClickCouponItem: (coupon: UnregisteredCoupon) => void;
 }
 
 const UnregisteredCouponListSection = (props: UnregisteredCouponListSectionProps) => {

--- a/frontend/src/@hooks/ui/unregistered-coupon/useUnregisteredForm.ts
+++ b/frontend/src/@hooks/ui/unregistered-coupon/useUnregisteredForm.ts
@@ -79,9 +79,11 @@ export const useUnregisteredForm = () => {
       navigate(DYNAMIC_PATH.UNREGISTERED_COUPON_DETAIL(unregisteredCouponList[0].id), {
         replace: true,
       });
+
+      return;
     }
 
-    navigate(PATH.UNREGISTERED_COUPON_LIST);
+    navigate(PATH.UNREGISTERED_COUPON_LIST, { replace: true });
   };
 
   return {

--- a/frontend/src/@pages/coupon-list/coupon-detail/request/index.tsx
+++ b/frontend/src/@pages/coupon-list/coupon-detail/request/index.tsx
@@ -26,6 +26,7 @@ const CouponRequestPage = () => {
   const todayDate = getTodayDate();
 
   const [meetingDate, onChangeMeetingDate] = useInput<YYYYMMDD>(todayDate, [isBeforeToday]);
+
   const [meetingMessage, onChangeMeetingMessage] = useInput('', [
     (value: string) => isOverMaxLength(value, 200),
   ]);

--- a/frontend/src/@pages/unregistered-coupon-list/create/index.tsx
+++ b/frontend/src/@pages/unregistered-coupon-list/create/index.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef } from 'react';
 
 import PageTemplate from '@/@components/@shared/PageTemplate';
 import UnregisteredCouponCreateForm from '@/@components/unregistered-coupon/UnregisteredCouponCreateForm';
+import UnregisteredCouponItem from '@/@components/unregistered-coupon/UnregisteredCouponItem';
 import { useUnregisteredForm } from '@/@hooks/ui/unregistered-coupon/useUnregisteredForm';
 
 import * as Styled from './style';
@@ -28,19 +29,18 @@ const UnregisteredCouponCreatePage = () => {
     <PageTemplate title='미등록 쿠폰 보내기'>
       <Styled.Root>
         <Styled.PreviewContainer ref={elementRef}>
-          {/* {receiverList.length === 0 ? (
+          {couponCount === 0 ? (
             <Styled.GuideContainer>쿠폰을 완성해보세요!</Styled.GuideContainer>
           ) : (
-            receiverList.map(receiver => (
-              <BigCouponItem.Preview
-                key={receiver.id}
-                receiver={receiver}
+            [...new Array(couponCount)].map((_, idx) => (
+              <UnregisteredCouponItem.Preview
+                key={idx}
                 couponMessage={couponMessage}
                 couponTag={couponTag}
                 couponType={couponType}
               />
             ))
-          )} */}
+          )}
         </Styled.PreviewContainer>
         <Styled.Inner>
           <UnregisteredCouponCreateForm

--- a/frontend/src/@pages/unregistered-coupon-list/index.tsx
+++ b/frontend/src/@pages/unregistered-coupon-list/index.tsx
@@ -11,7 +11,7 @@ import UnregisteredCouponListSection from '@/@components/unregistered-coupon/Unr
 import { useStatus } from '@/@hooks/@common/useStatus';
 import { DYNAMIC_PATH } from '@/Router';
 import { unregisteredFilterOptionsSessionStorage } from '@/storage/session';
-import { UnregisteredCouponResponse } from '@/types/unregistered-coupon/remote';
+import { UnregisteredCoupon } from '@/types/unregistered-coupon/client';
 
 import * as Styled from './style';
 
@@ -32,11 +32,11 @@ const UnregisteredCouponList = () => {
     unregisteredFilterOptionsSessionStorage.set(status);
   };
 
-  const onClickUnregisteredCouponItem = ({ id }: UnregisteredCouponResponse) => {
+  const onClickUnregisteredCouponItem = ({ id }: UnregisteredCoupon) => {
     navigate(DYNAMIC_PATH.UNREGISTERED_COUPON_DETAIL(id));
   };
 
-  const onClickRegisteredCouponItem = ({ couponId }: UnregisteredCouponResponse) => {
+  const onClickRegisteredCouponItem = ({ couponId }: UnregisteredCoupon) => {
     if (couponId === null) {
       return;
     }

--- a/frontend/src/mocks/fixtures/unregistered-coupon.ts
+++ b/frontend/src/mocks/fixtures/unregistered-coupon.ts
@@ -90,6 +90,8 @@ export default {
     const newUnregisteredCouponList = this.current.filter(({ id }) => id !== unregisteredCouponId);
 
     this.current = newUnregisteredCouponList;
+  },
+
   createUnregisteredCoupon({ id, body }: { id: number; body: CreateUnregisteredCouponRequest }) {
     const { couponMessage, couponTag, couponType } = body;
 

--- a/frontend/src/mocks/fixtures/unregistered-coupon.ts
+++ b/frontend/src/mocks/fixtures/unregistered-coupon.ts
@@ -1,4 +1,7 @@
 import { UNREGISTERED_COUPON_STATUS } from '@/types/unregistered-coupon/client';
+import { CreateUnregisteredCouponRequest } from '@/types/unregistered-coupon/remote';
+
+import { Valueof } from './../../types/utils';
 
 export default {
   current: [
@@ -87,5 +90,28 @@ export default {
     const newUnregisteredCouponList = this.current.filter(({ id }) => id !== unregisteredCouponId);
 
     this.current = newUnregisteredCouponList;
+  createUnregisteredCoupon({ id, body }: { id: number; body: CreateUnregisteredCouponRequest }) {
+    const { couponMessage, couponTag, couponType } = body;
+
+    return {
+      id,
+      couponCode: `asdfghjkqwertyui${id}`,
+      couponId: null,
+      sender: {
+        id: 1,
+        nickname: '시지프',
+        imageUrl: 'https://avatars.githubusercontent.com/u/24906022?s=48&v=4',
+      },
+      receiver: null,
+      unregisteredCouponStatus: 'ISSUED',
+      createdTime: '2022-10-12T14:32:22',
+      couponTag,
+      couponMessage,
+      couponType,
+    };
+  },
+
+  addUnregisteredCoupon(unregisteredCoupon: Valueof<typeof this.current>[]) {
+    this.current = [...this.current, ...unregisteredCoupon];
   },
 };

--- a/frontend/src/mocks/handlers/unregistered-coupon.ts
+++ b/frontend/src/mocks/handlers/unregistered-coupon.ts
@@ -5,6 +5,7 @@ import { UNREGISTERED_COUPON_STATUS } from '@/types/unregistered-coupon/client';
 import { RegisterUnregisteredCouponRequest } from '@/types/unregistered-coupon/remote';
 
 import unregisteredCouponMock from '../fixtures/unregistered-coupon';
+import { CreateUnregisteredCouponRequest } from './../../types/unregistered-coupon/remote';
 
 export const unregisteredCouponHandler = [
   rest.get(`${BASE_URL}/lazy-coupons/status`, (req, res, ctx) => {
@@ -92,4 +93,22 @@ export const unregisteredCouponHandler = [
       }
     }
   ),
+
+  rest.post<CreateUnregisteredCouponRequest>(`${BASE_URL}/lazy-coupons`, (req, res, ctx) => {
+    const { body } = req;
+
+    try {
+      const unregisteredCoupons = [...new Array(body.quantity)].map((_, idx) => {
+        const id = unregisteredCouponMock.current.length + idx + 1;
+
+        return unregisteredCouponMock.createUnregisteredCoupon({ id, body });
+      });
+
+      unregisteredCouponMock.addUnregisteredCoupon(unregisteredCoupons);
+
+      return res(ctx.status(200), ctx.json({ data: unregisteredCoupons }));
+    } catch ({ message }) {
+      return res(ctx.status(400), ctx.json({ message }));
+    }
+  }),
 ];

--- a/frontend/src/types/unregistered-coupon/client.ts
+++ b/frontend/src/types/unregistered-coupon/client.ts
@@ -1,5 +1,21 @@
-import { Valueof } from '../utils';
+import { COUPON_ENG_TYPE, COUPON_HASHTAGS } from '@/types/coupon/client';
+import { Member } from '@/types/user/client';
+
+import { Valueof, YYYYMMDDhhmmss } from '../utils';
 
 export const unregisteredCouponStatus = ['ISSUED', 'REGISTERED', 'EXPIRED'] as const;
 
 export type UNREGISTERED_COUPON_STATUS = Valueof<typeof unregisteredCouponStatus>;
+
+export interface UnregisteredCoupon {
+  id: number;
+  couponCode: string;
+  couponId: number | null;
+  sender: Member;
+  receiver: Member | null;
+  couponTag: COUPON_HASHTAGS;
+  couponMessage: string;
+  couponType: COUPON_ENG_TYPE;
+  unregisteredCouponStatus: UNREGISTERED_COUPON_STATUS;
+  createdTime: YYYYMMDDhhmmss;
+}

--- a/frontend/src/types/unregistered-coupon/remote.ts
+++ b/frontend/src/types/unregistered-coupon/remote.ts
@@ -1,29 +1,16 @@
 import { COUPON_ENG_TYPE, COUPON_HASHTAGS } from '@/types/coupon/client';
-import { Member } from '@/types/user/client';
-import { YYYYMMDDhhmmss } from '@/types/utils';
 
-import { UNREGISTERED_COUPON_STATUS } from './client';
+import { UNREGISTERED_COUPON_STATUS, UnregisteredCoupon } from './client';
 
 export interface UnregisteredCouponListByStatusRequest {
   type: UNREGISTERED_COUPON_STATUS;
 }
 
 export interface UnregisteredCouponListResponse {
-  data: UnregisteredCouponResponse[];
+  data: UnregisteredCoupon[];
 }
 
-export interface UnregisteredCouponResponse {
-  id: number;
-  couponCode: string;
-  couponId: number | null;
-  sender: Member;
-  receiver: Member | null;
-  couponTag: COUPON_HASHTAGS;
-  couponMessage: string;
-  couponType: COUPON_ENG_TYPE;
-  unregisteredCouponStatus: UNREGISTERED_COUPON_STATUS;
-  createdTime: YYYYMMDDhhmmss;
-}
+export type UnregisteredCouponResponse = UnregisteredCoupon;
 
 export interface RegisterUnregisteredCouponRequest {
   couponCode: string;


### PR DESCRIPTION
## 작업 내용

- 미등록 쿠폰 생성 이 후 라우팅 로직을 수정

  - 하나의 쿠폰을 생성하면 디테일, 복수 개의 쿠폰을 생성하면 리스트 페이지로 라우팅 된다.


- 생성 폼에서 `Preview` 컴포넌트가 보여진다

  - 미리 만들 쿠폰에 대한 뷰 정보를 제공한다.
  - `Preview` 컴포넌트로 작성
  - 현재 이벤트 페이지에서 사용되는 컴포넌트는 `Preview, Original`과는 분리된 컴포넌트로 작성한다.


- CreateUnregisteredCoupon Mock API를 개발한다.

- UnregisteredCoupon Type 구조 개선

  - 쿠폰 도메인과 동일하게 서버 스키마 타입 구조는 클라이언트 타입 기반으로 설계되어야 합니다.
  - 클라이언트의 컴포넌트 역시 클라이언트 타입 기반으로 작성되어야 합니다. 
  - 서버의 반환 타입에 클라이언트 데이터 타입이 의존하지 않도록 구분하여 설계합니다.
  - 서버의 반환 타입은 클라이언트 데이터 타입에 의존합니다. 
## 공유사항

해당 작업 내용에 관한 부연 설명 및 및 향후 작업해야 할 내용 등에 대한 설명

Resolves #505
Resolves #504