### PR TITLE
fix: 미등록 쿠폰 아이디 기반 단일 조회를 LazyCoupon의 아이디로 조회

### DIFF
--- a/backend/src/main/java/com/woowacourse/kkogkkog/lazycoupon/application/LazyCouponService.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/lazycoupon/application/LazyCouponService.java
@@ -45,7 +45,7 @@ public class LazyCouponService {
     @Transactional(readOnly = true)
     public LazyCouponResponse findById(Long memberId, Long lazyCouponId) {
         Member member = memberRepository.get(memberId);
-        CouponLazyCoupon couponLazyCoupon = lazyCouponRepository.get(lazyCouponId);
+        CouponLazyCoupon couponLazyCoupon = findLazyCoupon(lazyCouponId);
         couponLazyCoupon.validateSender(member);
         return LazyCouponResponse.of(couponLazyCoupon);
     }
@@ -76,10 +76,14 @@ public class LazyCouponService {
 
     public void delete(Long memberId, Long lazyCouponId) {
         Member member = memberRepository.get(memberId);
-        CouponLazyCoupon couponLazyCoupon = lazyCouponRepository.get(
-            lazyCouponId);
+        CouponLazyCoupon couponLazyCoupon = findLazyCoupon(lazyCouponId);
         couponLazyCoupon.validateSender(member);
         lazyCouponRepository.delete(couponLazyCoupon);
+    }
+
+    private CouponLazyCoupon findLazyCoupon(Long id) {
+        return lazyCouponRepository.findByLazyCouponId(id)
+            .orElseThrow(LazyCouponNotFoundException::new);
     }
 
     private CouponLazyCoupon findLazyCoupon(String couponCode) {

--- a/backend/src/main/java/com/woowacourse/kkogkkog/lazycoupon/application/LazyCouponService.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/lazycoupon/application/LazyCouponService.java
@@ -14,7 +14,7 @@ import com.woowacourse.kkogkkog.lazycoupon.application.dto.LazyCouponResponse;
 import com.woowacourse.kkogkkog.lazycoupon.application.dto.LazyCouponSaveRequest;
 import com.woowacourse.kkogkkog.lazycoupon.domain.CouponLazyCoupon;
 import com.woowacourse.kkogkkog.lazycoupon.domain.LazyCoupon;
-import com.woowacourse.kkogkkog.lazycoupon.domain.repository.LazyCouponRepository;
+import com.woowacourse.kkogkkog.lazycoupon.domain.repository.CouponLazyCouponRepository;
 import com.woowacourse.kkogkkog.lazycoupon.exception.LazyCouponNotFoundException;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -27,7 +27,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class LazyCouponService {
 
-    private final LazyCouponRepository lazyCouponRepository;
+    private final CouponLazyCouponRepository couponLazyCouponRepository;
     private final CouponRepository couponRepository;
     private final MemberRepository memberRepository;
     private final CouponHistoryRepository couponHistoryRepository;
@@ -37,7 +37,7 @@ public class LazyCouponService {
     public List<LazyCouponResponse> findAllBySender(Long memberId, String lazyCouponStatus) {
         Member sender = memberRepository.get(memberId);
         LazyCouponStatus status = LazyCouponStatus.valueOf(lazyCouponStatus);
-        return lazyCouponRepository.findAllBySender(sender, status).stream()
+        return couponLazyCouponRepository.findAllBySender(sender, status).stream()
             .map(LazyCouponResponse::of)
             .collect(Collectors.toList());
     }
@@ -61,7 +61,7 @@ public class LazyCouponService {
         LazyCoupon.validateQuantity(quantity);
         Member sender = memberRepository.get(request.getSenderId());
         List<CouponLazyCoupon> lazyCoupons = request.toEntities(sender);
-        return lazyCouponRepository.saveAll(lazyCoupons).stream()
+        return couponLazyCouponRepository.saveAll(lazyCoupons).stream()
             .map(LazyCouponResponse::of)
             .collect(Collectors.toList());
     }
@@ -78,16 +78,16 @@ public class LazyCouponService {
         Member member = memberRepository.get(memberId);
         CouponLazyCoupon couponLazyCoupon = findLazyCoupon(lazyCouponId);
         couponLazyCoupon.validateSender(member);
-        lazyCouponRepository.delete(couponLazyCoupon);
+        couponLazyCouponRepository.delete(couponLazyCoupon);
     }
 
     private CouponLazyCoupon findLazyCoupon(Long id) {
-        return lazyCouponRepository.findByLazyCouponId(id)
+        return couponLazyCouponRepository.findByLazyCouponId(id)
             .orElseThrow(LazyCouponNotFoundException::new);
     }
 
     private CouponLazyCoupon findLazyCoupon(String couponCode) {
-        return lazyCouponRepository.findByLazyCouponCouponCode(couponCode)
+        return couponLazyCouponRepository.findByLazyCouponCouponCode(couponCode)
             .orElseThrow(LazyCouponNotFoundException::new);
     }
 

--- a/backend/src/main/java/com/woowacourse/kkogkkog/lazycoupon/domain/repository/CouponLazyCouponRepository.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/lazycoupon/domain/repository/CouponLazyCouponRepository.java
@@ -9,7 +9,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-public interface LazyCouponRepository extends JpaRepository<CouponLazyCoupon, Long> {
+public interface CouponLazyCouponRepository extends JpaRepository<CouponLazyCoupon, Long> {
 
     Optional<CouponLazyCoupon> findByLazyCouponId(Long id);
 

--- a/backend/src/main/java/com/woowacourse/kkogkkog/lazycoupon/domain/repository/LazyCouponRepository.java
+++ b/backend/src/main/java/com/woowacourse/kkogkkog/lazycoupon/domain/repository/LazyCouponRepository.java
@@ -1,9 +1,8 @@
 package com.woowacourse.kkogkkog.lazycoupon.domain.repository;
 
+import com.woowacourse.kkogkkog.lazycoupon.domain.CouponLazyCoupon;
 import com.woowacourse.kkogkkog.lazycoupon.domain.LazyCouponStatus;
 import com.woowacourse.kkogkkog.member.domain.Member;
-import com.woowacourse.kkogkkog.lazycoupon.domain.CouponLazyCoupon;
-import com.woowacourse.kkogkkog.lazycoupon.exception.LazyCouponNotFoundException;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -12,9 +11,7 @@ import org.springframework.data.repository.query.Param;
 
 public interface LazyCouponRepository extends JpaRepository<CouponLazyCoupon, Long> {
 
-    default CouponLazyCoupon get(Long id) {
-        return findById(id).orElseThrow(LazyCouponNotFoundException::new);
-    }
+    Optional<CouponLazyCoupon> findByLazyCouponId(Long id);
 
     Optional<CouponLazyCoupon> findByLazyCouponCouponCode(String couponCode);
 

--- a/backend/src/test/java/com/woowacourse/kkogkkog/lazycoupon/application/LazyCouponServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/kkogkkog/lazycoupon/application/LazyCouponServiceTest.java
@@ -21,7 +21,7 @@ import com.woowacourse.kkogkkog.lazycoupon.application.dto.LazyCouponSaveRequest
 import com.woowacourse.kkogkkog.lazycoupon.domain.CouponLazyCoupon;
 import com.woowacourse.kkogkkog.lazycoupon.domain.LazyCoupon;
 import com.woowacourse.kkogkkog.lazycoupon.domain.LazyCouponStatus;
-import com.woowacourse.kkogkkog.lazycoupon.domain.repository.LazyCouponRepository;
+import com.woowacourse.kkogkkog.lazycoupon.domain.repository.CouponLazyCouponRepository;
 import com.woowacourse.kkogkkog.lazycoupon.exception.LazyCouponQuantityExcessException;
 import com.woowacourse.kkogkkog.member.domain.Member;
 import com.woowacourse.kkogkkog.member.domain.Workspace;
@@ -53,7 +53,7 @@ public class LazyCouponServiceTest {
     private CouponHistoryRepository couponHistoryRepository;
 
     @Autowired
-    private LazyCouponRepository lazyCouponRepository;
+    private CouponLazyCouponRepository couponLazyCouponRepository;
 
     @Nested
     @DisplayName("save 메서드는")
@@ -100,7 +100,7 @@ public class LazyCouponServiceTest {
             Workspace workspace = workspaceRepository.save(KKOGKKOG.getWorkspace());
             sender = memberRepository.save(SENDER.getMember(workspace));
             receiver = memberRepository.save(RECEIVER.getMember(workspace));
-            CouponLazyCoupon couponLazyCoupon = lazyCouponRepository.save(COFFEE.getCouponLazyCoupon(sender));
+            CouponLazyCoupon couponLazyCoupon = couponLazyCouponRepository.save(COFFEE.getCouponLazyCoupon(sender));
             lazyCoupon = couponLazyCoupon.getLazyCoupon();
         }
 
@@ -140,8 +140,8 @@ public class LazyCouponServiceTest {
             Workspace workspace = workspaceRepository.save(KKOGKKOG.getWorkspace());
             sender = memberRepository.save(JEONG.getMember(workspace));
             receiver = memberRepository.save(AUTHOR.getMember(workspace));
-            lazyCouponRepository.save(COFFEE.getCouponLazyCoupon(sender));
-            lazyCouponRepository.save(COFFEE.getCouponLazyCoupon(sender));
+            couponLazyCouponRepository.save(COFFEE.getCouponLazyCoupon(sender));
+            couponLazyCouponRepository.save(COFFEE.getCouponLazyCoupon(sender));
         }
 
         @Test
@@ -162,7 +162,7 @@ public class LazyCouponServiceTest {
         @Test
         @DisplayName("REGISTERED 상태의 미등록 쿠폰 조회를 요청하면, 수령한 쿠폰 아이디와 받은 사람 정보도 반환한다.")
         void success_where_registered() {
-            LazyCoupon lazyCoupon = lazyCouponRepository.save(COFFEE.getCouponLazyCoupon(sender))
+            LazyCoupon lazyCoupon = couponLazyCouponRepository.save(COFFEE.getCouponLazyCoupon(sender))
                 .getLazyCoupon();
             CouponResponse couponResponse = lazyCouponService.saveByCouponCode(receiver.getId(),
                 쿠폰_코드_등록_요청(lazyCoupon.getCouponCode()));
@@ -253,7 +253,7 @@ public class LazyCouponServiceTest {
 
             lazyCouponService.delete(sender.getId(), lazyCouponId);
 
-            Boolean isPresent = lazyCouponRepository.findById(lazyCouponId)
+            Boolean isPresent = couponLazyCouponRepository.findById(lazyCouponId)
                 .isPresent();
             assertThat(isPresent).isFalse();
         }


### PR DESCRIPTION
## 작업 내용

- 미등록 쿠폰 아이디 기반 단일 조회를 LazyCoupon의 아이디로 조회하게 변경

- 연결엔티티 조회 레포지토리 이름 변경

- ISSUE
Resolves #514 