### PR TITLE
chore: tomcat과 hikariCP 설정

### DIFF
--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -15,6 +15,7 @@ spring:
     password:
     hikari:
       maximum-pool-size: 10
+      connection-timeout: 3000
   flyway:
     enabled: false
 

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -13,8 +13,11 @@ spring:
     url: jdbc:h2:mem:kkogkkog-test;MODE=MYSQL;DB_CLOSE_DELAY=-1
     username: sa
     password:
+    hikari:
+      maximum-pool-size: 10
   flyway:
     enabled: false
+
 
 logging:
   level:
@@ -43,4 +46,10 @@ security:
     client-secret: "111111-111111111-11111111"
     redirect:
       login: "http://localhost:3000/login/google/redirect"
+
+server:
+  tomcat:
+    threads:
+      max: 10
+    accept-count: 10
 


### PR DESCRIPTION
## 작업 내용

톰캣 Thread 최대 갯수와 Hikari Connection Pool의 최대 개수를 설정한다.

Tomcat 관련 설정:
```
maxThread 200 -> 10
maxConnections 8192 -> 8192
acceptCount 100 -> 10
```

HikariConnectionPool 설정:
```
maxConnections 10 -> 10
connectionTimeOut 30000ms -> 3000ms
```

노션 문서 백엔드 항목에 부하테스트 결과물과 왜 설정했는지 정리되어있습니다.
추가로 HikariCP에 connectionTimeOut 부분을 수정했는데 기본값 30초에서 3초로 줄였습니다.
해당 설정은 ConnectionPool에 모든 Connection이 사용중일 때, Connection 요청이 들어오면 대기하는 시간입니다.
사용자 입장에서 30초동안 응답이 없는 것보다는, 빠르게 에러 응답을 보내는 것이 적절하다고 판단하여 수정했습니다.

## 공유사항
[Tomcat 관련 설정](https://kkogkkog.notion.site/1-e2eb8076a5d344c4952b4264db0d245b)
[HikariCP 관련 설정](https://kkogkkog.notion.site/e06f3189f01a462aa523d3692fabfc2d)

