### PR TITLE
fix: unregisteredCouponStatus -> lazyCouponStatus로 필드명, 타입 수정

### DIFF
--- a/frontend/src/@components/unregistered-coupon/UnregisteredCouponItem/index.tsx
+++ b/frontend/src/@components/unregistered-coupon/UnregisteredCouponItem/index.tsx
@@ -20,7 +20,7 @@ const UnregisteredCouponItem = (props: UnregisteredCouponItemProps) => {
   const { className, onClick, ...coupon } = props;
   const { displayMessage } = useToast();
 
-  const { receiver, couponTag, unregisteredCouponStatus, couponMessage, thumbnail, couponCode } = {
+  const { receiver, couponTag, lazyCouponStatus, couponMessage, thumbnail, couponCode } = {
     ...coupon,
     thumbnail: THUMBNAIL[coupon.couponType],
   };
@@ -40,7 +40,7 @@ const UnregisteredCouponItem = (props: UnregisteredCouponItemProps) => {
     <Styled.Root>
       <Styled.Coupon className={className} hasCursor={!!onClick} onClick={onClick}>
         <Styled.CouponPropertyContainer>
-          <UnregisteredCouponStatus status={unregisteredCouponStatus} />
+          <UnregisteredCouponStatus status={lazyCouponStatus} />
           <Styled.ImageInner>
             <img src={thumbnail.src} alt={thumbnail.alt} width={44} height={44} />
           </Styled.ImageInner>
@@ -56,7 +56,7 @@ const UnregisteredCouponItem = (props: UnregisteredCouponItemProps) => {
         </Styled.TextContainer>
       </Styled.Coupon>
 
-      {unregisteredCouponStatus === 'ISSUED' && (
+      {lazyCouponStatus === 'ISSUED' && (
         <Styled.CopyButton type='button' onClick={copyUrl}>
           <Icon iconName='copy' />
         </Styled.CopyButton>

--- a/frontend/src/@pages/unregistered-coupon-register/index.tsx
+++ b/frontend/src/@pages/unregistered-coupon-register/index.tsx
@@ -17,16 +17,14 @@ const UnregisteredCouponCodeProxyPage = () => {
 
   return (
     <>
-      {unregisteredCoupon.unregisteredCouponStatus === 'ISSUED' && (
+      {unregisteredCoupon.lazyCouponStatus === 'ISSUED' && (
         <IssuedUnregisteredCouponPage
           unregisteredCoupon={unregisteredCoupon}
           couponCode={couponCode}
         />
       )}
-      {unregisteredCoupon.unregisteredCouponStatus === 'REGISTERED' && <RegisteredCouponPage />}
-      {unregisteredCoupon.unregisteredCouponStatus === 'EXPIRED' && (
-        <ExpiredUnregisteredCouponPage />
-      )}
+      {unregisteredCoupon.lazyCouponStatus === 'REGISTERED' && <RegisteredCouponPage />}
+      {unregisteredCoupon.lazyCouponStatus === 'EXPIRED' && <ExpiredUnregisteredCouponPage />}
     </>
   );
 };

--- a/frontend/src/mocks/fixtures/unregistered-coupon.ts
+++ b/frontend/src/mocks/fixtures/unregistered-coupon.ts
@@ -18,7 +18,7 @@ export default {
       couponTag: '즐코!',
       couponMessage: '하하하',
       couponType: 'COFFEE',
-      unregisteredCouponStatus: 'ISSUED',
+      lazyCouponStatus: 'ISSUED',
       createdTime: '2022-10-12T14:32:22',
     },
     {
@@ -38,7 +38,7 @@ export default {
       couponTag: '즐코!',
       couponMessage: '하하하',
       couponType: 'COFFEE',
-      unregisteredCouponStatus: 'REGISTERED',
+      lazyCouponStatus: 'REGISTERED',
       createdTime: '2022-10-12T14:32:22',
     },
     {
@@ -54,13 +54,13 @@ export default {
       couponTag: '즐코!',
       couponMessage: '하하하',
       couponType: 'COFFEE',
-      unregisteredCouponStatus: 'EXPIRED',
+      lazyCouponStatus: 'EXPIRED',
       createdTime: '2022-10-12T14:32:22',
     },
   ],
   findUnregisteredCouponListByStatus(status: UNREGISTERED_COUPON_STATUS) {
     const unregisteredCouponList = this.current.filter(
-      ({ unregisteredCouponStatus }) => unregisteredCouponStatus === status
+      ({ lazyCouponStatus }) => lazyCouponStatus === status
     );
 
     return unregisteredCouponList;
@@ -105,7 +105,7 @@ export default {
         imageUrl: 'https://avatars.githubusercontent.com/u/24906022?s=48&v=4',
       },
       receiver: null,
-      unregisteredCouponStatus: 'ISSUED',
+      lazyCouponStatus: 'ISSUED',
       createdTime: '2022-10-12T14:32:22',
       couponTag,
       couponMessage,

--- a/frontend/src/mocks/handlers/unregistered-coupon.ts
+++ b/frontend/src/mocks/handlers/unregistered-coupon.ts
@@ -58,13 +58,13 @@ export const unregisteredCouponHandler = [
       try {
         const coupon = unregisteredCouponMock.findUnregisteredCouponByCode(couponCode);
 
-        if (coupon.unregisteredCouponStatus !== 'ISSUED') {
+        if (coupon.lazyCouponStatus !== 'ISSUED') {
           return res(ctx.status(400), ctx.json({ message: '유효하지 않은 쿠폰입니다.' }));
         }
 
         unregisteredCouponMock.current = unregisteredCouponMock.current.map(coupon =>
-          coupon.unregisteredCouponStatus === 'ISSUED'
-            ? { ...coupon, unregisteredCouponStatus: 'REGISTERED' }
+          coupon.lazyCouponStatus === 'ISSUED'
+            ? { ...coupon, lazyCouponStatus: 'REGISTERED' }
             : coupon
         );
 

--- a/frontend/src/types/unregistered-coupon/client.ts
+++ b/frontend/src/types/unregistered-coupon/client.ts
@@ -16,6 +16,6 @@ export interface UnregisteredCoupon {
   couponTag: COUPON_HASHTAGS;
   couponMessage: string;
   couponType: COUPON_ENG_TYPE;
-  unregisteredCouponStatus: UNREGISTERED_COUPON_STATUS;
+  lazyCouponStatus: UNREGISTERED_COUPON_STATUS;
   createdTime: YYYYMMDDhhmmss;
 }


### PR DESCRIPTION
## 작업 내용

![image](https://user-images.githubusercontent.com/78349600/196860259-87d03651-c4d0-4811-9ddb-7987b443e73a.png)

위를 보시면 `FetchUnregisteredCouponByStatus`의 응답 스키마가 기존과 달라졌음을 알 수 있습니다. 이에 맞게 코드를 수정합니다.


- 구현한 기능

  - UnregisteredCoupon의 타입을 수정한다.
  - UnregisteredCoupon의 unregisteredCouponStatus 필드를 참조하는 코드를 수정한다.

## 공유사항


Resolves #513 
