### PR TITLE
feat: Coupon 타입을 구별된 유니온으로 정의하여 couponStatus로 meetingDate 가드할 수 있도록 한다.

### DIFF
--- a/frontend/src/mocks/fixtures/unregistered-coupon.ts
+++ b/frontend/src/mocks/fixtures/unregistered-coupon.ts
@@ -1,7 +1,7 @@
 import { UNREGISTERED_COUPON_STATUS } from '@/types/unregistered-coupon/client';
 import { CreateUnregisteredCouponRequest } from '@/types/unregistered-coupon/remote';
 
-import { Valueof } from './../../types/utils';
+import { Elementof } from './../../types/utils';
 
 export default {
   current: [
@@ -113,7 +113,7 @@ export default {
     };
   },
 
-  addUnregisteredCoupon(unregisteredCoupon: Valueof<typeof this.current>[]) {
+  addUnregisteredCoupon(unregisteredCoupon: Elementof<typeof this.current>[]) {
     this.current = [...this.current, ...unregisteredCoupon];
   },
 };

--- a/frontend/src/types/coupon/client.ts
+++ b/frontend/src/types/coupon/client.ts
@@ -22,7 +22,12 @@ export const couponEvent = [
   'FINISH',
 ] as const;
 
-export const couponStatus = ['REQUESTED', 'READY', 'ACCEPTED', 'FINISHED'] as const;
+export const couponStatus = {
+  REQUESTED: 'REQUESTED',
+  READY: 'READY',
+  ACCEPTED: 'ACCEPTED',
+  FINISHED: 'FINISHED',
+} as const;
 
 export const couponHashtags = [
   '고마워요',
@@ -50,21 +55,28 @@ export type COUPON_HASHTAGS = typeof couponHashtags[number];
 
 export type COUPON_EVENT = typeof couponEvent[number];
 
-export type COUPON_STATUS = typeof couponStatus[number];
+export type COUPON_STATUS = typeof couponStatus[keyof typeof couponStatus];
+export type COUPON_STATUS_WITH_MEETINGDATE = Exclude<COUPON_STATUS, 'READY'>;
 
 export type COUPON_MEETING_DATE = YYYYMMDDhhmmss;
 
-export interface Coupon {
+export type CouponCase<T extends COUPON_STATUS> = {
   id: number;
   sender: Member;
   receiver: Member;
   couponTag: string;
   couponMessage: string;
   couponType: COUPON_ENG_TYPE;
-  couponStatus: COUPON_STATUS;
-  meetingDate: COUPON_MEETING_DATE | null;
+  couponStatus: T;
+  meetingDate: T extends COUPON_STATUS_WITH_MEETINGDATE ? COUPON_MEETING_DATE : null;
   createdTime: YYYYMMDDhhmmss;
-}
+};
+
+export type Coupon =
+  | CouponCase<'ACCEPTED'>
+  | CouponCase<'FINISHED'>
+  | CouponCase<'READY'>
+  | CouponCase<'REQUESTED'>;
 
 export interface CouponHistory {
   id: number;

--- a/frontend/src/types/coupon/remote.ts
+++ b/frontend/src/types/coupon/remote.ts
@@ -1,4 +1,4 @@
-import { YYYYMMDD } from '@/types/utils';
+import { AddPropertyInUnion, YYYYMMDD } from '@/types/utils';
 
 import {
   Coupon,
@@ -42,11 +42,6 @@ export type SentCouponListResponse = CouponListResponse;
 export type ReceivedCouponListResponse = CouponListResponse;
 export type SentCouponListByStatusResponse = CouponListResponse;
 export type ReceivedCouponListByStatusResponse = CouponListResponse;
-
-type AddPropertyInUnion<
-  T extends Record<PropertyKey, unknown>,
-  K extends Record<PropertyKey, unknown>
-> = T extends unknown ? T & K : never;
 
 export type CouponDetailResponse = AddPropertyInUnion<Coupon, { couponHistories: CouponHistory[] }>;
 

--- a/frontend/src/types/coupon/remote.ts
+++ b/frontend/src/types/coupon/remote.ts
@@ -43,9 +43,12 @@ export type ReceivedCouponListResponse = CouponListResponse;
 export type SentCouponListByStatusResponse = CouponListResponse;
 export type ReceivedCouponListByStatusResponse = CouponListResponse;
 
-export interface CouponDetailResponse extends Coupon {
-  couponHistories: CouponHistory[];
-}
+type AddPropertyInUnion<
+  T extends Record<PropertyKey, unknown>,
+  K extends Record<PropertyKey, unknown>
+> = T extends unknown ? T & K : never;
+
+export type CouponDetailResponse = AddPropertyInUnion<Coupon, { couponHistories: CouponHistory[] }>;
 
 export interface ReservationListResponse {
   data: Reservation[];

--- a/frontend/src/types/unregistered-coupon/client.ts
+++ b/frontend/src/types/unregistered-coupon/client.ts
@@ -1,11 +1,11 @@
 import { COUPON_ENG_TYPE, COUPON_HASHTAGS } from '@/types/coupon/client';
 import { Member } from '@/types/user/client';
 
-import { Valueof, YYYYMMDDhhmmss } from '../utils';
+import { Elementof, YYYYMMDDhhmmss } from '../utils';
 
 export const unregisteredCouponStatus = ['ISSUED', 'REGISTERED', 'EXPIRED'] as const;
 
-export type UNREGISTERED_COUPON_STATUS = Valueof<typeof unregisteredCouponStatus>;
+export type UNREGISTERED_COUPON_STATUS = Elementof<typeof unregisteredCouponStatus>;
 
 export interface UnregisteredCoupon {
   id: number;

--- a/frontend/src/types/utils.ts
+++ b/frontend/src/types/utils.ts
@@ -20,6 +20,11 @@ export type Elementof<T extends readonly unknown[]> = T[number];
 
 export type Valueof<T extends Record<PropertyKey, unknown>> = T[keyof T];
 
+export type AddPropertyInUnion<
+  T extends Record<PropertyKey, unknown>,
+  K extends Record<PropertyKey, unknown>
+> = T extends unknown ? T & K : never;
+
 export type YYYYMMDD = `${string}-${string}-${string}`;
 export type YYYYMMDD_KR = `${string}년 ${string}월 ${string}일`;
 export type YYYYMMDDhhmmss = `${YYYYMMDD}T${string}:${string}:${string}`;

--- a/frontend/src/types/utils.ts
+++ b/frontend/src/types/utils.ts
@@ -16,7 +16,9 @@ export type MakeOptional<T, K extends keyof T> = Omit<T, K> & {
   [P in K]?: T[P];
 };
 
-export type Valueof<T extends readonly unknown[]> = T[number];
+export type Elementof<T extends readonly unknown[]> = T[number];
+
+export type Valueof<T extends Record<PropertyKey, unknown>> = T[keyof T];
 
 export type YYYYMMDD = `${string}-${string}-${string}`;
 export type YYYYMMDD_KR = `${string}년 ${string}월 ${string}일`;


### PR DESCRIPTION
## 작업 내용

- Valueof, Elementof 타입 구분하기
  - 기존에 배열의 요소를 union으로 바꾸는 타입을 Valueof라고 정의해놓았습니다. 이는 Elementof 라는 이름이 더 적절할 것 같습니다.
  - keyof가 객체의 key 의 타입을 union으로 바꾸는 것이라고 하면, Valueof는 객체의 value 타입을 union으로 바꾸는 것으로 정의합니다. 이를 정의해놓았습니다.

- CouponType을 구별된 유니온으로 정의하여, couponStatus를 내로잉하면, meetingDate가 적절히 추론되도록 하였습니다.

## 고민
우리가 client 타입을 정의할 때 배열을 as const로 정의하고, Elementof 방식으로 union으로 만들어 타입을 사용했습니다 근데 지금보니 이게 좀 사용성이 떨어지는 것 같습니다. enum과 같이 값으로도, 타입으로도 사용되는 상황을 바라는데, 배열로 정의해버리면 인덱스로밖에 접근할 수 없어 enum처럼 값을 찾아가기는 힘들 것 같습니다.
아직 그런 코드가 있진 않습니다!

Resolves #532
