### PR TITLE
fix: onClickRegisteredCouponItem은 디테일 페이지로 라우팅을 트리거한다.

### DIFF
--- a/frontend/src/@pages/main/index.tsx
+++ b/frontend/src/@pages/main/index.tsx
@@ -22,6 +22,7 @@ const MainPage = () => {
   const navigate = useNavigate();
 
   const { reservationList, isLoading: isAcceptedCouponListLoading } = useFetchReservationList();
+
   const { openCouponList: receivedOpenCouponList, isLoading: isReceivedCouponListLoading } =
     useFetchCouponList({
       couponListType: 'received',

--- a/frontend/src/@pages/unregistered-coupon-list/index.tsx
+++ b/frontend/src/@pages/unregistered-coupon-list/index.tsx
@@ -43,7 +43,7 @@ const UnregisteredCouponList = () => {
       return;
     }
 
-    navigate(DYNAMIC_PATH.COUPON_DECLINE(couponId));
+    navigate(DYNAMIC_PATH.COUPON_DETAIL(couponId));
   };
 
   const onClickExpiredCouponItem = () => {


### PR DESCRIPTION
## 작업 내용



- onClickRegisteredCouponItem은 디테일 페이지로 라우팅을 트리거한다.

  - 거절 페이지로 라우팅이 되고 있었으나, **보낸 쿠폰이면서** **대기중인** 쿠폰은 거절 페이지에 들어갈 수 없음. 방어로직이 되어있어 라우팅이 자꾸 뒤로 오던 현상 해결


## 공유사항

거절 페이지로 라우팅이 되고 있었으나, **보낸 쿠폰이면서** **대기중인** 쿠폰은 거절 페이지에 들어갈 수 없음. 방어로직이 되어있어 라우팅이 자꾸 뒤로 오던 현상 해결

Resolves #518
