### PR TITLE
docs: README의 인프라 구조 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@
 ![backend](https://user-images.githubusercontent.com/76774809/197915562-d62457b8-1b92-4122-9ff6-2222b0ccca48.png)
 
 ### Infrastructure
-![infra](https://user-images.githubusercontent.com/76774809/197915578-2ef286c5-1cdb-4787-8a7a-67f341b84f9b.png)
+![infra](https://user-images.githubusercontent.com/73531614/200893249-5b9f1cca-b7c7-497c-a229-55a6eea7d982.png)
 
 ### CI/CD
 ![ci:cd](https://user-images.githubusercontent.com/76774809/197916408-938508b9-5273-4b21-b4d3-874079a590d9.png)


### PR DESCRIPTION
## 작업 내용

- README의 인프라 구조를 현재 구조에 맞게 수정합니다.
- [수정된 README](https://github.com/woowacourse-teams/2022-kkogkkog/tree/docs/fix-readme-infra) 참고

## 공유사항

- 외부에 이전 인프라 구조 그림 보여주고 싶으면 이 [이 사이트 링크](https://sites.google.com/woowahan.com/woowacourse-demo-4th/%ED%94%84%EB%A1%9C%EC%A0%9D%ED%8A%B8/%EA%BC%AD%EA%BC%AD/%EC%82%AC%EC%9A%A9%EA%B8%B0%EC%88%A0)를 보여주면 될 것 같습니다.