### PR TITLE
fix: 에러 바운더리 이슈 해결

### DIFF
--- a/frontend/src/@components/@shared/ErrorFallback/index.tsx
+++ b/frontend/src/@components/@shared/ErrorFallback/index.tsx
@@ -1,6 +1,8 @@
 import { AxiosError } from 'axios';
+import { Link } from 'react-router-dom';
 
 import landingLogoImage from '@/assets/images/landing_logo.png';
+import { PATH } from '@/Router';
 import theme from '@/styles/theme';
 
 import Icon from '../Icon';
@@ -12,13 +14,18 @@ export interface ErrorFallbackProps {
   resetErrorBoundary?: () => void;
 }
 
-const ErrorFallback = ({ error, resetErrorBoundary }: ErrorFallbackProps) => {
+const ErrorFallback = ({ resetErrorBoundary }: ErrorFallbackProps) => {
   return (
-    <PageTemplate.ExtendedStyleHeader title='문제가 발생했어요'>
+    <PageTemplate.ExtendedStyleHeader title='문제가 발생했어요' hasHeader={false}>
       <Styled.Root>
-        <img src={landingLogoImage} alt='로고' width='86' />
+        <Link to={PATH.MAIN} css={Styled.EscapeSection} onClick={resetErrorBoundary}>
+          <img src={landingLogoImage} alt='로고' width={50} height={50} />
+          메인으로
+        </Link>
         <Styled.ResetSection onClick={resetErrorBoundary}>
-          <Icon iconName='reload' color={theme.colors.light_grey_200} />
+          <Styled.FlexCenter>
+            <Icon iconName='reload' color={theme.colors.light_grey_200} />
+          </Styled.FlexCenter>
           <button>다시 불러오기</button>
         </Styled.ResetSection>
       </Styled.Root>

--- a/frontend/src/@components/@shared/ErrorFallback/style.tsx
+++ b/frontend/src/@components/@shared/ErrorFallback/style.tsx
@@ -1,9 +1,8 @@
-import { css } from '@emotion/react';
+import { css, Theme } from '@emotion/react';
 import styled from '@emotion/styled';
 
 export const Root = styled.div`
   display: flex;
-  flex-direction: column;
   justify-content: center;
   align-items: center;
   gap: 20px;
@@ -15,16 +14,48 @@ export const Root = styled.div`
   `}
 `;
 
-export const ResetSection = styled.div`
+export const EscapeSection = (theme: Theme) => css`
+  width: 100px;
+  height: 80px;
+
   display: flex;
   flex-direction: column;
+  justify-content: space-between;
   align-items: center;
   gap: 12px;
 
-  color: ${({ theme }) => theme.colors.light_grey_200};
+  color: ${theme.colors.primary_400};
+
   cursor: pointer;
 
   & > button {
-    font-size: 20px;
+    font-size: 16px;
   }
+`;
+
+export const ResetSection = styled.div`
+  width: 100px;
+  height: 80px;
+
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: center;
+
+  color: ${({ theme }) => theme.colors.light_grey_200};
+
+  cursor: pointer;
+
+  & > button {
+    font-size: 16px;
+  }
+`;
+
+export const FlexCenter = styled.div`
+  width: 50px;
+  height: 50px;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
 `;


### PR DESCRIPTION
## 작업 내용

- 헤더 제거 및 메인으로 이동하는 버튼 구현

    ![image](https://user-images.githubusercontent.com/78349600/196887735-323add41-c66a-4aca-95ae-1592be87fa47.png)

## 공유사항

현재 에러바운더리의 FallBackUI에서 홈 버튼을 눌러 홈 화면으로 빠져나갈려고 시도하면 라우팅은 진행되나, 페이지 렌더링이 새롭게 진행되지는 않습니다. => `error`를 갱신하지 않는 이상 리렌더링 되지 않기 때문인데, 메인으로 가기 버튼을 추가하여 해결하였습니다. (메인으로 이동되며, 클릭 시 에러 상태가 갱신)



Resolves #516
