### PR TITLE
feat: 미등록 쿠폰 조회 및 등록 기능 개선

### DIFF
--- a/frontend/src/@components/coupon/CouponStatus/index.tsx
+++ b/frontend/src/@components/coupon/CouponStatus/index.tsx
@@ -23,7 +23,7 @@ const couponStatusMapper = (
 
 interface CouponStatusProps {
   status: 'REQUESTED' | 'READY' | 'ACCEPTED' | 'FINISHED';
-  meetingDate: COUPON_MEETING_DATE | null;
+  meetingDate?: COUPON_MEETING_DATE | null;
   isSent: boolean;
 }
 

--- a/frontend/src/@components/unregistered-coupon/UnregisteredCouponExpiredTime/index.tsx
+++ b/frontend/src/@components/unregistered-coupon/UnregisteredCouponExpiredTime/index.tsx
@@ -70,7 +70,7 @@ const UnregisteredCouponExpiredTime = (props: UnregisteredCouponExpiredTimeProps
         </Styled.TimeContainer>
       )}
       <Styled.Text>
-        {remainingTime > 0 ? '이 지나기 전에 요청해보세요!' : '받을 수 있는 기간이 지났어요 !'}
+        {remainingTime > 0 ? '후에 쿠폰이 만료됩니다!' : '받을 수 있는 기간이 지났어요 !'}
       </Styled.Text>
     </Styled.Root>
   );

--- a/frontend/src/@components/unregistered-coupon/UnregisteredCouponItem/index.tsx
+++ b/frontend/src/@components/unregistered-coupon/UnregisteredCouponItem/index.tsx
@@ -107,3 +107,35 @@ UnregisteredCouponItem.Preview = function UnregisteredCouponItem(
     </Styled.Root>
   );
 };
+
+UnregisteredCouponItem.Receiver = function UnregisteredCouponItem(
+  props: UnregisteredCouponItemProps
+) {
+  const { ...coupon } = props;
+
+  const { sender, couponTag, couponMessage, thumbnail } = {
+    ...coupon,
+    thumbnail: THUMBNAIL[coupon.couponType],
+  };
+
+  return (
+    <Styled.Root>
+      <Styled.Coupon hasCursor={false}>
+        <Styled.CouponPropertyContainer>
+          <Styled.ImageInner>
+            <img src={thumbnail} alt='쿠폰' width={44} height={44} />
+          </Styled.ImageInner>
+        </Styled.CouponPropertyContainer>
+        <Styled.TextContainer>
+          <Styled.Top>
+            <Styled.Member>
+              <Styled.English>From</Styled.English> {sender?.nickname}
+            </Styled.Member>
+          </Styled.Top>
+          <Styled.Message>{couponMessage}</Styled.Message>
+          <Styled.Hashtag>#{couponTag}</Styled.Hashtag>
+        </Styled.TextContainer>
+      </Styled.Coupon>
+    </Styled.Root>
+  );
+};

--- a/frontend/src/@hooks/@queries/coupon.ts
+++ b/frontend/src/@hooks/@queries/coupon.ts
@@ -27,6 +27,11 @@ const QUERY_KEY = {
   /** SUB KEY */
   sent: 'sent',
   received: 'received',
+
+  REQUESTED: 'REQUESTED',
+  READY: 'READY',
+  ACCEPTED: 'ACCEPTED',
+  FINISHED: 'FINISHED',
 };
 
 export const useFetchCoupon = (id: number) => {

--- a/frontend/src/@hooks/@queries/coupon.ts
+++ b/frontend/src/@hooks/@queries/coupon.ts
@@ -154,7 +154,7 @@ export const useChangeCouponStatusMutation = (id: number) => {
 
 /** invalidateQueries */
 
-export const useCouponInvalidationOnRegisterCoupon = () => {
+export const useCouponInvalidationOnRegisterUnregisteredCoupon = () => {
   const queryClient = useQueryClient();
 
   const invalidateReceivedCouponList = () => {

--- a/frontend/src/@hooks/@queries/coupon.ts
+++ b/frontend/src/@hooks/@queries/coupon.ts
@@ -151,3 +151,22 @@ export const useChangeCouponStatusMutation = (id: number) => {
     },
   });
 };
+
+/** invalidateQueries */
+
+export const useCouponInvalidationOnRegisterCoupon = () => {
+  const queryClient = useQueryClient();
+
+  const invalidateReceivedCouponList = () => {
+    queryClient.invalidateQueries([QUERY_KEY.couponList, QUERY_KEY.received]);
+    queryClient.invalidateQueries([
+      QUERY_KEY.couponListByStatus,
+      QUERY_KEY.received,
+      QUERY_KEY.READY,
+    ]);
+  };
+
+  return {
+    invalidateReceivedCouponList,
+  };
+};

--- a/frontend/src/@hooks/@queries/unregistered-coupon.ts
+++ b/frontend/src/@hooks/@queries/unregistered-coupon.ts
@@ -88,13 +88,13 @@ export const useCreateUnregisteredCouponMutation = () => {
   });
 };
 
-export const useRegisterUnregisteredCouponMutation = () => {
+export const useRegisterUnregisteredCouponMutation = (id: number) => {
   const queryClient = useQueryClient();
   const { showLoading, hideLoading } = useLoading();
 
   return useMutation(registerUnregisteredCoupon, {
     onSuccess() {
-      queryClient.invalidateQueries([QUERY_KEY.unregisteredCoupon]);
+      queryClient.invalidateQueries([QUERY_KEY.unregisteredCoupon, id]);
       queryClient.invalidateQueries([QUERY_KEY.unregisteredCouponListByStatus, QUERY_KEY.ISSUED]);
       // @TODO: Key를 전역적으로 공유하고, import해서 사용하기
       queryClient.invalidateQueries(['couponList', 'sent']);

--- a/frontend/src/@hooks/@queries/unregistered-coupon.ts
+++ b/frontend/src/@hooks/@queries/unregistered-coupon.ts
@@ -11,6 +11,7 @@ import { UnregisteredCouponListByStatusRequest } from '@/types/unregistered-coup
 
 import { getUnregisteredCouponByCode } from '../../apis/unregistered-coupon';
 import { useLoading } from '../@common/useLoading';
+import { useCouponInvalidationOnRegisterCoupon } from './coupon';
 import { useMutation, useQuery } from './utils';
 
 const QUERY_KEY = {
@@ -91,14 +92,14 @@ export const useCreateUnregisteredCouponMutation = () => {
 export const useRegisterUnregisteredCouponMutation = (id: number) => {
   const queryClient = useQueryClient();
   const { showLoading, hideLoading } = useLoading();
+  const { invalidateReceivedCouponList } = useCouponInvalidationOnRegisterCoupon();
 
   return useMutation(registerUnregisteredCoupon, {
     onSuccess() {
       queryClient.invalidateQueries([QUERY_KEY.unregisteredCoupon, id]);
       queryClient.invalidateQueries([QUERY_KEY.unregisteredCouponListByStatus, QUERY_KEY.ISSUED]);
-      // @TODO: Key를 전역적으로 공유하고, import해서 사용하기
-      queryClient.invalidateQueries(['couponList', 'sent']);
-      queryClient.invalidateQueries(['couponListByStatus', 'sent', 'READY']);
+
+      invalidateReceivedCouponList();
     },
     onMutate() {
       showLoading();

--- a/frontend/src/@hooks/@queries/unregistered-coupon.ts
+++ b/frontend/src/@hooks/@queries/unregistered-coupon.ts
@@ -95,6 +95,10 @@ export const useRegisterUnregisteredCouponMutation = () => {
   return useMutation(registerUnregisteredCoupon, {
     onSuccess() {
       queryClient.invalidateQueries([QUERY_KEY.unregisteredCoupon]);
+      queryClient.invalidateQueries([QUERY_KEY.unregisteredCouponListByStatus, QUERY_KEY.ISSUED]);
+      // @TODO: Key를 전역적으로 공유하고, import해서 사용하기
+      queryClient.invalidateQueries(['couponList', 'sent']);
+      queryClient.invalidateQueries(['couponListByStatus', 'sent', 'READY']);
     },
     onMutate() {
       showLoading();

--- a/frontend/src/@hooks/@queries/unregistered-coupon.ts
+++ b/frontend/src/@hooks/@queries/unregistered-coupon.ts
@@ -11,7 +11,7 @@ import { UnregisteredCouponListByStatusRequest } from '@/types/unregistered-coup
 
 import { getUnregisteredCouponByCode } from '../../apis/unregistered-coupon';
 import { useLoading } from '../@common/useLoading';
-import { useCouponInvalidationOnRegisterCoupon } from './coupon';
+import { useCouponInvalidationOnRegisterUnregisteredCoupon } from './coupon';
 import { useMutation, useQuery } from './utils';
 
 const QUERY_KEY = {
@@ -92,7 +92,7 @@ export const useCreateUnregisteredCouponMutation = () => {
 export const useRegisterUnregisteredCouponMutation = (id: number) => {
   const queryClient = useQueryClient();
   const { showLoading, hideLoading } = useLoading();
-  const { invalidateReceivedCouponList } = useCouponInvalidationOnRegisterCoupon();
+  const { invalidateReceivedCouponList } = useCouponInvalidationOnRegisterUnregisteredCoupon();
 
   return useMutation(registerUnregisteredCoupon, {
     onSuccess() {

--- a/frontend/src/@hooks/business/unregistered-coupon.ts
+++ b/frontend/src/@hooks/business/unregistered-coupon.ts
@@ -28,9 +28,9 @@ export const useCreateUnregisteredCoupon = () => {
   return { createUnregisteredCoupon };
 };
 
-export const useRegisterUnregisteredCoupon = () => {
+export const useRegisterUnregisteredCoupon = (id: number) => {
   const { displayMessage } = useToast();
-  const { mutateAsync } = useRegisterUnregisteredCouponMutation();
+  const { mutateAsync } = useRegisterUnregisteredCouponMutation(id);
 
   const registerUnregisteredCoupon = (body: RegisterUnregisteredCouponRequest) => {
     return mutateAsync(body, {

--- a/frontend/src/@pages/unregistered-coupon-list/index.tsx
+++ b/frontend/src/@pages/unregistered-coupon-list/index.tsx
@@ -1,6 +1,7 @@
 import { Suspense } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 
+import Icon from '@/@components/@shared/Icon';
 import ListFilter from '@/@components/@shared/ListFilter';
 import PageTemplate from '@/@components/@shared/PageTemplate';
 import VerticalCouponList from '@/@components/coupon/CouponList/vertical';
@@ -9,8 +10,9 @@ import ExpiredCouponListSection from '@/@components/unregistered-coupon/Unregist
 import RegisteredCouponListSection from '@/@components/unregistered-coupon/UnregisteredCouponListSection/RegisteredCouponListSection';
 import UnregisteredCouponListSection from '@/@components/unregistered-coupon/UnregisteredCouponListSection/UnregisteredCouponListSection';
 import { useStatus } from '@/@hooks/@common/useStatus';
-import { DYNAMIC_PATH } from '@/Router';
+import { DYNAMIC_PATH, PATH } from '@/Router';
 import { unregisteredFilterOptionsSessionStorage } from '@/storage/session';
+import theme from '@/styles/theme';
 import { UnregisteredCoupon } from '@/types/unregistered-coupon/client';
 
 import * as Styled from './style';
@@ -71,6 +73,11 @@ const UnregisteredCouponList = () => {
             )}
           </Styled.Container>
         </Suspense>
+        <Styled.LinkInner>
+          <Link to={PATH.UNREGISTERED_COUPON_CREATE} css={Styled.ExtendedLink}>
+            <Icon iconName='plus' size='37' color={theme.colors.primary_400} />
+          </Link>
+        </Styled.LinkInner>
       </Styled.Root>
     </PageTemplate>
   );

--- a/frontend/src/@pages/unregistered-coupon-list/style.tsx
+++ b/frontend/src/@pages/unregistered-coupon-list/style.tsx
@@ -1,3 +1,4 @@
+import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 
 export const Root = styled.div`
@@ -12,4 +13,19 @@ export const ListFilterContainer = styled.div`
 
 export const Container = styled.section`
   margin-bottom: 10px;
+`;
+
+export const LinkInner = styled.div`
+  position: sticky;
+  bottom: 0;
+  right: 0;
+
+  display: flex;
+  justify-content: flex-end;
+`;
+
+export const ExtendedLink = css`
+  position: relative;
+  right: 16px;
+  bottom: 16px;
 `;

--- a/frontend/src/@pages/unregistered-coupon-register/IssuedRegisteredCouponPage/index.tsx
+++ b/frontend/src/@pages/unregistered-coupon-register/IssuedRegisteredCouponPage/index.tsx
@@ -60,7 +60,7 @@ const IssuedUnregisteredCouponPage = (props: IssuedUnregisteredCouponPageProps) 
         </Styled.Top>
         <Styled.Main>
           <Styled.CouponInner>
-            <UnregisteredCouponItem.Preview {...unregisteredCoupon} />
+            <UnregisteredCouponItem.Receiver {...unregisteredCoupon} />
           </Styled.CouponInner>
           <Styled.SubSection>
             <Styled.SubSectionTitle>쿠폰 메시지</Styled.SubSectionTitle>

--- a/frontend/src/@pages/unregistered-coupon-register/IssuedRegisteredCouponPage/index.tsx
+++ b/frontend/src/@pages/unregistered-coupon-register/IssuedRegisteredCouponPage/index.tsx
@@ -5,6 +5,7 @@ import PageTemplate from '@/@components/@shared/PageTemplate';
 import Position from '@/@components/@shared/Position';
 import UnregisteredCouponExpiredTime from '@/@components/unregistered-coupon/UnregisteredCouponExpiredTime';
 import UnregisteredCouponItem from '@/@components/unregistered-coupon/UnregisteredCouponItem';
+import { useToast } from '@/@hooks/@common/useToast';
 import { useFetchMe } from '@/@hooks/@queries/user';
 import { useRegisterUnregisteredCoupon } from '@/@hooks/business/unregistered-coupon';
 import { PATH } from '@/Router';
@@ -21,15 +22,22 @@ interface IssuedUnregisteredCouponPageProps {
 const IssuedUnregisteredCouponPage = (props: IssuedUnregisteredCouponPageProps) => {
   const { unregisteredCoupon, couponCode } = props;
 
-  const { couponMessage, createdTime } = unregisteredCoupon;
+  const { couponMessage, createdTime, sender } = unregisteredCoupon;
 
   const navigate = useNavigate();
 
+  const { displayMessage } = useToast();
   const { me } = useFetchMe();
 
   const { registerUnregisteredCoupon } = useRegisterUnregisteredCoupon();
 
   const onClickRegisterButton = async () => {
+    if (sender.id === me?.id) {
+      displayMessage(`이 쿠폰은 ${me.nickname}님이 발급한 쿠폰이에요!`, true);
+
+      return;
+    }
+
     if (me) {
       await registerUnregisteredCoupon({ couponCode });
 

--- a/frontend/src/@pages/unregistered-coupon-register/IssuedRegisteredCouponPage/index.tsx
+++ b/frontend/src/@pages/unregistered-coupon-register/IssuedRegisteredCouponPage/index.tsx
@@ -22,14 +22,14 @@ interface IssuedUnregisteredCouponPageProps {
 const IssuedUnregisteredCouponPage = (props: IssuedUnregisteredCouponPageProps) => {
   const { unregisteredCoupon, couponCode } = props;
 
-  const { couponMessage, createdTime, sender } = unregisteredCoupon;
+  const { id, couponMessage, createdTime, sender } = unregisteredCoupon;
 
   const navigate = useNavigate();
 
   const { displayMessage } = useToast();
   const { me } = useFetchMe();
 
-  const { registerUnregisteredCoupon } = useRegisterUnregisteredCoupon();
+  const { registerUnregisteredCoupon } = useRegisterUnregisteredCoupon(id);
 
   const onClickRegisterButton = async () => {
     if (sender.id === me?.id) {

--- a/frontend/src/storage/session/index.ts
+++ b/frontend/src/storage/session/index.ts
@@ -31,7 +31,7 @@ export const filterOptionsSessionStorage = new SessionStorage<FilterOption>(
 );
 
 export const unregisteredFilterOptionsSessionStorage = new SessionStorage<UnregisteredFilterOption>(
-  SESSION_KEY.filterOptions
+  SESSION_KEY.unregisteredFilterOptions
 );
 
 export const prevUrlSessionStorage = new SessionStorage(SESSION_KEY.prevUrl);


### PR DESCRIPTION
## 작업 내용

- 미등록 쿠폰 필터링 초기값 에러 해결
- 쿠폰 코드 페이지에 발급자도 들어갈 수는 있지만, 요청을 불가능하게 만든다. 자신이 발급한 쿠폰이 상대방에게 어떻게 보여지는지 확인할 필요가 있다고 생각해서 페이지 진입 자체를 막지는 않았습니다.
- 미등록 쿠폰 리스트에서 생성 페이지로 가는 + 버튼 구현
- 미등록 쿠폰을 등록했을 때, coupon 도메인의 key도 invalidate 시키기

## 공유사항
- 처음으로 리액트 쿼리 다른 도메인의 key를 invalidate 시켜야하는 상황이 왔습니다. key 를 보관하는 파일을 따로 만들어서 export 처리해야할 것 같습니다. 더 이상 은닉으로 할 수 없다고 생각했습니다. 일단 구조를 바꾸지 않고, 상수 값 그대로 넣었습니다. 이후에 한번에 변경시키는 작업을 진행해야겠습니다.
- 쿠폰 등록 이후, 성공 액션 과 누가 이미 쿠폰을 등록했을때 등록 요청을 보냈을 때의 에러처리가 되고 있지 않았습니다. 근데 코드단에서 보면 되어야할 것 같은데, 왜 안되는지... dev에서 테스트해보면서 확인해보고, 다른 PR 올리든가 하겠습니다.

Resolves #이슈번호
