### PR TITLE
chore: graceful shutdown 옵션 추가

### DIFF
--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -53,4 +53,4 @@ server:
     threads:
       max: 10
     accept-count: 10
-
+  shutdown: graceful


### PR DESCRIPTION
## 작업 내용

- 톰캣 종료시 처리하던 모든 요청 완료한 이후에 종료되도록 하는 설정 추가
- prod, dev 환경의 yml 파일에도 설정 추가 완료

## 공유사항

- [참고문헌](https://www.baeldung.com/spring-boot-web-server-shutdown)
- 이렇게 설정하면 톰캣 종료 작업을 시작하면, 더 이상 작업들을 추가로 받지 않으며, 최대 30초 동안 현재 처리 중이던 작업들을 끝낼 때까지 대기한 이후에 서버를 종료시키게 된다고 합니다.
- 다만, CD 워크플로우에서 `kill -15` 명령어 실행 후 최소 30초 동안 대기한 이후에 새로운 서버 재실행하도록 설정 필요.